### PR TITLE
Sharding: copy primary key tables only at the end of the ferry

### DIFF
--- a/sharding/filter.go
+++ b/sharding/filter.go
@@ -218,7 +218,7 @@ func (s *ShardedTableFilter) ApplicableTables(tables []*schema.Table) (applicabl
 
 		if _, exists := s.PrimaryKeyTables[table.Name]; exists {
 			if len(table.PKColumns) != 1 {
-				return nil, fmt.Errorf("Multiple PK columns are not supported with the PrimaryKeyTables tables option")
+				return nil, fmt.Errorf("Multiple PK columns are not supported with the PrimaryKeyTables option")
 			}
 			applicable = append(applicable, table)
 		}

--- a/sharding/test/joined_tables_test.go
+++ b/sharding/test/joined_tables_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 	"time"
 
-	rtesthelpers "github.com/Shopify/ghostferry/sharding/testhelpers"
+	sth "github.com/Shopify/ghostferry/sharding/testhelpers"
 	"github.com/Shopify/ghostferry/testhelpers"
 	"github.com/stretchr/testify/suite"
 )
 
 type JoinedTablesTestSuite struct {
-	*rtesthelpers.ShardingUnitTestSuite
+	*sth.ShardingUnitTestSuite
 
 	DataWriter testhelpers.DataWriter
 }
@@ -52,11 +52,10 @@ func (t *JoinedTablesTestSuite) TestJoinedTablesWithDataWriter() {
 	t.CutoverLock = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := t.Ferry.Ferry.SourceDB.Exec("SET GLOBAL read_only = ON")
 		t.Require().Nil(err)
-		time.Sleep(2 * time.Second)
 
 		t.DataWriter.Stop()
 		t.DataWriter.Wait()
-		time.Sleep(5 * time.Second)
+		time.Sleep(1 * time.Second)
 	})
 
 	go t.DataWriter.Run()
@@ -87,5 +86,5 @@ func (t *JoinedTablesTestSuite) TestJoinedTablesWithDataWriter() {
 }
 
 func TestJoinedTablesTestSuite(t *testing.T) {
-	suite.Run(t, &JoinedTablesTestSuite{ShardingUnitTestSuite: &rtesthelpers.ShardingUnitTestSuite{}})
+	suite.Run(t, &JoinedTablesTestSuite{ShardingUnitTestSuite: &sth.ShardingUnitTestSuite{}})
 }

--- a/sharding/test/trivial_integration_test.go
+++ b/sharding/test/trivial_integration_test.go
@@ -18,12 +18,12 @@ func setupSingleTableDatabase(f *testhelpers.TestFerry) {
 	testhelpers.AddTenantID(f.TargetDB, "gftest", "table1", 3)
 }
 
-func selectiveFerry(shardingValue interface{}) *testhelpers.TestFerry {
+func selectiveFerry(tenantId interface{}) *testhelpers.TestFerry {
 	ferry := testhelpers.NewTestFerry()
 
 	ferry.Config.CopyFilter = &sharding.ShardedCopyFilter{
 		ShardingKey:   "tenant_id",
-		ShardingValue: shardingValue,
+		ShardingValue: tenantId,
 	}
 
 	ferry.Config.TableFilter = &sharding.ShardedTableFilter{

--- a/sharding/testhelpers/unit_test_suite.go
+++ b/sharding/testhelpers/unit_test_suite.go
@@ -17,7 +17,7 @@ const (
 	sourceDbName    = "gftest1"
 	targetDbName    = "gftest2"
 	testTable       = "table1"
-	primaryKeyTable = "single_row_table"
+	primaryKeyTable = "tenants_table"
 	joinedTableName = "joined_table"
 	joinTableName   = "join_table"
 	joiningKey      = "join_id"

--- a/test/iterative_verifier_integration_test.go
+++ b/test/iterative_verifier_integration_test.go
@@ -48,7 +48,7 @@ func TestVerificationFailsDeletedRow(t *testing.T) {
 			result, err := iterativeVerifier.VerifyDuringCutover()
 			assert.Nil(t, err)
 			assert.False(t, result.DataCorrect)
-			assert.Regexp(t, "verification failed.*gftest.table1.*pks: (43,42)|(42,43)", result.Message)
+			assert.Regexp(t, "verification failed.*gftest.table1.*pks: (43)|(42)|(43,42)|(42,43)", result.Message)
 			ran = true
 		},
 		DataWriter: &testhelpers.MixedActionDataWriter{
@@ -91,7 +91,7 @@ func TestVerificationFailsUpdatedRow(t *testing.T) {
 			result, err := iterativeVerifier.VerifyDuringCutover()
 			assert.Nil(t, err)
 			assert.False(t, result.DataCorrect)
-			assert.Regexp(t, "verification failed.*gftest.table1.*pks: (43,42)|(42,43)", result.Message)
+			assert.Regexp(t, "verification failed.*gftest.table1.*pks: (42)|(43)|(43,42)|(42,43)", result.Message)
 			ran = true
 		},
 		DataWriter: &testhelpers.MixedActionDataWriter{

--- a/test/iterative_verifier_test.go
+++ b/test/iterative_verifier_test.go
@@ -59,6 +59,28 @@ func (t *IterativeVerifierTestSuite) TestNothingToVerify() {
 	t.Require().Equal("", result.Message)
 }
 
+func (t *IterativeVerifierTestSuite) TestVerifyOnceFails() {
+	t.InsertRowInDb(42, "foo", t.Ferry.SourceDB)
+	t.InsertRowInDb(42, "bar", t.Ferry.TargetDB)
+
+	result, err := t.verifier.VerifyOnce()
+	t.Require().NotNil(result)
+	t.Require().Nil(err)
+	t.Require().False(result.DataCorrect)
+	t.Require().Equal("verification failed on table: gftest.test_table_1 for pk: 42", result.Message)
+}
+
+func (t *IterativeVerifierTestSuite) TestVerifyOncePass() {
+	t.InsertRowInDb(42, "foo", t.Ferry.SourceDB)
+	t.InsertRowInDb(42, "foo", t.Ferry.TargetDB)
+
+	result, err := t.verifier.VerifyOnce()
+	t.Require().NotNil(result)
+	t.Require().Nil(err)
+	t.Require().True(result.DataCorrect)
+	t.Require().Equal("", result.Message)
+}
+
 func (t *IterativeVerifierTestSuite) TestBeforeCutoverFailuresFailAgainDuringCutover() {
 	t.InsertRowInDb(42, "foo", t.Ferry.SourceDB)
 	t.InsertRowInDb(42, "bar", t.Ferry.TargetDB)

--- a/verifier.go
+++ b/verifier.go
@@ -22,6 +22,10 @@ type VerificationResult struct {
 	Message     string
 }
 
+func (e VerificationResult) Error() string {
+	return e.Message
+}
+
 type VerificationResultAndStatus struct {
 	VerificationResult
 


### PR DESCRIPTION
This change helps keep the primary key table in the target database consistent for a longer time period.

For example, for us, we have developers who `JOIN ON` a primary key table in their queries to filter out some data but see unexpected results. This change makes that sort of inconvenience less likely

follow up to: https://github.com/Shopify/shopify/pull/153139
related to: https://github.com/Shopify/pods/issues/259
@Shopify/pods