### PR TITLE
Step 1: Cursor to use PK struct instead of uint64 to iterate tables

### DIFF
--- a/data_iterator.go
+++ b/data_iterator.go
@@ -193,7 +193,9 @@ func (d *DataIterator) Run() {
 
 				logger := d.logger.WithField("table", table.String())
 
-				cursor := d.CursorConfig.NewCursor(table, d.CurrentState.TargetPrimaryKeys()[table.String()])
+				// TODO: switch the state tracker to use the PK class
+				targetPK := d.CurrentState.TargetPrimaryKeys()[table.String()]
+				cursor := d.CursorConfig.NewCursor(table, PK{Value: targetPK})
 				err := cursor.Each(func(batch *RowBatch) error {
 					metrics.Count("RowEvent", int64(batch.Size()), []MetricTag{
 						MetricTag{"table", table.Name},

--- a/pk.go
+++ b/pk.go
@@ -1,0 +1,49 @@
+package ghostferry
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/siddontang/go-mysql/schema"
+)
+
+type PK struct {
+	Value interface{}
+}
+
+func (pk PK) Compare(other PK) int {
+	switch v1 := pk.Value.(type) {
+	case uint64:
+		v2 := other.Value.(uint64)
+
+		if v1 < v2 {
+			return -1
+		} else if v1 == v2 {
+			return 0
+		} else {
+			return 1
+		}
+
+	default:
+		panic(fmt.Sprintf("pk type %T are current not supported", v1))
+	}
+}
+
+// Could possibly upstream these functions in the future.
+func MinPK(column *schema.TableColumn) PK {
+	switch column.Type {
+	case schema.TYPE_NUMBER:
+		return PK{Value: uint64(0)}
+	default:
+		panic(fmt.Sprintf("non integer type is currently not supported"))
+	}
+}
+
+func MaxPK(column *schema.TableColumn) PK {
+	switch column.Type {
+	case schema.TYPE_NUMBER:
+		return PK{Value: uint64(math.MaxUint64)}
+	default:
+		panic(fmt.Sprintf("non integer type is currently not supported"))
+	}
+}

--- a/test/pk_test.go
+++ b/test/pk_test.go
@@ -1,0 +1,28 @@
+package test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/Shopify/ghostferry"
+	"github.com/Shopify/ghostferry/testhelpers"
+	"github.com/stretchr/testify/suite"
+)
+
+type PKTestSuite struct {
+	suite.Suite
+}
+
+func (t *PKTestSuite) TestCompareUint64() {
+	pk1 := ghostferry.PK{Value: uint64(10)}
+	pk2 := ghostferry.PK{Value: uint64(math.MaxUint64)}
+
+	t.Require().Equal(-1, pk1.Compare(pk2))
+	t.Require().Equal(0, pk1.Compare(pk1))
+	t.Require().Equal(1, pk2.Compare(pk1))
+}
+
+func TestPK(t *testing.T) {
+	testhelpers.SetupTest()
+	suite.Run(t, new(PKTestSuite))
+}


### PR DESCRIPTION
This is step one of the work to migrate data with generic sortable columns. This implementation switch the Cursor's implementation to use a PK struct instead of uint64 to iterate over the data. The PK struct is currently only supports uint64 although it should allow arbitrary sortable types in the future.

*I would like to have some feedback in this approach before moving forward with the full implementation, detailed below:*

In step two (near future), I would like to convert the remaining code base to utilize the PK struct. This includes the `BuildSelect` method that we use to filter for arbitrary rows and some other locations.

In step three (near future), I would like to add string based primary key support. **At this point, we can migrate tables like `schema_migrations` without having to resort to mysqldump or other out of band methods during the cutover stage.**

After this, we can potentially support non primary key (unique/sortable columns), other data types, multiple column keys, and so on. However, I currently have no plans to implement the support for those myself.