### PR TITLE
Refactor sql.DB creation to DatabaseConfig

### DIFF
--- a/throttler.go
+++ b/throttler.go
@@ -111,15 +111,8 @@ func NewLagThrottler(config *LagThrottlerConfig) (*LagThrottler, error) {
 		return nil, fmt.Errorf("connection invalid: %s", err)
 	}
 
-	dbCfg, err := config.Connection.MySQLConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to build database config: %s", err)
-	}
-
 	logger := logrus.WithField("tag", "throttler")
-	logger.WithField("dsn", MaskedDSN(dbCfg)).Info("connecting to throttling database")
-
-	db, err := sql.Open("mysql", dbCfg.FormatDSN())
+	db, err := config.Connection.SqlDB(logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create connection: %s", err)
 	}


### PR DESCRIPTION
Previously, the way we create `*sql.DB` are scattered all over the place and they do the same thing. It make sense to refactor this into `DatabaseConfig`. This means I won't have to write it again in order to wait for the replica to catch up to the master.

This is a precursor to the PR for waiting on replica to catch up to the master writer node.