### PR TITLE
 WaitUntilReplicaIsCaughtUpToMaster in Ghostferry core

### DIFF
--- a/ferry.go
+++ b/ferry.go
@@ -61,6 +61,8 @@ type Ferry struct {
 	DoneTime     time.Time
 	OverallState string
 
+	WaitUntilReplicaIsCaughtUpToMaster *WaitUntilReplicaIsCaughtUpToMaster
+
 	logger *logrus.Entry
 
 	rowCopyCompleteCh chan struct{}
@@ -318,6 +320,12 @@ func (f *Ferry) WaitUntilBinlogStreamerCatchesUp() {
 // This method will actually not shutdown the BinlogStreamer immediately.
 // You will know that the BinlogStreamer finished when .Run() returns.
 func (f *Ferry) FlushBinlogAndStopStreaming() {
+	if f.WaitUntilReplicaIsCaughtUpToMaster != nil {
+		f.WaitUntilReplicaIsCaughtUpToMaster.ErrorHandler = f.ErrorHandler
+		f.WaitUntilReplicaIsCaughtUpToMaster.ReplicaDB = f.SourceDB
+		f.WaitUntilReplicaIsCaughtUpToMaster.Wait()
+	}
+
 	f.BinlogStreamer.FlushAndStop()
 }
 

--- a/test/wait_until_replica_is_caught_up_to_master_test.go
+++ b/test/wait_until_replica_is_caught_up_to_master_test.go
@@ -1,0 +1,83 @@
+package test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/Shopify/ghostferry"
+	"github.com/Shopify/ghostferry/testhelpers"
+	"github.com/siddontang/go-mysql/mysql"
+	"github.com/stretchr/testify/suite"
+)
+
+type WaitUntilReplicaIsCaughtUpToMasterSuite struct {
+	suite.Suite
+
+	outdatedMasterPosition mysql.Position
+	w                      *ghostferry.WaitUntilReplicaIsCaughtUpToMaster
+}
+
+func (s *WaitUntilReplicaIsCaughtUpToMasterSuite) SetupTest() {
+	config := testhelpers.NewTestConfig()
+
+	// We'll setup a fake pt-heartbeat by updating the entries manually.
+	masterDB, err := config.Source.SqlDB(nil)
+	s.Require().Nil(err)
+	replicaDB, err := config.Target.SqlDB(nil)
+	s.Require().Nil(err)
+
+	s.w = &ghostferry.WaitUntilReplicaIsCaughtUpToMaster{
+		MasterDB:  masterDB,
+		ReplicaDB: replicaDB,
+		ReplicatedMasterPosition: ghostferry.ReplicatedMasterPositionViaCustomQuery{
+			Query: "SELECT file, position FROM meta.heartbeat WHERE server_id = 1",
+		},
+	}
+
+	s.outdatedMasterPosition, err = ghostferry.ShowMasterStatusBinlogPosition(s.w.MasterDB)
+	s.Require().Nil(err)
+
+	s.recreateTable(s.w.MasterDB)
+	s.recreateTable(s.w.ReplicaDB)
+}
+
+func (s *WaitUntilReplicaIsCaughtUpToMasterSuite) recreateTable(db *sql.DB) {
+	_, err := db.Exec("DROP DATABASE IF EXISTS meta")
+	s.Require().Nil(err)
+
+	_, err = db.Exec("CREATE DATABASE meta")
+	s.Require().Nil(err)
+
+	_, err = db.Exec("CREATE TABLE meta.heartbeat (server_id int unsigned NOT NULL, file varchar(255) DEFAULT NULL, position bigint unsigned DEFAULT NULL, PRIMARY KEY (server_id))")
+	s.Require().Nil(err)
+
+	s.updateHeartbeatMasterPos(db, s.outdatedMasterPosition)
+}
+
+func (s *WaitUntilReplicaIsCaughtUpToMasterSuite) updateHeartbeatMasterPos(db *sql.DB, pos mysql.Position) {
+	_, err := db.Exec("REPLACE INTO meta.heartbeat (server_id, file, position) VALUES (1, ?, ?)", pos.Name, pos.Pos)
+	s.Require().Nil(err)
+}
+
+func (s *WaitUntilReplicaIsCaughtUpToMasterSuite) TestIsCaughtUpIsCorrect() {
+	err := s.w.Start()
+	s.Require().Nil(err)
+
+	currentPosition, err := ghostferry.ShowMasterStatusBinlogPosition(s.w.MasterDB)
+	s.Require().Nil(err)
+	s.Require().Equal(1, currentPosition.Compare(s.outdatedMasterPosition), "test setup error, master position did not advance")
+
+	isCaughtUp, err := s.w.IsCaughtUp()
+	s.Require().Nil(err)
+	s.Require().False(isCaughtUp)
+
+	s.updateHeartbeatMasterPos(s.w.ReplicaDB, currentPosition)
+
+	isCaughtUp, err = s.w.IsCaughtUp()
+	s.Require().Nil(err)
+	s.Require().True(isCaughtUp)
+}
+
+func TestWaitUntilReplicaIsCaughtUpToMaster(t *testing.T) {
+	suite.Run(t, new(WaitUntilReplicaIsCaughtUpToMasterSuite))
+}

--- a/utils.go
+++ b/utils.go
@@ -3,11 +3,14 @@ package ghostferry
 import (
 	"context"
 	"crypto/rand"
+	"database/sql"
 	"encoding/binary"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/siddontang/go-mysql/mysql"
 	"github.com/sirupsen/logrus"
 )
 
@@ -138,4 +141,27 @@ loop:
 		}
 	}
 	return results, err
+}
+
+func ShowMasterStatusBinlogPosition(db *sql.DB) (mysql.Position, error) {
+	row := db.QueryRow("SHOW MASTER STATUS")
+	var file string
+	var position uint32
+	var binlog_do_db, binlog_ignore_db, executed_gtid_set string
+	err := row.Scan(&file, &position, &binlog_do_db, &binlog_ignore_db, &executed_gtid_set)
+	switch {
+	case err == sql.ErrNoRows:
+		return mysql.Position{}, fmt.Errorf("no results from show master status")
+	case err != nil:
+		return mysql.Position{}, err
+	default:
+		if file == "" {
+			return mysql.Position{}, fmt.Errorf("show master status does not show a file")
+		}
+
+		return mysql.Position{
+			Name: file,
+			Pos:  position,
+		}, nil
+	}
 }

--- a/wait_until_replica_is_caught_up_to_master.go
+++ b/wait_until_replica_is_caught_up_to_master.go
@@ -1,0 +1,125 @@
+package ghostferry
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/siddontang/go-mysql/mysql"
+	"github.com/sirupsen/logrus"
+)
+
+type ReplicatedMasterPositionFetcher interface {
+	Current(*sql.DB) (mysql.Position, error)
+}
+
+// Selects the master position that we have replicated until from a heartbeat
+// table of sort.
+type ReplicatedMasterPositionViaCustomQuery struct {
+	// The custom query executing should return a single row with two values:
+	// the string file and the integer position. For pt-heartbeat, this query
+	// would be:
+	//
+	// "SELECT file, position FROM meta.ptheartbeat WHERE server_id = %d" % serverId
+	//
+	// where serverId is the master server id, and meta.ptheartbeat is the table
+	// where pt-heartbeat writes to.
+	//
+	// For pt-heartbeat in particular, you should not use the
+	// relay_master_log_file and exec_master_log_pos of the DB being replicated
+	// as these values are not the master binlog positions.
+	Query string
+}
+
+func (r ReplicatedMasterPositionViaCustomQuery) Current(replicaDB *sql.DB) (mysql.Position, error) {
+	var file string
+	var pos uint32
+	row := replicaDB.QueryRow(r.Query)
+	err := row.Scan(&file, &pos)
+	if err != nil {
+		return mysql.Position{}, nil
+	}
+
+	switch {
+	case err == sql.ErrNoRows:
+		return mysql.Position{}, fmt.Errorf("no results from query")
+	case err != nil:
+		return mysql.Position{}, err
+	default:
+		if file == "" {
+			return mysql.Position{}, fmt.Errorf("query does not return a file")
+		}
+
+		return mysql.Position{
+			Name: file,
+			Pos:  pos,
+		}, nil
+	}
+}
+
+// Only set the MasterDB and ReplicatedMasterPosition options in your code as
+// the others will be overwritten by the ferry.
+type WaitUntilReplicaIsCaughtUpToMaster struct {
+	MasterDB                 *sql.DB
+	ReplicatedMasterPosition ReplicatedMasterPositionFetcher
+
+	ReplicaDB    *sql.DB
+	ErrorHandler ErrorHandler
+
+	logger          *logrus.Entry
+	targetMasterPos mysql.Position
+}
+
+func (w *WaitUntilReplicaIsCaughtUpToMaster) Start() error {
+	w.logger = logrus.WithField("tag", "wait_replica")
+
+	return WithRetries(100, 600*time.Millisecond, w.logger, "read master binlog position", func() error {
+		var err error
+		w.targetMasterPos, err = ShowMasterStatusBinlogPosition(w.MasterDB)
+		return err
+	})
+}
+
+func (w *WaitUntilReplicaIsCaughtUpToMaster) IsCaughtUp() (bool, error) {
+	var currentReplicatedMasterPos mysql.Position
+	err := WithRetries(100, 600*time.Millisecond, w.logger, "read replicated master binlog position", func() error {
+		var err error
+		currentReplicatedMasterPos, err = w.ReplicatedMasterPosition.Current(w.ReplicaDB)
+		return err
+	})
+
+	if err != nil {
+		return false, err
+	}
+
+	if currentReplicatedMasterPos.Compare(w.targetMasterPos) >= 0 {
+		w.logger.Infof("target master position reached by replica: %v >= %v\n", currentReplicatedMasterPos, w.targetMasterPos)
+		return true, nil
+	}
+
+	w.logger.Debugf("replicated master position is: %v < %v\n", currentReplicatedMasterPos, w.targetMasterPos)
+	return false, nil
+}
+
+func (w *WaitUntilReplicaIsCaughtUpToMaster) Wait() {
+	err := w.Start()
+	if err != nil {
+		w.logger.WithError(err).Error("failed to get master binlog coordinates")
+		w.ErrorHandler.Fatal("wait_replica", err)
+		return
+	}
+
+	w.logger.Infof("target master position is: %v\n", w.targetMasterPos)
+
+	isCaughtUp := false
+	for !isCaughtUp {
+		isCaughtUp, err = w.IsCaughtUp()
+		if err != nil {
+			w.logger.WithError(err).Error("failed to get replica binlog coordinates")
+			w.ErrorHandler.Fatal("wait_replica", err)
+			return
+		}
+
+		time.Sleep(600 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
**Note: the current implementation is NOT hooked up to sharding/copydb. The present work focuses on the main algorithm. Implementation inside sharding/copydb can come in follow up PRs.**

### Problem

If we are copying from a slave source database, we must ensure that the slave is up to date after making the source read only before flushing and stopping the binlog streamer. Without doing so, a race condition exists to cause data corruption. As an example:

1. User sets source master writer to READONLY. Suppose master binlog position    is now 10 and slave binlog position is 8.
2. Ghostferry request for binlog streamer to stop. The binlog streamer sets the target stop position 8.
3. Ghostferry misses binlog entry 9 and 10, causing data corruption.

### Solution

This commit fixes the problem by making sure the replica is caught up to the master by introducing a optional loop checking this before we flush and stop the binlog streamer. This is accomplished by:

1. User sets source master writer to READONLY.
2. Ghostferry connects to the master writer and reads the binlog position via SHOW MASTER STATUS. This position is saved.
3. Ghostferry connects to the slave and reads the current master binlog position via a custom query. As an example, you could SELECT the master node from the pt-heartbeat table and thus discover its binlog position that has been replicated to the slave.
4. Ghostferry continues to execute this custom query until the position is greater than the target position saved in step 2.

We use a heartbeat table because `SHOW SLAVE STATUS` does not give the correct result if the slave is not replicating directly from the master, as in a case with a complex replication topology. However, it is possible to write some code to support the case of `SHOW SLAVE STATUS` as the interface is general.

### Implementation detail

Currently it is implemented as a class you can optionally initialize in the sharding/copydb/custom Ferry and passed into `ghostferry.Ferry`. For now, the way we get the master binlog position that has been replicated to the slave is via a custom query specified by the consumer of this API. An example is given in the comment/test.