### PR TITLE
Wait Replica cleanup

### DIFF
--- a/ferry.go
+++ b/ferry.go
@@ -321,9 +321,12 @@ func (f *Ferry) WaitUntilBinlogStreamerCatchesUp() {
 // You will know that the BinlogStreamer finished when .Run() returns.
 func (f *Ferry) FlushBinlogAndStopStreaming() {
 	if f.WaitUntilReplicaIsCaughtUpToMaster != nil {
-		f.WaitUntilReplicaIsCaughtUpToMaster.ErrorHandler = f.ErrorHandler
 		f.WaitUntilReplicaIsCaughtUpToMaster.ReplicaDB = f.SourceDB
-		f.WaitUntilReplicaIsCaughtUpToMaster.Wait()
+		err := f.WaitUntilReplicaIsCaughtUpToMaster.Wait()
+		if err != nil {
+			f.ErrorHandler.Fatal("wait_replica", err)
+			return
+		}
 	}
 
 	f.BinlogStreamer.FlushAndStop()

--- a/test/wait_until_replica_is_caught_up_to_master_test.go
+++ b/test/wait_until_replica_is_caught_up_to_master_test.go
@@ -60,20 +60,17 @@ func (s *WaitUntilReplicaIsCaughtUpToMasterSuite) updateHeartbeatMasterPos(db *s
 }
 
 func (s *WaitUntilReplicaIsCaughtUpToMasterSuite) TestIsCaughtUpIsCorrect() {
-	err := s.w.MarkTargetMasterPosition()
-	s.Require().Nil(err)
-
 	currentPosition, err := ghostferry.ShowMasterStatusBinlogPosition(s.w.MasterDB)
 	s.Require().Nil(err)
 	s.Require().Equal(1, currentPosition.Compare(s.outdatedMasterPosition), "test setup error, master position did not advance")
 
-	isCaughtUp, err := s.w.IsCaughtUp()
+	isCaughtUp, err := s.w.IsCaughtUp(currentPosition)
 	s.Require().Nil(err)
 	s.Require().False(isCaughtUp)
 
 	s.updateHeartbeatMasterPos(s.w.ReplicaDB, currentPosition)
 
-	isCaughtUp, err = s.w.IsCaughtUp()
+	isCaughtUp, err = s.w.IsCaughtUp(currentPosition)
 	s.Require().Nil(err)
 	s.Require().True(isCaughtUp)
 }


### PR DESCRIPTION
Cleaning up the code for WaitUntilReplicaIsCaughtUpToMaster:

- Return an error in `Wait` instead of sending directly to `ErrorHandler`.
- Added an option to make replica wait timeout after a certain amount of time.
- Simplified the `Wait` method so we don't need to set a global-ish variable while still preserving some testing capabilities.
