### PR TITLE
Iterative Verifier: keep on re-verifying until store is small enough

### DIFF
--- a/sharding/config.go
+++ b/sharding/config.go
@@ -1,6 +1,8 @@
 package sharding
 
 import (
+	"time"
+
 	"github.com/Shopify/ghostferry"
 )
 
@@ -23,6 +25,7 @@ type Config struct {
 	PrimaryKeyTables          []string
 
 	VerifierIterationConcurrency int
+	MaxExpectedVerifierDowntime  time.Duration
 
 	Throttle *ghostferry.LagThrottlerConfig
 }

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -106,8 +106,9 @@ func (r *ShardingFerry) newIterativeVerifier() *ghostferry.IterativeVerifier {
 		DatabaseRewrites: r.config.DatabaseRewrites,
 		TableRewrites:    r.config.TableRewrites,
 
-		IgnoredTables: r.config.IgnoredVerificationTables,
-		Concurrency:   verifierConcurrency,
+		IgnoredTables:       r.config.IgnoredVerificationTables,
+		Concurrency:         verifierConcurrency,
+		MaxExpectedDowntime: r.config.MaxExpectedVerifierDowntime,
 	}
 }
 


### PR DESCRIPTION
This PR iterates on our previous heuristic for improving cutover phase verification performance for the iterative verifier. Rather than eagerly re-verifying only once to cut down the `reverifyStore` size, keep re-verifying until the overall size of the store does not improve between iterations – with a reasonable static `maxIterations` and a configurable `MaxDowntime` duration which will determine if the Ferry should proceed any further if the cutover phase verification is predicted to surpass that value.

The PR also adds some helpful metrics for having more visibility into long-running Ferries.

@Shopify/pods 