### PR TITLE
Add DryRunVerification mode

### DIFF
--- a/iterative_verifier.go
+++ b/iterative_verifier.go
@@ -133,6 +133,10 @@ type IterativeVerifier struct {
 	SourceDB         *sql.DB
 	TargetDB         *sql.DB
 
+	// This makes the verifier ignore any problems and assume all rows match,
+	// so that performance can be tested without running a full copy.
+	IgnoreVerificationErrors bool
+
 	Tables              []*schema.Table
 	IgnoredTables       []string
 	DatabaseRewrites    map[string]string
@@ -570,6 +574,10 @@ func (v *IterativeVerifier) compareFingerprints(pks []uint64, table *schema.Tabl
 	}
 	if targetErr != nil {
 		return nil, targetErr
+	}
+	if v.IgnoreVerificationErrors {
+		// Execute all the slow work but don't ever return mismatched rows.
+		return nil, nil
 	}
 
 	return compareHashes(sourceHashes, targetHashes), nil

--- a/sharding/cmd/main.go
+++ b/sharding/cmd/main.go
@@ -56,12 +56,17 @@ func main() {
 		errorAndExit(fmt.Sprintf("failed to initialize ferry: %v", err))
 	}
 
-	err = ferry.Start()
-	if err != nil {
-		errorAndExit(fmt.Sprintf("failed to start ferry: %v", err))
-	}
+	if config.DryRunVerification {
+		fmt.Printf("performing dryrun verification only")
+		ferry.DryRunVerification()
+	} else {
+		err = ferry.Start()
+		if err != nil {
+			errorAndExit(fmt.Sprintf("failed to start ferry: %v", err))
+		}
 
-	ferry.Run()
+		ferry.Run()
+	}
 
 	sharding.StopAndFlushMetrics()
 }

--- a/sharding/config.go
+++ b/sharding/config.go
@@ -28,4 +28,6 @@ type Config struct {
 	MaxExpectedVerifierDowntime  time.Duration
 
 	Throttle *ghostferry.LagThrottlerConfig
+
+	DryRunVerification bool
 }

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -273,6 +273,45 @@ func (r *ShardingFerry) copyPrimaryKeyTables() error {
 	return nil
 }
 
+func (r *ShardingFerry) DryRunVerification() {
+	var err error
+	if r.Ferry.Tables, err = ghostferry.LoadTables(r.Ferry.SourceDB, r.Ferry.TableFilter); err != nil {
+		r.Ferry.ErrorHandler.Fatal("sharding_dryrun", err)
+	}
+
+	r.Ferry.BinlogStreamer.TableSchema = r.Ferry.Tables
+	if err = r.Ferry.BinlogStreamer.ConnectBinlogStreamerToMysql(); err != nil {
+		r.Ferry.ErrorHandler.Fatal("sharding_dryrun", err)
+	}
+
+	r.verifier = r.newIterativeVerifier()
+	if err = r.verifier.Initialize(); err != nil {
+		r.Ferry.ErrorHandler.Fatal("sharding_dryrun", err)
+	}
+
+	r.verifier.IgnoreVerificationErrors = true
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		r.Ferry.BinlogStreamer.Run()
+		wg.Done()
+	}()
+
+	if err = r.verifier.VerifyBeforeCutover(); err != nil {
+		r.logger.WithField("error", err).Errorf("dryrun pre-cutover verification encountered an error")
+		r.Ferry.ErrorHandler.Fatal("sharding_dryrun", err)
+	}
+
+	r.Ferry.BinlogStreamer.FlushAndStop()
+	wg.Wait()
+
+	if _, err = r.verifier.VerifyDuringCutover(); err != nil {
+		r.logger.WithField("error", err).Errorf("dryrun cutover verification encountered an error")
+		r.Ferry.ErrorHandler.Fatal("sharding_dryrun", err)
+	}
+}
+
 func compileRegexps(exps []string) ([]*regexp.Regexp, error) {
 	var err error
 	res := make([]*regexp.Regexp, len(exps))

--- a/sharding/test/dry_run_verification_test.go
+++ b/sharding/test/dry_run_verification_test.go
@@ -1,0 +1,73 @@
+package test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Shopify/ghostferry"
+	"github.com/Shopify/ghostferry/sharding"
+	"github.com/Shopify/ghostferry/testhelpers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDryRunVerificationDoesNotModifyTarget(t *testing.T) {
+	config := &sharding.Config{
+		Config: testhelpers.NewTestConfig(),
+
+		ShardingKey:   "tenant_id",
+		ShardingValue: 1,
+		SourceDB:      "gftest",
+		TargetDB:      "gftest",
+
+		MaxExpectedVerifierDowntime: time.Minute,
+	}
+
+	ferry, err := sharding.NewFerry(config)
+	assert.Nil(t, err)
+
+	ferry.Ferry.ErrorHandler = &ghostferry.PanicErrorHandler{Ferry: ferry.Ferry}
+
+	err = ferry.Initialize()
+	assert.Nil(t, err)
+
+	sourceDB := ferry.Ferry.SourceDB
+	targetDB := ferry.Ferry.TargetDB
+
+	defer func() {
+		testhelpers.DeleteTestDBs(sourceDB)
+		testhelpers.DeleteTestDBs(targetDB)
+	}()
+
+	testhelpers.SeedInitialData(sourceDB, "gftest", "table1", 1000)
+	testhelpers.SeedInitialData(targetDB, "gftest", "table1", 0)
+
+	testhelpers.AddTenantID(sourceDB, "gftest", "table1", 3)
+	testhelpers.AddTenantID(targetDB, "gftest", "table1", 3)
+
+	dataWriter := &testhelpers.MixedActionDataWriter{
+		ProbabilityOfInsert: 1.0,
+		NumberOfWriters:     2,
+
+		Tables: []string{"gftest.table1"},
+		Db:     sourceDB,
+
+		ExtraInsertData: func(tableName string, vals map[string]interface{}) {
+			vals["tenant_id"] = 1
+		},
+	}
+	go dataWriter.Run()
+
+	ferry.DryRunVerification()
+
+	dataWriter.Stop()
+	dataWriter.Wait()
+
+	var count int
+	row := sourceDB.QueryRow("SELECT count(*) FROM gftest.table1")
+	testhelpers.PanicIfError(row.Scan(&count))
+	assert.True(t, count > 1000)
+
+	row = targetDB.QueryRow("SELECT count(*) FROM gftest.table1")
+	testhelpers.PanicIfError(row.Scan(&count))
+	assert.Equal(t, 0, count)
+}

--- a/testhelpers/data_writer.go
+++ b/testhelpers/data_writer.go
@@ -97,6 +97,13 @@ func AddTenantID(db *sql.DB, dbName, tableName string, numberOfTenants int) {
 	PanicIfError(err)
 }
 
+func DeleteTestDBs(db *sql.DB) {
+	for _, dbname := range ApplicableTestDbs {
+		_, err := db.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbname))
+		PanicIfError(err)
+	}
+}
+
 type DataWriter interface {
 	Run()
 	Stop()

--- a/testhelpers/integration_test_case.go
+++ b/testhelpers/integration_test_case.go
@@ -1,7 +1,6 @@
 package testhelpers
 
 import (
-	"fmt"
 	"sync"
 	"testing"
 
@@ -129,20 +128,11 @@ func (this *IntegrationTestCase) Teardown() {
 		logrus.Error("you might see an unrelated panic as we delete the db, if there are background processes operating on the db")
 	}
 
-	for _, dbname := range ApplicableTestDbs {
-		if this.Ferry.SourceDB != nil {
-			_, err := this.Ferry.SourceDB.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbname))
-			if err != nil {
-				logrus.WithError(err).Errorf("failed to drop database %s on the source db as a part of the test cleanup", dbname)
-			}
-		}
-
-		if this.Ferry.TargetDB != nil {
-			_, err := this.Ferry.TargetDB.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbname))
-			if err != nil {
-				logrus.WithError(err).Errorf("failed to drop database %s on the target db as a part of the test cleanup", dbname)
-			}
-		}
+	if this.Ferry.SourceDB != nil {
+		DeleteTestDBs(this.Ferry.SourceDB)
+	}
+	if this.Ferry.TargetDB != nil {
+		DeleteTestDBs(this.Ferry.TargetDB)
 	}
 
 	if r != nil {


### PR DESCRIPTION
This allows us to run all verification steps without running a copy. It runs all the same work it normally takes to verify, so it should take about the same amount of time, but doesn't write binlog events to the target or actually compare hashes to do real verification.

We may not want to merge this, but I'm putting it here so we can use it for testing something.

@Shopify/pods 