### PR TITLE
sharding: fix duration config 

### DIFF
--- a/sharding/config.go
+++ b/sharding/config.go
@@ -1,8 +1,6 @@
 package sharding
 
 import (
-	"time"
-
 	"github.com/Shopify/ghostferry"
 )
 
@@ -29,7 +27,7 @@ type Config struct {
 	PrimaryKeyTables          []string
 
 	VerifierIterationConcurrency int
-	MaxExpectedVerifierDowntime  time.Duration
+	MaxExpectedVerifierDowntime  string
 
 	Throttle *ghostferry.LagThrottlerConfig
 }


### PR DESCRIPTION
Follow up to https://github.com/Shopify/ghostferry/pull/36

For some reason I had thought using `30[s|d|h]` notation is the canonical way of unmarshalling a time.Duration. Guess not 😬 

@pushrax @fw42 