### PR TITLE
Handle empty throttler results

### DIFF
--- a/throttler.go
+++ b/throttler.go
@@ -148,12 +148,18 @@ func (t *LagThrottler) Run(ctx context.Context) error {
 }
 
 func (t *LagThrottler) updateLag(ctx context.Context) error {
-	var newLag int
+	var newLag sql.NullInt64
 	err := t.DB.QueryRowContext(ctx, t.config.Query).Scan(&newLag)
+	if err == sql.ErrNoRows {
+		return nil
+	}
 	if err != nil {
 		return err
 	}
+	if !newLag.Valid {
+		return nil
+	}
 
-	t.lag = newLag
+	t.lag = int(newLag.Int64)
 	return nil
 }


### PR DESCRIPTION
Sometimes, when the throttler queries the database, the db returns a single row with only a `NULL` column. This is especially true when the query contains aggregation functions like `MAX()`. Currently, this causes the Ferry to fail ungracefully. 

This PR addresses this by keeping the last known throttling state/value when such conditions occur. It also addresses the condition where _no_ rows are returned in the same manner.

@Shopify/pods @shuhaowu 