### PR TITLE
FlushAndBatchByTable must be pointer receiver

### DIFF
--- a/iterative_verifier.go
+++ b/iterative_verifier.go
@@ -85,7 +85,7 @@ func (r *ReverifyStore) Add(entry ReverifyEntry) {
 	}
 }
 
-func (r ReverifyStore) FlushAndBatchByTable(batchsize int) []ReverifyBatch {
+func (r *ReverifyStore) FlushAndBatchByTable(batchsize int) []ReverifyBatch {
 	r.mapStoreMutex.Lock()
 	defer r.mapStoreMutex.Unlock()
 


### PR DESCRIPTION
This is another follow-up to https://github.com/Shopify/ghostferry/pull/36

Unfortunately, due to the difficult-to-test optimization, we missed this very subtle bug in the PR above: 
* Calling `(r ReverifyStore) FlushAndBatchByTable` on `r.reverifyStore` would perform a `r.flushStore()` which then would set the `r.RowCount` field to 0 on a copy of the struct
* Another goroutine calling `(r *ReverifyStore) Add` would not see this update 
* `before` and `after` values for the reverification optimization (see `reverifyUntilStoreIsSmallEnough`) would monotonically increase, rendering the heuristic of "stop when after >= before" useless.

@shopify/pods