### PR TITLE
Check if target database is writable before starting ferry

### DIFF
--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -86,7 +86,12 @@ func (r *ShardingFerry) Initialize() error {
 		}
 	}
 
-	return r.Ferry.Initialize()
+	err := r.Ferry.Initialize()
+	if err != nil {
+		r.Ferry.ErrorHandler.Fatal("ferry.initialize", err)
+		return err
+	}
+	return nil
 }
 
 func (r *ShardingFerry) newIterativeVerifier() (*ghostferry.IterativeVerifier, error) {

--- a/test/binlog_streamer_test.go
+++ b/test/binlog_streamer_test.go
@@ -10,14 +10,14 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type FerryTestSuite struct {
+type BinlogStreamerTestSuite struct {
 	*testhelpers.GhostferryUnitTestSuite
 
 	config         *ghostferry.Config
 	binlogStreamer *ghostferry.BinlogStreamer
 }
 
-func (this *FerryTestSuite) SetupTest() {
+func (this *BinlogStreamerTestSuite) SetupTest() {
 	this.GhostferryUnitTestSuite.SetupTest()
 
 	testFerry := testhelpers.NewTestFerry()
@@ -41,7 +41,7 @@ func (this *FerryTestSuite) SetupTest() {
 	this.Require().Nil(this.binlogStreamer.Initialize())
 }
 
-func (this *FerryTestSuite) TestConnectWithIdKeepsId() {
+func (this *BinlogStreamerTestSuite) TestConnectWithIdKeepsId() {
 	this.binlogStreamer.Config.MyServerId = 1421
 
 	err := this.binlogStreamer.ConnectBinlogStreamerToMysql()
@@ -50,7 +50,7 @@ func (this *FerryTestSuite) TestConnectWithIdKeepsId() {
 	this.Require().Equal(uint32(1421), this.binlogStreamer.Config.MyServerId)
 }
 
-func (this *FerryTestSuite) TestConnectWithZeroIdGetsRandomServerId() {
+func (this *BinlogStreamerTestSuite) TestConnectWithZeroIdGetsRandomServerId() {
 	this.binlogStreamer.Config.MyServerId = 0
 
 	err := this.binlogStreamer.ConnectBinlogStreamerToMysql()
@@ -59,7 +59,7 @@ func (this *FerryTestSuite) TestConnectWithZeroIdGetsRandomServerId() {
 	this.Require().NotZero(this.binlogStreamer.Config.MyServerId)
 }
 
-func (this *FerryTestSuite) TestConnectErrorsOutIfErrorInServerIdGeneration() {
+func (this *BinlogStreamerTestSuite) TestConnectErrorsOutIfErrorInServerIdGeneration() {
 	this.binlogStreamer.Config.MyServerId = 0
 
 	this.binlogStreamer.Db.Close()
@@ -70,7 +70,7 @@ func (this *FerryTestSuite) TestConnectErrorsOutIfErrorInServerIdGeneration() {
 	this.Require().Zero(this.binlogStreamer.Config.MyServerId)
 }
 
-func TestFerryTestSuite(t *testing.T) {
+func TestBinlogStreamerTestSuite(t *testing.T) {
 	testhelpers.SetupTest()
-	suite.Run(t, &FerryTestSuite{GhostferryUnitTestSuite: &testhelpers.GhostferryUnitTestSuite{}})
+	suite.Run(t, &BinlogStreamerTestSuite{GhostferryUnitTestSuite: &testhelpers.GhostferryUnitTestSuite{}})
 }

--- a/test/ferry_test.go
+++ b/test/ferry_test.go
@@ -1,0 +1,44 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/Shopify/ghostferry"
+	"github.com/Shopify/ghostferry/testhelpers"
+	"github.com/stretchr/testify/suite"
+)
+
+type FerryTestSuite struct {
+	*testhelpers.GhostferryUnitTestSuite
+
+	ferry *ghostferry.Ferry
+}
+
+func (t *FerryTestSuite) SetupTest() {
+	t.GhostferryUnitTestSuite.SetupTest()
+}
+
+func (t *FerryTestSuite) TearDownTest() {
+	_, err := t.Ferry.TargetDB.Exec("SET GLOBAL read_only = OFF")
+	t.Require().Nil(err)
+}
+
+func (t *FerryTestSuite) TestReadOnlyDatabaseFailsInitialization() {
+	_, err := t.Ferry.TargetDB.Exec("SET GLOBAL read_only = ON")
+	t.Require().Nil(err)
+
+	ferry := testhelpers.NewTestFerry().Ferry // make new ferry that re-uses the same targetDB as t.Ferry
+	err = ferry.Initialize()
+	t.Require().Equal("@@read_only must be OFF on target db", err.Error())
+
+	_, err = t.Ferry.TargetDB.Exec("SET GLOBAL read_only = OFF")
+	t.Require().Nil(err)
+
+	ferry = testhelpers.NewTestFerry().Ferry
+	err = ferry.Initialize()
+	t.Require().Nil(err)
+}
+
+func TestFerryTestSuite(t *testing.T) {
+	suite.Run(t, &FerryTestSuite{GhostferryUnitTestSuite: &testhelpers.GhostferryUnitTestSuite{}})
+}


### PR DESCRIPTION
This allows a ferry to fail early in case the provided target database connection is not writeable. We previously had this check in our application but it makes more sense to perform this check at the Ghostferry level.

@Shopify/pods @shuhaowu 