### PR TITLE
TIMESTAMP Timezone fix

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -118,7 +118,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8a890d0793e1199e134a0c8192c33456d1aca48bc874ca08dc8b7822d8d06b01"
+  digest = "1:8b826f26e0bbb00dcfd8284c4480c41dab14240be39ebcd84341213052fd71e5"
   name = "github.com/siddontang/go-mysql"
   packages = [
     "client",
@@ -128,7 +128,7 @@
     "schema",
   ]
   pruneopts = "UT"
-  revision = "29d34f19266fe38678ecfcf7ad4449c33b2bd26d"
+  revision = "58848a70cf1a8baf4ae5647485c3885f39907988"
 
 [[projects]]
   digest = "1:5622116f2c79239f2d25d47b881e14f96a8b8c17b63b8a8326a38ee1a332b007"

--- a/binlog_streamer.go
+++ b/binlog_streamer.go
@@ -61,13 +61,14 @@ func (s *BinlogStreamer) createBinlogSyncer() error {
 	}
 
 	syncerConfig := replication.BinlogSyncerConfig{
-		ServerID:   s.Config.MyServerId,
-		Host:       s.Config.Source.Host,
-		Port:       s.Config.Source.Port,
-		User:       s.Config.Source.User,
-		Password:   s.Config.Source.Pass,
-		TLSConfig:  tlsConfig,
-		UseDecimal: true,
+		ServerID:                s.Config.MyServerId,
+		Host:                    s.Config.Source.Host,
+		Port:                    s.Config.Source.Port,
+		User:                    s.Config.Source.User,
+		Password:                s.Config.Source.Pass,
+		TLSConfig:               tlsConfig,
+		UseDecimal:              true,
+		TimestampStringLocation: time.UTC,
 	}
 
 	s.binlogSyncer = replication.NewBinlogSyncer(syncerConfig)

--- a/test/types_integration_test.go
+++ b/test/types_integration_test.go
@@ -20,7 +20,7 @@ func addTypesToTable(db *sql.DB, dbName, tableName string) {
 		"ADD date_col DATE," +
 		"ADD time_col TIME," +
 		"ADD dt_col DATETIME," +
-		"ADD ts_col TIMESTAMP," + // TODO broken on master
+		"ADD ts_col TIMESTAMP," +
 		"ADD varchar_col VARCHAR(128)," +
 		"ADD enum_col ENUM('foo', 'bar')," +
 		"ADD set_col SET('foo', 'bar', 'baz')," +
@@ -50,8 +50,8 @@ func setupMultiTypeTable(f *testhelpers.TestFerry) {
 
 	for i := 0; i < 100; i++ {
 		query := "INSERT INTO gftest.table1 " +
-			"(id, data, tiny_col, float_col, double_col, decimal_col, year_col, date_col, time_col, dt_col, varchar_col, enum_col, set_col, utfmb4_col, utf32_col, latin1_col, blob_col, uint64_col, uint32_col, uint16_col, uint8_col)" +
-			"VALUES (NULL, ?, ?, 3.14, 2.72, 42.42, NOW(), NOW(), NOW(), NOW(), ?, ?, 'foo,baz', ?, ?, ?, ?, 18446744073709551615, 3221225472, 49152, 192)"
+			"(id, data, tiny_col, float_col, double_col, decimal_col, year_col, date_col, time_col, dt_col, ts_col, varchar_col, enum_col, set_col, utfmb4_col, utf32_col, latin1_col, blob_col, uint64_col, uint32_col, uint16_col, uint8_col)" +
+			"VALUES (NULL, ?, ?, 3.14, 2.72, 42.42, NOW(), NOW(), NOW(), NOW(), NOW(), ?, ?, 'foo,baz', ?, ?, ?, ?, 18446744073709551615, 3221225472, 49152, 192)"
 
 		enumVal := "foo"
 		if i%2 == 0 {

--- a/vendor/github.com/siddontang/go-mysql/replication/binlogsyncer.go
+++ b/vendor/github.com/siddontang/go-mysql/replication/binlogsyncer.go
@@ -57,6 +57,20 @@ type BinlogSyncerConfig struct {
 	// We will use Local location for timestamp and UTC location for datatime.
 	ParseTime bool
 
+	// If ParseTime is false, convert TIMESTAMP into this specified timezone. If
+	// ParseTime is true, this option will have no effect and TIMESTAMP data will
+	// be parsed into the local timezone and a full time.Time struct will be
+	// returned.
+	//
+	// Note that MySQL TIMESTAMP columns are offset from the machine local
+	// timezone while DATETIME columns are offset from UTC. This is consistent
+	// with documented MySQL behaviour as it return TIMESTAMP in local timezone
+	// and DATETIME in UTC.
+	//
+	// Setting this to UTC effectively equalizes the TIMESTAMP and DATETIME time
+	// strings obtained from MySQL.
+	TimestampStringLocation *time.Location
+
 	// Use decimal.Decimal structure for decimals.
 	UseDecimal bool
 
@@ -124,6 +138,7 @@ func NewBinlogSyncer(cfg BinlogSyncerConfig) *BinlogSyncer {
 	b.parser = NewBinlogParser()
 	b.parser.SetRawMode(b.cfg.RawModeEnabled)
 	b.parser.SetParseTime(b.cfg.ParseTime)
+	b.parser.SetTimestampStringLocation(b.cfg.TimestampStringLocation)
 	b.parser.SetUseDecimal(b.cfg.UseDecimal)
 	b.parser.SetVerifyChecksum(b.cfg.VerifyChecksum)
 	b.running = false

--- a/vendor/github.com/siddontang/go-mysql/replication/parser.go
+++ b/vendor/github.com/siddontang/go-mysql/replication/parser.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"sync/atomic"
+	"time"
 
 	"github.com/juju/errors"
 )
@@ -25,7 +26,8 @@ type BinlogParser struct {
 	// for rawMode, we only parse FormatDescriptionEvent and RotateEvent
 	rawMode bool
 
-	parseTime bool
+	parseTime               bool
+	timestampStringLocation *time.Location
 
 	// used to start/stop processing
 	stopProcessing uint32
@@ -181,6 +183,10 @@ func (p *BinlogParser) SetRawMode(mode bool) {
 
 func (p *BinlogParser) SetParseTime(parseTime bool) {
 	p.parseTime = parseTime
+}
+
+func (p *BinlogParser) SetTimestampStringLocation(timestampStringLocation *time.Location) {
+	p.timestampStringLocation = timestampStringLocation
 }
 
 func (p *BinlogParser) SetUseDecimal(useDecimal bool) {
@@ -347,6 +353,7 @@ func (p *BinlogParser) newRowsEvent(h *EventHeader) *RowsEvent {
 	e.needBitmap2 = false
 	e.tables = p.tables
 	e.parseTime = p.parseTime
+	e.timestampStringLocation = p.timestampStringLocation
 	e.useDecimal = p.useDecimal
 
 	switch h.EventType {

--- a/vendor/github.com/siddontang/go-mysql/replication/time.go
+++ b/vendor/github.com/siddontang/go-mysql/replication/time.go
@@ -16,10 +16,16 @@ type fracTime struct {
 
 	// Dec must in [0, 6]
 	Dec int
+
+	timestampStringLocation *time.Location
 }
 
 func (t fracTime) String() string {
-	return t.Format(fracTimeFormat[t.Dec])
+	tt := t.Time
+	if t.timestampStringLocation != nil {
+		tt = tt.In(t.timestampStringLocation)
+	}
+	return tt.Format(fracTimeFormat[t.Dec])
 }
 
 func formatZeroTime(frac int, dec int) string {


### PR DESCRIPTION
https://github.com/siddontang/go-mysql/pull/295 has been merged and thus we have a way to fix the timezone issue causing binlogs to not properly sync over. 

However, the deeper question now is whether or not setting this to UTC will solve the issue. Should we also try to set the mysql session timezone to UTC while executing queries on the target and the source? Or maybe we have to do something else as well?

Fixes #23