### PR TITLE
Integration of CompressionVerifier into sharding package

### DIFF
--- a/compression_verifier.go
+++ b/compression_verifier.go
@@ -177,7 +177,7 @@ func (c *CompressionVerifier) IsCompressedTable(table string) bool {
 func (c *CompressionVerifier) verifyConfiguredCompression(tableColumnCompressions TableColumnCompressionConfig) error {
 	for table, columns := range tableColumnCompressions {
 		for column, algorithm := range columns {
-			if _, ok := c.supportedAlgorithms[algorithm]; !ok {
+			if _, ok := c.supportedAlgorithms[strings.ToUpper(algorithm)]; !ok {
 				return &UnsupportedCompressionError{
 					table:     table,
 					column:    column,

--- a/config.go
+++ b/config.go
@@ -171,7 +171,7 @@ type Config struct {
 	//	1. Snappy (https://google.github.io/snappy/) as "SNAPPY"
 	//
 	// Optional: defaults to empty map/no compression
-	TableColumnCompression map[string]map[string]string
+	TableColumnCompression TableColumnCompressionConfig
 
 	// The maximum number of retries for writes if the writes failed on
 	// the target database.


### PR DESCRIPTION
This integrates the work done in #44 into the sharding package for use in the shop mover.

I also realized that after performing delta-copy of joined tables we never verify the copied rows.

@Shopify/pods 