### PR TITLE
Refactored DataIteratorState to StateTracker for interruptibility

### DIFF
--- a/binlog_streamer.go
+++ b/binlog_streamer.go
@@ -35,7 +35,7 @@ type BinlogStreamer struct {
 	eventListeners []func([]DMLEvent) error
 }
 
-func (s *BinlogStreamer) Initialize() (err error) {
+func (s *BinlogStreamer) Initialize() error {
 	s.logger = logrus.WithField("tag", "binlog_streamer")
 	s.stopRequested = false
 	return nil

--- a/data_iterator.go
+++ b/data_iterator.go
@@ -91,26 +91,6 @@ func (d *DataIterator) Run() {
 						}
 					}
 
-					// The way we save the LastSuccessfulPK is probably incorrect if we
-					// want to ensure that when we crash, we have a "correct" view of
-					// the LastSuccessfulPK.
-					// However, it's uncertain if it is even theoretically possible to
-					// save the "correct" value.
-					// TODO: investigate this if we want to ensure that on error, we have
-					//       the "correct" last successful PK and other values.
-					// TODO: it is also perhaps possible to save the Cursor objects
-					// directly as opposed to saving a state, but that is left to
-					// the future.
-					lastRow := batch.Values()[len(batch.Values())-1]
-					pkpos, err := lastRow.GetUint64(batch.PkIndex())
-					if err != nil {
-						logger.WithError(err).Error("failed to convert pk to uint64")
-						return err
-					}
-
-					logger.Debugf("updated last successful PK to %d", pkpos)
-					d.StateTracker.UpdateLastSuccessfulPK(table.String(), pkpos)
-
 					return nil
 				})
 

--- a/data_iterator.go
+++ b/data_iterator.go
@@ -1,142 +1,14 @@
 package ghostferry
 
 import (
-	"container/ring"
 	"database/sql"
+	"errors"
+	"fmt"
 	"sync"
-	"time"
 
 	"github.com/siddontang/go-mysql/schema"
 	"github.com/sirupsen/logrus"
 )
-
-type PKPositionLog struct {
-	Position uint64
-	At       time.Time
-}
-
-type DataIteratorState struct {
-	// We need to lock these maps as Go does not support concurrent access to
-	// maps.
-	// Maybe able to convert to sync.Map in Go1.9
-	targetPrimaryKeys         map[string]uint64
-	lastSuccessfulPrimaryKeys map[string]uint64
-	completedTables           map[string]bool
-	copySpeedLog              *ring.Ring
-
-	targetPkMutex     *sync.RWMutex
-	successfulPkMutex *sync.RWMutex
-	tablesMutex       *sync.RWMutex
-}
-
-func newDataIteratorState(tableIteratorCount int) *DataIteratorState {
-	// We want to make sure that the ring buffer is not filled with
-	// only the timestamp from the last iteration.
-	//
-	// Having it some multiple times of the number of table iterators
-	// _should_ allow for this.
-	speedLog := ring.New(tableIteratorCount * 5)
-	speedLog.Value = PKPositionLog{
-		Position: 0,
-		At:       time.Now(),
-	}
-
-	return &DataIteratorState{
-		targetPrimaryKeys:         make(map[string]uint64),
-		lastSuccessfulPrimaryKeys: make(map[string]uint64),
-		completedTables:           make(map[string]bool),
-		copySpeedLog:              speedLog,
-		targetPkMutex:             &sync.RWMutex{},
-		successfulPkMutex:         &sync.RWMutex{},
-		tablesMutex:               &sync.RWMutex{},
-	}
-}
-
-func (this *DataIteratorState) UpdateTargetPK(table string, pk uint64) {
-	this.targetPkMutex.Lock()
-	defer this.targetPkMutex.Unlock()
-
-	this.targetPrimaryKeys[table] = pk
-}
-
-func (this *DataIteratorState) UpdateLastSuccessfulPK(table string, pk uint64) {
-	this.successfulPkMutex.Lock()
-	defer this.successfulPkMutex.Unlock()
-
-	deltaPK := pk - this.lastSuccessfulPrimaryKeys[table]
-	this.lastSuccessfulPrimaryKeys[table] = pk
-
-	currentTotalPK := this.copySpeedLog.Value.(PKPositionLog).Position
-	this.copySpeedLog = this.copySpeedLog.Next()
-	this.copySpeedLog.Value = PKPositionLog{
-		Position: currentTotalPK + deltaPK,
-		At:       time.Now(),
-	}
-}
-
-func (this *DataIteratorState) MarkTableAsCompleted(table string) {
-	this.tablesMutex.Lock()
-	defer this.tablesMutex.Unlock()
-
-	this.completedTables[table] = true
-}
-
-func (this *DataIteratorState) TargetPrimaryKeys() map[string]uint64 {
-	this.targetPkMutex.RLock()
-	defer this.targetPkMutex.RUnlock()
-
-	m := make(map[string]uint64)
-	for k, v := range this.targetPrimaryKeys {
-		m[k] = v
-	}
-
-	return m
-}
-
-func (this *DataIteratorState) LastSuccessfulPrimaryKeys() map[string]uint64 {
-	this.successfulPkMutex.RLock()
-	defer this.successfulPkMutex.RUnlock()
-
-	m := make(map[string]uint64)
-	for k, v := range this.lastSuccessfulPrimaryKeys {
-		m[k] = v
-	}
-
-	return m
-}
-
-func (this *DataIteratorState) CompletedTables() map[string]bool {
-	this.tablesMutex.RLock()
-	defer this.tablesMutex.RUnlock()
-
-	m := make(map[string]bool)
-	for k, v := range this.completedTables {
-		m[k] = v
-	}
-
-	return m
-}
-
-func (this *DataIteratorState) EstimatedPKProcessedPerSecond() float64 {
-	this.successfulPkMutex.RLock()
-	defer this.successfulPkMutex.RUnlock()
-
-	if this.copySpeedLog.Value.(PKPositionLog).Position == 0 {
-		return 0.0
-	}
-
-	earliest := this.copySpeedLog
-	for earliest.Prev() != nil && earliest.Prev() != this.copySpeedLog && earliest.Prev().Value.(PKPositionLog).Position != 0 {
-		earliest = earliest.Prev()
-	}
-
-	currentValue := this.copySpeedLog.Value.(PKPositionLog)
-	earliestValue := earliest.Value.(PKPositionLog)
-	deltaPK := currentValue.Position - earliestValue.Position
-	deltaT := currentValue.At.Sub(earliestValue.At).Seconds()
-
-	return float64(deltaPK) / deltaT
-}
 
 type DataIterator struct {
 	DB          *sql.DB
@@ -145,9 +17,9 @@ type DataIterator struct {
 
 	ErrorHandler ErrorHandler
 	CursorConfig *CursorConfig
+	StateTracker *StateTracker
 
-	CurrentState *DataIteratorState
-
+	targetPKs      *sync.Map
 	batchListeners []func(*RowBatch) error
 	doneListeners  []func() error
 	logger         *logrus.Entry
@@ -155,7 +27,11 @@ type DataIterator struct {
 
 func (d *DataIterator) Initialize() error {
 	d.logger = logrus.WithField("tag", "data_iterator")
-	d.CurrentState = newDataIteratorState(d.Concurrency)
+	d.targetPKs = &sync.Map{}
+
+	if d.StateTracker == nil {
+		return errors.New("StateTracker must be defined")
+	}
 
 	return nil
 }
@@ -169,11 +45,11 @@ func (d *DataIterator) Run() {
 	}
 
 	for _, table := range emptyTables {
-		d.CurrentState.MarkTableAsCompleted(table.String())
+		d.StateTracker.MarkTableAsCompleted(table.String())
 	}
 
 	for table, maxPk := range tablesWithData {
-		d.CurrentState.UpdateTargetPK(table.String(), maxPk)
+		d.targetPKs.Store(table.String(), maxPk)
 	}
 
 	tablesQueue := make(chan *schema.Table)
@@ -192,7 +68,15 @@ func (d *DataIterator) Run() {
 
 				logger := d.logger.WithField("table", table.String())
 
-				cursor := d.CursorConfig.NewCursor(table, d.CurrentState.TargetPrimaryKeys()[table.String()])
+				targetPKInterface, found := d.targetPKs.Load(table.String())
+				if !found {
+					err := fmt.Errorf("%s not found in targetPKs, this is likely a programmer error", table.String())
+					logger.WithError(err).Error("this is definitely a bug")
+					d.ErrorHandler.Fatal("data_iterator", err)
+					return
+				}
+
+				cursor := d.CursorConfig.NewCursor(table, targetPKInterface.(uint64))
 				err := cursor.Each(func(batch *RowBatch) error {
 					metrics.Count("RowEvent", int64(batch.Size()), []MetricTag{
 						MetricTag{"table", table.Name},
@@ -225,7 +109,7 @@ func (d *DataIterator) Run() {
 					}
 
 					logger.Debugf("updated last successful PK to %d", pkpos)
-					d.CurrentState.UpdateLastSuccessfulPK(table.String(), pkpos)
+					d.StateTracker.UpdateLastSuccessfulPK(table.String(), pkpos)
 
 					return nil
 				})
@@ -236,7 +120,7 @@ func (d *DataIterator) Run() {
 				}
 
 				logger.Debug("table iteration completed")
-				d.CurrentState.MarkTableAsCompleted(table.String())
+				d.StateTracker.MarkTableAsCompleted(table.String())
 			}
 		}()
 	}

--- a/error_handler.go
+++ b/error_handler.go
@@ -29,6 +29,13 @@ func (this *PanicErrorHandler) ReportError(from string, err error) {
 		return
 	}
 
+	stateJSON, jsonErr := this.Ferry.SerializeStateToJSON()
+	if jsonErr != nil {
+		logger.WithError(jsonErr).Error("failed to dump state to JSON...")
+	} else {
+		fmt.Fprintln(os.Stdout, stateJSON)
+	}
+
 	// Invoke ErrorCallback if defined
 	if this.ErrorCallback != (HTTPCallback{}) {
 		client := &http.Client{}
@@ -39,28 +46,19 @@ func (this *PanicErrorHandler) ReportError(from string, err error) {
 
 		errorDataBytes, jsonErr := json.MarshalIndent(errorData, "", "  ")
 		if jsonErr != nil {
-			logger.WithField("error", jsonErr).Errorf("ghostferry-sharding failed to marshal error data")
+			logger.WithField("error", jsonErr).Errorf("ghostferry failed to marshal error data")
 		} else {
 			this.ErrorCallback.Payload = string(errorDataBytes)
 
 			postErr := this.ErrorCallback.Post(client)
 			if postErr != nil {
-				logger.WithField("error", postErr).Errorf("ghostferry-sharding failed to notify error")
+				logger.WithField("error", postErr).Errorf("ghostferry failed to notify error")
 			}
 		}
 	}
 
-	logger.WithError(err).WithField("errfrom", from).Error("fatal error detected, state dump coming in stdout")
-
-	stateJSON, err := this.Ferry.SerializeStateToJSON()
-	if err != nil {
-		logger.WithError(err).Error("failed to dump state to JSON...")
-	} else {
-		fmt.Fprintln(os.Stdout, stateJSON)
-	}
-
 	// Print error to STDERR
-	logger.WithError(err).WithField("errfrom", from).Error("fatal error detected, state dump coming in stdout")
+	logger.WithError(err).WithField("errfrom", from).Error("fatal error detected, state dump in stdout")
 }
 
 func (this *PanicErrorHandler) Fatal(from string, err error) {

--- a/error_handler.go
+++ b/error_handler.go
@@ -2,7 +2,9 @@ package ghostferry
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"os"
 	"sync/atomic"
 
 	"github.com/sirupsen/logrus"
@@ -46,6 +48,15 @@ func (this *PanicErrorHandler) ReportError(from string, err error) {
 				logger.WithField("error", postErr).Errorf("ghostferry-sharding failed to notify error")
 			}
 		}
+	}
+
+	logger.WithError(err).WithField("errfrom", from).Error("fatal error detected, state dump coming in stdout")
+
+	stateJSON, err := this.Ferry.SerializeStateToJSON()
+	if err != nil {
+		logger.WithError(err).Error("failed to dump state to JSON...")
+	} else {
+		fmt.Fprintln(os.Stdout, stateJSON)
 	}
 
 	// Print error to STDERR

--- a/ferry.go
+++ b/ferry.go
@@ -205,7 +205,7 @@ func (f *Ferry) Initialize() (err error) {
 		f.Throttler = &PauserThrottler{}
 	}
 
-	f.StateTracker = NewStateTracker(f.DataIterationConcurrency*10, nil)
+	f.StateTracker = NewStateTracker(f.DataIterationConcurrency * 10)
 
 	f.BinlogStreamer = &BinlogStreamer{
 		Db:           f.SourceDB,
@@ -242,14 +242,19 @@ func (f *Ferry) Initialize() (err error) {
 	}
 
 	f.BatchWriter = &BatchWriter{
-		DB: f.TargetDB,
+		DB:           f.TargetDB,
+		StateTracker: f.StateTracker,
 
 		DatabaseRewrites: f.Config.DatabaseRewrites,
 		TableRewrites:    f.Config.TableRewrites,
 
 		WriteRetries: f.Config.DBWriteRetries,
 	}
-	f.BatchWriter.Initialize()
+
+	err = f.BatchWriter.Initialize()
+	if err != nil {
+		return err
+	}
 
 	f.logger.Info("ferry initialized")
 	return nil

--- a/state_tracker.go
+++ b/state_tracker.go
@@ -1,0 +1,150 @@
+package ghostferry
+
+import (
+	"container/ring"
+	"sync"
+	"time"
+
+	"github.com/siddontang/go-mysql/mysql"
+)
+
+type SerializableState struct {
+	GhostferryVersion         string
+	LastKnownTableSchemaCache TableSchemaCache
+
+	LastSuccessfulPrimaryKeys map[string]uint64
+	CompletedTables           map[string]bool
+	LastWrittenBinlogPosition mysql.Position
+}
+
+// For tracking the speed of the copy
+type PKPositionLog struct {
+	Position uint64
+	At       time.Time
+}
+
+type StateTracker struct {
+	lastSuccessfulPrimaryKeys map[string]uint64
+	completedTables           map[string]bool
+	lastWrittenBinlogPosition mysql.Position
+
+	binlogMutex *sync.RWMutex
+	tableMutex  *sync.RWMutex
+
+	copySpeedLog *ring.Ring
+}
+
+func (s *StateTracker) UpdateLastSuccessfulPK(table string, pk uint64) {
+	s.tableMutex.Lock()
+	defer s.tableMutex.Unlock()
+
+	deltaPK := pk - s.lastSuccessfulPrimaryKeys[table]
+	s.lastSuccessfulPrimaryKeys[table] = pk
+
+	currentTotalPK := s.copySpeedLog.Value.(PKPositionLog).Position
+	s.copySpeedLog = s.copySpeedLog.Next()
+	s.copySpeedLog.Value = PKPositionLog{
+		Position: currentTotalPK + deltaPK,
+		At:       time.Now(),
+	}
+}
+
+func (s *StateTracker) MarkTableAsCompleted(table string) {
+	s.tableMutex.Lock()
+	defer s.tableMutex.Unlock()
+
+	s.completedTables[table] = true
+}
+
+func (s *StateTracker) UpdateLastWrittenBinlogPosition(pos mysql.Position) {
+	s.binlogMutex.Lock()
+	defer s.binlogMutex.Unlock()
+
+	s.lastWrittenBinlogPosition = pos
+}
+
+func (s *StateTracker) Serialize(lastKnownTableSchemaCache TableSchemaCache) *SerializableState {
+	s.tableMutex.RLock()
+	s.binlogMutex.RLock()
+	defer func() {
+		s.tableMutex.RUnlock()
+		s.binlogMutex.RUnlock()
+	}()
+
+	state := &SerializableState{
+		GhostferryVersion:         VersionString,
+		LastKnownTableSchemaCache: lastKnownTableSchemaCache,
+
+		LastWrittenBinlogPosition: s.lastWrittenBinlogPosition,
+		LastSuccessfulPrimaryKeys: make(map[string]uint64),
+		CompletedTables:           make(map[string]bool),
+	}
+
+	for k, v := range s.lastSuccessfulPrimaryKeys {
+		state.LastSuccessfulPrimaryKeys[k] = v
+	}
+
+	for k, v := range s.completedTables {
+		state.CompletedTables[k] = v
+	}
+
+	return state
+}
+
+// This is reasonably accurate if the rows copied are distributed uniformly
+// between pk = 0 -> max(pk). It would not be accurate if the distribution is
+// concentrated in a particular region.
+func (s *StateTracker) EstimatedPKCopiedPerSecond() float64 {
+	s.tableMutex.RLock()
+	defer s.tableMutex.RUnlock()
+
+	if s.copySpeedLog.Value.(PKPositionLog).Position == 0 {
+		return 0.0
+	}
+
+	earliest := s.copySpeedLog
+	for earliest.Prev() != nil && earliest.Prev() != s.copySpeedLog && earliest.Prev().Value.(PKPositionLog).Position != 0 {
+		earliest = earliest.Prev()
+	}
+
+	currentValue := s.copySpeedLog.Value.(PKPositionLog)
+	earliestValue := earliest.Value.(PKPositionLog)
+	deltaPK := currentValue.Position - earliestValue.Position
+	deltaT := currentValue.At.Sub(earliestValue.At).Seconds()
+
+	return float64(deltaPK) / deltaT
+}
+
+// speedLogCount should be a number that is an order of magnitude or so larger
+// than the number of table iterators. This is to ensure the ring buffer used
+// to calculate the speed is not filled with only data from the last iteration
+// of the cursor and thus would be wildly inaccurate.
+//
+// serializedState is a state the tracker should start from, as opposed to
+// starting from the beginning.
+func NewStateTracker(speedLogCount int, serializedState *SerializableState) *StateTracker {
+	if serializedState == nil {
+		// A zero MySQL position will be set in the state tracker. The consumer
+		// of this struct should realize this means to load the current master
+		// position.
+		serializedState = &SerializableState{
+			LastSuccessfulPrimaryKeys: make(map[string]uint64),
+			CompletedTables:           make(map[string]bool),
+		}
+	}
+
+	speedLog := ring.New(speedLogCount)
+	speedLog.Value = PKPositionLog{
+		Position: 0,
+		At:       time.Now(),
+	}
+
+	return &StateTracker{
+		lastSuccessfulPrimaryKeys: serializedState.LastSuccessfulPrimaryKeys,
+		completedTables:           serializedState.CompletedTables,
+		lastWrittenBinlogPosition: serializedState.LastWrittenBinlogPosition,
+		binlogMutex:               &sync.RWMutex{},
+		tableMutex:                &sync.RWMutex{},
+		copySpeedLog:              speedLog,
+	}
+}

--- a/status.go
+++ b/status.go
@@ -79,9 +79,17 @@ func FetchStatus(f *Ferry, v Verifier) *Status {
 
 	// Getting all table statuses
 	status.TableStatuses = make([]*TableStatus, 0, len(f.Tables))
-	completedTables := f.DataIterator.CurrentState.CompletedTables()
-	targetPKs := f.DataIterator.CurrentState.TargetPrimaryKeys()
-	lastSuccessfulPKs := f.DataIterator.CurrentState.LastSuccessfulPrimaryKeys()
+
+	serializedState := f.StateTracker.Serialize(nil)
+
+	lastSuccessfulPKs := serializedState.LastSuccessfulPrimaryKeys
+	completedTables := serializedState.CompletedTables
+
+	targetPKs := make(map[string]uint64)
+	f.DataIterator.targetPKs.Range(func(k, v interface{}) bool {
+		targetPKs[k.(string)] = v.(uint64)
+		return true
+	})
 
 	status.CompletedTableCount = len(completedTables)
 	status.TotalTableCount = len(f.Tables)
@@ -170,7 +178,7 @@ func FetchStatus(f *Ferry, v Verifier) *Status {
 	// ASAP. It's not supposed to be that accurate anyway.
 	var totalPKsToCopy uint64 = 0
 	var completedPKs uint64 = 0
-	estimatedPKsPerSecond := f.DataIterator.CurrentState.EstimatedPKProcessedPerSecond()
+	estimatedPKsPerSecond := f.StateTracker.EstimatedPKCopiedPerSecond()
 	for _, targetPK := range targetPKs {
 		totalPKsToCopy += targetPK
 	}

--- a/test/data_iterator_test.go
+++ b/test/data_iterator_test.go
@@ -51,7 +51,7 @@ func (this *DataIteratorTestSuite) SetupTest() {
 			BatchSize:   config.DataIterationBatchSize,
 			ReadRetries: config.DBReadRetries,
 		},
-		StateTracker: ghostferry.NewStateTracker(config.DataIterationConcurrency*10, nil),
+		StateTracker: ghostferry.NewStateTracker(config.DataIterationConcurrency * 10),
 
 		Tables: tables.AsSlice(),
 	}

--- a/test/data_iterator_test.go
+++ b/test/data_iterator_test.go
@@ -51,6 +51,7 @@ func (this *DataIteratorTestSuite) SetupTest() {
 			BatchSize:   config.DataIterationBatchSize,
 			ReadRetries: config.DBReadRetries,
 		},
+		StateTracker: ghostferry.NewStateTracker(config.DataIterationConcurrency*10, nil),
 
 		Tables: tables.AsSlice(),
 	}
@@ -73,7 +74,7 @@ func (this *DataIteratorTestSuite) TestNoEventsForEmptyTable() {
 
 	this.Require().Equal(0, len(this.receivedRows))
 	this.Require().Equal(
-		this.di.CurrentState.CompletedTables(),
+		this.completedTables(),
 		map[string]bool{
 			fmt.Sprintf("%s.%s", testhelpers.TestSchemaName, testhelpers.TestTable1Name):           true,
 			fmt.Sprintf("%s.%s", testhelpers.TestSchemaName, testhelpers.TestCompressedTable1Name): true,
@@ -115,7 +116,7 @@ func (this *DataIteratorTestSuite) TestExistingRowsAreIterated() {
 		data[testhelpers.TestCompressedTable1Name] = append(data[testhelpers.TestCompressedTable1Name], datum)
 	}
 
-	this.Require().Equal(0, len(this.di.CurrentState.CompletedTables()))
+	this.Require().Equal(0, len(this.completedTables()))
 
 	this.Require().Equal(5, len(ids[testhelpers.TestTable1Name]))
 	this.Require().Equal(5, len(ids[testhelpers.TestCompressedTable1Name]))
@@ -138,7 +139,7 @@ func (this *DataIteratorTestSuite) TestExistingRowsAreIterated() {
 	}
 
 	this.Require().Equal(
-		this.di.CurrentState.CompletedTables(),
+		this.completedTables(),
 		map[string]bool{
 			fmt.Sprintf("%s.%s", testhelpers.TestSchemaName, testhelpers.TestTable1Name):           true,
 			fmt.Sprintf("%s.%s", testhelpers.TestSchemaName, testhelpers.TestCompressedTable1Name): true,
@@ -159,8 +160,8 @@ func (this *DataIteratorTestSuite) TestDoneListenerGetsNotifiedWhenDone() {
 	this.Require().True(wasNotified)
 }
 
-func (this *DataIteratorTestSuite) TestInitialize() {
-	this.Require().NotNil(this.di.CurrentState)
+func (this *DataIteratorTestSuite) completedTables() map[string]bool {
+	return this.di.StateTracker.Serialize(nil).CompletedTables
 }
 
 func TestDataIterator(t *testing.T) {


### PR DESCRIPTION
*The code review might look big, but most of it is me moving the DataIteratorState into its own file called StateTracker.*

Instead of having the DataIterator own the state of the Ferry run, Ferry should own the state as it involves both the DataIterator and the BinlogWriter. This means effectively, the DataIterator and the BinlogWriter "notifies" the StateTracker about their progress. 

This PR moves DataIteratorState to a StateTracker managed by the Ferry. However, this centralization does make using the DataIterator/BinlogStreamer independently of the Ferry slightly more difficult. I think this trade off is okay as it makes the state tracking easy to reason about (it's all in one component!). If we need to, we can refactor a little bit to provide some helper methods to use those underlying components.
 
The current StateTracker does not track the verifier progress. This will be done in the future in a similar way. We also can't resume with the dump state. That code will come after the initial effort for interrupt/resume during the normal Ghostferry run.