### PR TITLE
iterative verifier: allow ignored columns

### DIFF
--- a/sharding/config.go
+++ b/sharding/config.go
@@ -21,10 +21,11 @@ type Config struct {
 	CutoverUnlock HTTPCallback
 	ErrorCallback HTTPCallback
 
-	JoinedTables              map[string][]JoinTable
-	IgnoredTables             []string
-	IgnoredVerificationTables []string
-	PrimaryKeyTables          []string
+	JoinedTables               map[string][]JoinTable
+	IgnoredTables              []string
+	IgnoredVerificationTables  []string
+	IgnoredVerificationColumns map[string][]string
+	PrimaryKeyTables           []string
 
 	VerifierIterationConcurrency int
 	MaxExpectedVerifierDowntime  string

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -118,6 +118,14 @@ func (r *ShardingFerry) newIterativeVerifier() (*ghostferry.IterativeVerifier, e
 		}
 	}
 
+	ignoredColumns := make(map[string]map[string]struct{})
+	for table, columns := range r.config.IgnoredVerificationColumns {
+		ignoredColumns[table] = make(map[string]struct{})
+		for _, column := range columns {
+			ignoredColumns[table][column] = struct{}{}
+		}
+	}
+
 	return &ghostferry.IterativeVerifier{
 		CursorConfig: &ghostferry.CursorConfig{
 			DB:          r.Ferry.SourceDB,
@@ -139,6 +147,7 @@ func (r *ShardingFerry) newIterativeVerifier() (*ghostferry.IterativeVerifier, e
 		TableRewrites:    r.config.TableRewrites,
 
 		IgnoredTables:       r.config.IgnoredVerificationTables,
+		IgnoredColumns:      ignoredColumns,
 		Concurrency:         verifierConcurrency,
 		MaxExpectedDowntime: maxExpectedDowntime,
 	}, nil

--- a/test/iterative_verifier_test.go
+++ b/test/iterative_verifier_test.go
@@ -70,6 +70,20 @@ func (t *IterativeVerifierTestSuite) TestNothingToVerify() {
 	t.Require().Equal("", result.Message)
 }
 
+func (t *IterativeVerifierTestSuite) TestVerifyOnceWithIgnoredColumns() {
+	ignoredColumns := map[string]map[string]struct{}{"test_table_1": {"data": struct{}{}}}
+	t.verifier.IgnoredColumns = ignoredColumns
+
+	t.InsertRowInDb(42, "foo", t.Ferry.SourceDB)
+	t.InsertRowInDb(42, "bar", t.Ferry.TargetDB)
+
+	result, err := t.verifier.VerifyOnce()
+	t.Require().NotNil(result)
+	t.Require().Nil(err)
+	t.Require().True(result.DataCorrect)
+	t.Require().Equal("", result.Message)
+}
+
 func (t *IterativeVerifierTestSuite) TestVerifyOnceFails() {
 	t.InsertRowInDb(42, "foo", t.Ferry.SourceDB)
 	t.InsertRowInDb(42, "bar", t.Ferry.TargetDB)
@@ -80,6 +94,7 @@ func (t *IterativeVerifierTestSuite) TestVerifyOnceFails() {
 	t.Require().False(result.DataCorrect)
 	t.Require().Equal("verification failed on table: gftest.test_table_1 for pk: 42", result.Message)
 }
+
 func (t *IterativeVerifierTestSuite) TestVerifyCompressedOnceFails() {
 	t.InsertCompressedRowInDb(42, testhelpers.TestCompressedData1, t.Ferry.SourceDB)
 	t.InsertCompressedRowInDb(42, testhelpers.TestCompressedData2, t.Ferry.TargetDB)


### PR DESCRIPTION
**Problem**
Sometimes, it's desirable to intentionally allow ignoring certain columns like `created_at` during verification. This happens most often in tables that share data between tenants.

**But the sharding package only copies tables that have a tenant_id, how can they share data?**
We allow two other types of tables: joined tables and primary key tables. This is exactly where we need to use this feature

**Solution**
It's a fairly simple change to exclude verification of some columns without impacting their copying

@Shopify/pods 