### PR TITLE
context.WithContext everywhere to allow us to stop goroutines

### DIFF
--- a/batch_writer.go
+++ b/batch_writer.go
@@ -1,7 +1,6 @@
 package ghostferry
 
 import (
-	"context"
 	"database/sql"
 	"fmt"
 	"sync"
@@ -28,8 +27,8 @@ func (w *BatchWriter) Initialize() {
 	w.logger = logrus.WithField("tag", "batch_writer")
 }
 
-func (w *BatchWriter) WriteRowBatch(ctx context.Context, batch *RowBatch) error {
-	return WithRetriesContext(ctx, w.WriteRetries, 0, w.logger, "write batch to target", func() error {
+func (w *BatchWriter) WriteRowBatch(batch *RowBatch) error {
+	return WithRetries(w.WriteRetries, 0, w.logger, "write batch to target", func() error {
 		if batch.Size() == 0 {
 			return nil
 		}

--- a/batch_writer.go
+++ b/batch_writer.go
@@ -1,6 +1,7 @@
 package ghostferry
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"sync"
@@ -27,8 +28,8 @@ func (w *BatchWriter) Initialize() {
 	w.logger = logrus.WithField("tag", "batch_writer")
 }
 
-func (w *BatchWriter) WriteRowBatch(batch *RowBatch) error {
-	return WithRetries(w.WriteRetries, 0, w.logger, "write batch to target", func() error {
+func (w *BatchWriter) WriteRowBatch(ctx context.Context, batch *RowBatch) error {
+	return WithRetriesContext(ctx, w.WriteRetries, 0, w.logger, "write batch to target", func() error {
 		if batch.Size() == 0 {
 			return nil
 		}

--- a/binlog_streamer.go
+++ b/binlog_streamer.go
@@ -115,7 +115,8 @@ func (s *BinlogStreamer) Run() {
 		var timedOut bool
 
 		err := WithRetries(5, 0, s.logger, "get binlog event", func() (er error) {
-			ctx, _ := context.WithTimeout(context.Background(), 500*time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+			defer cancel()
 			ev, er = s.binlogStreamer.GetEvent(ctx)
 
 			if er == context.DeadlineExceeded {

--- a/binlog_streamer.go
+++ b/binlog_streamer.go
@@ -32,7 +32,7 @@ type BinlogStreamer struct {
 	stopRequested bool
 
 	logger         *logrus.Entry
-	eventListeners []func([]DMLEvent) error
+	eventListeners []func(context.Context, []DMLEvent) error
 }
 
 func (s *BinlogStreamer) Initialize() (err error) {
@@ -102,7 +102,7 @@ func (s *BinlogStreamer) ConnectBinlogStreamerToMysql() error {
 	return nil
 }
 
-func (s *BinlogStreamer) Run() {
+func (s *BinlogStreamer) Run(ctx context.Context) {
 	defer func() {
 		s.logger.Info("exiting binlog streamer")
 		s.binlogSyncer.Close()
@@ -114,10 +114,10 @@ func (s *BinlogStreamer) Run() {
 		var ev *replication.BinlogEvent
 		var timedOut bool
 
-		err := WithRetries(5, 0, s.logger, "get binlog event", func() (er error) {
-			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-			defer cancel()
-			ev, er = s.binlogStreamer.GetEvent(ctx)
+		err := WithRetriesContext(ctx, 5, 0, s.logger, "get binlog event", func() (er error) {
+			eventCtx, eventCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+			defer eventCancel()
+			ev, er = s.binlogStreamer.GetEvent(eventCtx)
 
 			if er == context.DeadlineExceeded {
 				timedOut = true
@@ -126,6 +126,11 @@ func (s *BinlogStreamer) Run() {
 
 			return er
 		})
+
+		if err == context.Canceled {
+			s.logger.Info("cancellation received, terminating goroutine abruptly")
+			return
+		}
 
 		if err != nil {
 			s.ErrorHandler.Fatal("binlog_streamer", err)
@@ -147,7 +152,7 @@ func (s *BinlogStreamer) Run() {
 				"file": s.lastStreamedBinlogPosition.Name,
 			}).Info("rotated binlog file")
 		case *replication.RowsEvent:
-			err = s.handleRowsEvent(ev)
+			err = s.handleRowsEvent(ctx, ev)
 			if err != nil {
 				s.logger.WithError(err).Error("failed to handle rows event")
 				s.ErrorHandler.Fatal("binlog_streamer", err)
@@ -171,7 +176,7 @@ func (s *BinlogStreamer) Run() {
 	}
 }
 
-func (s *BinlogStreamer) AddEventListener(listener func([]DMLEvent) error) {
+func (s *BinlogStreamer) AddEventListener(listener func(context.Context, []DMLEvent) error) {
 	s.eventListeners = append(s.eventListeners, listener)
 }
 
@@ -183,22 +188,29 @@ func (s *BinlogStreamer) IsAlmostCaughtUp() bool {
 	return time.Now().Sub(s.lastProcessedEventTime) < caughtUpThreshold
 }
 
-func (s *BinlogStreamer) FlushAndStop() {
-	s.logger.Info("requesting binlog streamer to stop")
+func (s *BinlogStreamer) FlushAndStop(ctx context.Context) {
+	if ctx.Err() == nil {
+		s.logger.Info("requesting binlog streamer to stop")
+	}
 	// Must first read the binlog position before requesting stop
 	// Otherwise there is a race condition where the stopRequested is
 	// set to True but the TargetPosition is nil, which would cause
 	// the BinlogStreamer to immediately exit, as it thinks that it has
 	// passed the initial target position.
-	err := WithRetries(100, 600*time.Millisecond, s.logger, "read current binlog position", func() error {
+	err := WithRetriesContext(ctx, 100, 600*time.Millisecond, s.logger, "read current binlog position", func() error {
 		var err error
 		s.targetBinlogPosition, err = ShowMasterStatusBinlogPosition(s.Db)
 		return err
 	})
 
+	if err == context.Canceled {
+		return
+	}
+
 	if err != nil {
 		s.ErrorHandler.Fatal("binlog_streamer", err)
 	}
+
 	s.logger.WithField("target_position", s.targetBinlogPosition).Info("current stop binlog position was recorded")
 
 	s.stopRequested = true
@@ -222,7 +234,7 @@ func (s *BinlogStreamer) updateLastStreamedPosAndTime(ev *replication.BinlogEven
 	}
 }
 
-func (s *BinlogStreamer) handleRowsEvent(ev *replication.BinlogEvent) error {
+func (s *BinlogStreamer) handleRowsEvent(ctx context.Context, ev *replication.BinlogEvent) error {
 	eventTime := time.Unix(int64(ev.Header.Timestamp), 0)
 	rowsEvent := ev.Event.(*replication.RowsEvent)
 
@@ -263,7 +275,7 @@ func (s *BinlogStreamer) handleRowsEvent(ev *replication.BinlogEvent) error {
 	}
 
 	for _, listener := range s.eventListeners {
-		err := listener(events)
+		err := listener(ctx, events)
 		if err != nil {
 			return err
 		}

--- a/binlog_writer.go
+++ b/binlog_writer.go
@@ -86,13 +86,9 @@ func (b *BinlogWriter) Stop() {
 	close(b.binlogEventBuffer)
 }
 
-func (b *BinlogWriter) BufferBinlogEvents(ctx context.Context, events []DMLEvent) error {
+func (b *BinlogWriter) BufferBinlogEvents(events []DMLEvent) error {
 	for _, event := range events {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case b.binlogEventBuffer <- event:
-		}
+		b.binlogEventBuffer <- event
 	}
 
 	return nil

--- a/control_server.go
+++ b/control_server.go
@@ -1,6 +1,7 @@
 package ghostferry
 
 import (
+	"context"
 	"html/template"
 	"net/http"
 	"path/filepath"
@@ -128,7 +129,7 @@ func (this *ControlServer) HandleVerify(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	err := this.Verifier.StartInBackground()
+	err := this.Verifier.StartInBackground(context.Background())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/copydb/copydb.go
+++ b/copydb/copydb.go
@@ -128,7 +128,7 @@ func (this *CopydbFerry) CreateDatabasesAndTables() error {
 }
 
 func (this *CopydbFerry) runIterativeVerifierAfterRowCopy(ctx context.Context) error {
-	err := this.verifier.(*ghostferry.IterativeVerifier).VerifyBeforeCutover()
+	err := this.verifier.(*ghostferry.IterativeVerifier).VerifyBeforeCutover(ctx)
 	return err
 }
 

--- a/copydb/copydb.go
+++ b/copydb/copydb.go
@@ -158,6 +158,8 @@ func (this *CopydbFerry) Run() {
 	// should be identical.
 	copyWG.Wait()
 
+	logrus.Info("ghostferry main operations has terminated but the control server remains online")
+	logrus.Info("press CTRL+C or send an interrupt to stop the control server and end this process")
 	// This is where you cutover from using the source database to
 	// using the target database.
 

--- a/iterative_verifier.go
+++ b/iterative_verifier.go
@@ -2,6 +2,7 @@ package ghostferry
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -401,7 +402,7 @@ func (v *IterativeVerifier) iterateTableFingerprints(table *schema.Table, mismat
 
 	// It only needs the PKs, not the entire row.
 	cursor.ColumnsToSelect = []string{fmt.Sprintf("`%s`", table.GetPKColumn(0).Name)}
-	return cursor.Each(func(batch *RowBatch) error {
+	return cursor.Each(context.TODO(), func(batch *RowBatch) error {
 		metrics.Count("RowEvent", int64(batch.Size()), []MetricTag{
 			MetricTag{"table", table.Name},
 			MetricTag{"source", "iterative_verifier_before_cutover"},
@@ -542,7 +543,7 @@ func (v *IterativeVerifier) reverifyPks(table *schema.Table, pks []uint64) (Veri
 	}, mismatchedPks, nil
 }
 
-func (v *IterativeVerifier) binlogEventListener(evs []DMLEvent) error {
+func (v *IterativeVerifier) binlogEventListener(ctx context.Context, evs []DMLEvent) error {
 	if v.verifyDuringCutoverStarted.Get() {
 		return fmt.Errorf("cutover has started but received binlog event!")
 	}

--- a/iterative_verifier.go
+++ b/iterative_verifier.go
@@ -545,7 +545,7 @@ func (v *IterativeVerifier) reverifyPks(ctx context.Context, table *schema.Table
 	}, mismatchedPks, nil
 }
 
-func (v *IterativeVerifier) binlogEventListener(ctx context.Context, evs []DMLEvent) error {
+func (v *IterativeVerifier) binlogEventListener(evs []DMLEvent) error {
 	if v.verifyDuringCutoverStarted.Get() {
 		return fmt.Errorf("cutover has started but received binlog event!")
 	}

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -176,7 +176,7 @@ func (r *ShardingFerry) Run() {
 	r.Ferry.WaitUntilRowCopyIsComplete(context.TODO())
 
 	metrics.Measure("VerifyBeforeCutover", nil, 1.0, func() {
-		err := r.verifier.VerifyBeforeCutover()
+		err := r.verifier.VerifyBeforeCutover(context.TODO())
 		if err != nil {
 			r.logger.WithField("error", err).Errorf("pre-cutover verification encountered an error, aborting run")
 			r.Ferry.ErrorHandler.Fatal("sharding", err)
@@ -221,7 +221,7 @@ func (r *ShardingFerry) Run() {
 
 	var verificationResult ghostferry.VerificationResult
 	metrics.Measure("VerifyCutover", nil, 1.0, func() {
-		verificationResult, err = r.verifier.VerifyDuringCutover()
+		verificationResult, err = r.verifier.VerifyDuringCutover(context.TODO())
 	})
 	if err != nil {
 		r.logger.WithField("error", err).Errorf("verification encountered an error, aborting run")
@@ -279,7 +279,7 @@ func (r *ShardingFerry) deltaCopyJoinedTables() error {
 		return err
 	}
 
-	verificationResult, err := verifier.VerifyOnce()
+	verificationResult, err := verifier.VerifyOnce(context.TODO())
 	if err != nil {
 		return err
 	}
@@ -340,7 +340,7 @@ func (r *ShardingFerry) copyPrimaryKeyTables() error {
 		return err
 	}
 
-	verificationResult, err := verifier.VerifyOnce()
+	verificationResult, err := verifier.VerifyOnce(context.TODO())
 	if err != nil {
 		return err
 	} else if !verificationResult.DataCorrect {

--- a/test/data_iterator_test.go
+++ b/test/data_iterator_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -58,7 +59,7 @@ func (this *DataIteratorTestSuite) SetupTest() {
 	this.receivedRows = make(map[string][]ghostferry.RowData, 0)
 
 	this.di.Initialize()
-	this.di.AddBatchListener(func(ev *ghostferry.RowBatch) error {
+	this.di.AddBatchListener(func(ctx context.Context, ev *ghostferry.RowBatch) error {
 		this.receivedRows[ev.TableSchema().Name] = append(this.receivedRows[ev.TableSchema().Name], ev.Values()...)
 		return nil
 	})
@@ -69,7 +70,7 @@ func (this *DataIteratorTestSuite) TestNoEventsForEmptyTable() {
 	_, err = this.Ferry.SourceDB.Query(fmt.Sprintf("DELETE FROM `%s`.`%s`", testhelpers.TestSchemaName, testhelpers.TestCompressedTable1Name))
 	this.Require().Nil(err)
 
-	this.di.Run()
+	this.di.Run(context.Background())
 
 	this.Require().Equal(0, len(this.receivedRows))
 	this.Require().Equal(
@@ -122,7 +123,7 @@ func (this *DataIteratorTestSuite) TestExistingRowsAreIterated() {
 	this.Require().Equal(0, len(this.receivedRows[testhelpers.TestTable1Name]))
 	this.Require().Equal(0, len(this.receivedRows[testhelpers.TestCompressedTable1Name]))
 
-	this.di.Run()
+	this.di.Run(context.Background())
 
 	this.Require().Equal(5, len(this.receivedRows[testhelpers.TestTable1Name]))
 	this.Require().Equal(5, len(this.receivedRows[testhelpers.TestCompressedTable1Name]))
@@ -149,12 +150,12 @@ func (this *DataIteratorTestSuite) TestExistingRowsAreIterated() {
 func (this *DataIteratorTestSuite) TestDoneListenerGetsNotifiedWhenDone() {
 	wasNotified := false
 
-	this.di.AddDoneListener(func() error {
+	this.di.AddDoneListener(func(ctx context.Context) error {
 		wasNotified = true
 		return nil
 	})
 
-	this.di.Run()
+	this.di.Run(context.Background())
 
 	this.Require().True(wasNotified)
 }

--- a/test/data_iterator_test.go
+++ b/test/data_iterator_test.go
@@ -59,7 +59,7 @@ func (this *DataIteratorTestSuite) SetupTest() {
 	this.receivedRows = make(map[string][]ghostferry.RowData, 0)
 
 	this.di.Initialize()
-	this.di.AddBatchListener(func(ctx context.Context, ev *ghostferry.RowBatch) error {
+	this.di.AddBatchListener(func(ev *ghostferry.RowBatch) error {
 		this.receivedRows[ev.TableSchema().Name] = append(this.receivedRows[ev.TableSchema().Name], ev.Values()...)
 		return nil
 	})

--- a/test/iterative_verifier_integration_test.go
+++ b/test/iterative_verifier_integration_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Shopify/ghostferry"
@@ -37,7 +38,7 @@ func TestVerificationFailsDeletedRow(t *testing.T) {
 			err := iterativeVerifier.Initialize()
 			testhelpers.PanicIfError(err)
 
-			err = iterativeVerifier.VerifyBeforeCutover()
+			err = iterativeVerifier.VerifyBeforeCutover(context.Background())
 			testhelpers.PanicIfError(err)
 		},
 		BeforeStoppingBinlogStreaming: func(ferry *testhelpers.TestFerry) {
@@ -45,7 +46,7 @@ func TestVerificationFailsDeletedRow(t *testing.T) {
 		},
 		AfterStoppedBinlogStreaming: func(ferry *testhelpers.TestFerry) {
 			deleteTestRowsToTriggerFailure(ferry)
-			result, err := iterativeVerifier.VerifyDuringCutover()
+			result, err := iterativeVerifier.VerifyDuringCutover(context.Background())
 			assert.Nil(t, err)
 			assert.False(t, result.DataCorrect)
 			assert.Regexp(t, "verification failed.*gftest.table1.*pks: (43)|(42)|(43,42)|(42,43)", result.Message)
@@ -80,7 +81,7 @@ func TestVerificationFailsUpdatedRow(t *testing.T) {
 			err := iterativeVerifier.Initialize()
 			testhelpers.PanicIfError(err)
 
-			err = iterativeVerifier.VerifyBeforeCutover()
+			err = iterativeVerifier.VerifyBeforeCutover(context.Background())
 			testhelpers.PanicIfError(err)
 		},
 		BeforeStoppingBinlogStreaming: func(ferry *testhelpers.TestFerry) {
@@ -88,7 +89,7 @@ func TestVerificationFailsUpdatedRow(t *testing.T) {
 		},
 		AfterStoppedBinlogStreaming: func(ferry *testhelpers.TestFerry) {
 			modifyDataColumnInSourceDB(ferry)
-			result, err := iterativeVerifier.VerifyDuringCutover()
+			result, err := iterativeVerifier.VerifyDuringCutover(context.Background())
 			assert.Nil(t, err)
 			assert.False(t, result.DataCorrect)
 			assert.Regexp(t, "verification failed.*gftest.table1.*pks: (42)|(43)|(43,42)|(42,43)", result.Message)
@@ -126,7 +127,7 @@ func TestIgnoresColumns(t *testing.T) {
 			err := iterativeVerifier.Initialize()
 			testhelpers.PanicIfError(err)
 
-			err = iterativeVerifier.VerifyBeforeCutover()
+			err = iterativeVerifier.VerifyBeforeCutover(context.Background())
 			testhelpers.PanicIfError(err)
 		},
 		BeforeStoppingBinlogStreaming: func(ferry *testhelpers.TestFerry) {
@@ -135,7 +136,7 @@ func TestIgnoresColumns(t *testing.T) {
 		AfterStoppedBinlogStreaming: func(ferry *testhelpers.TestFerry) {
 			modifyDataColumnInSourceDB(ferry)
 
-			result, err := iterativeVerifier.VerifyDuringCutover()
+			result, err := iterativeVerifier.VerifyDuringCutover(context.Background())
 			assert.Nil(t, err)
 			assert.True(t, result.DataCorrect)
 			assert.Equal(t, "", result.Message)
@@ -173,7 +174,7 @@ func TestIgnoresTables(t *testing.T) {
 			err := iterativeVerifier.Initialize()
 			testhelpers.PanicIfError(err)
 
-			err = iterativeVerifier.VerifyBeforeCutover()
+			err = iterativeVerifier.VerifyBeforeCutover(context.Background())
 			testhelpers.PanicIfError(err)
 		},
 		BeforeStoppingBinlogStreaming: func(ferry *testhelpers.TestFerry) {
@@ -181,7 +182,7 @@ func TestIgnoresTables(t *testing.T) {
 		},
 		AfterStoppedBinlogStreaming: func(ferry *testhelpers.TestFerry) {
 			modifyAllRows(ferry)
-			result, err := iterativeVerifier.VerifyDuringCutover()
+			result, err := iterativeVerifier.VerifyDuringCutover(context.Background())
 			assert.Nil(t, err)
 			assert.True(t, result.DataCorrect)
 			ran = true
@@ -215,11 +216,11 @@ func TestVerificationPasses(t *testing.T) {
 			err := iterativeVerifier.Initialize()
 			testhelpers.PanicIfError(err)
 
-			err = iterativeVerifier.VerifyBeforeCutover()
+			err = iterativeVerifier.VerifyBeforeCutover(context.Background())
 			testhelpers.PanicIfError(err)
 		},
 		AfterStoppedBinlogStreaming: func(ferry *testhelpers.TestFerry) {
-			result, err := iterativeVerifier.VerifyDuringCutover()
+			result, err := iterativeVerifier.VerifyDuringCutover(context.Background())
 			assert.Nil(t, err)
 			assert.True(t, result.DataCorrect)
 			ran = true

--- a/test/iterative_verifier_test.go
+++ b/test/iterative_verifier_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"sort"
@@ -61,10 +62,10 @@ func (t *IterativeVerifierTestSuite) TearDownTest() {
 }
 
 func (t *IterativeVerifierTestSuite) TestNothingToVerify() {
-	err := t.verifier.VerifyBeforeCutover()
+	err := t.verifier.VerifyBeforeCutover(context.Background())
 	t.Require().Nil(err)
 
-	result, err := t.verifier.VerifyDuringCutover()
+	result, err := t.verifier.VerifyDuringCutover(context.Background())
 	t.Require().Nil(err)
 	t.Require().True(result.DataCorrect)
 	t.Require().Equal("", result.Message)
@@ -77,7 +78,7 @@ func (t *IterativeVerifierTestSuite) TestVerifyOnceWithIgnoredColumns() {
 	t.InsertRowInDb(42, "foo", t.Ferry.SourceDB)
 	t.InsertRowInDb(42, "bar", t.Ferry.TargetDB)
 
-	result, err := t.verifier.VerifyOnce()
+	result, err := t.verifier.VerifyOnce(context.Background())
 	t.Require().NotNil(result)
 	t.Require().Nil(err)
 	t.Require().True(result.DataCorrect)
@@ -88,7 +89,7 @@ func (t *IterativeVerifierTestSuite) TestVerifyOnceFails() {
 	t.InsertRowInDb(42, "foo", t.Ferry.SourceDB)
 	t.InsertRowInDb(42, "bar", t.Ferry.TargetDB)
 
-	result, err := t.verifier.VerifyOnce()
+	result, err := t.verifier.VerifyOnce(context.Background())
 	t.Require().NotNil(result)
 	t.Require().Nil(err)
 	t.Require().False(result.DataCorrect)
@@ -99,7 +100,7 @@ func (t *IterativeVerifierTestSuite) TestVerifyCompressedOnceFails() {
 	t.InsertCompressedRowInDb(42, testhelpers.TestCompressedData1, t.Ferry.SourceDB)
 	t.InsertCompressedRowInDb(42, testhelpers.TestCompressedData2, t.Ferry.TargetDB)
 
-	result, err := t.verifier.VerifyOnce()
+	result, err := t.verifier.VerifyOnce(context.Background())
 	t.Require().NotNil(result)
 	t.Require().Nil(err)
 	t.Require().False(result.DataCorrect)
@@ -113,7 +114,7 @@ func (t *IterativeVerifierTestSuite) TestVerifyOncePass() {
 	t.InsertRowInDb(42, "foo", t.Ferry.SourceDB)
 	t.InsertRowInDb(42, "foo", t.Ferry.TargetDB)
 
-	result, err := t.verifier.VerifyOnce()
+	result, err := t.verifier.VerifyOnce(context.Background())
 	t.Require().NotNil(result)
 	t.Require().Nil(err)
 	t.Require().True(result.DataCorrect)
@@ -124,7 +125,7 @@ func (t *IterativeVerifierTestSuite) TestVerifyCompressedOncePass() {
 	t.InsertCompressedRowInDb(42, testhelpers.TestCompressedData1, t.Ferry.SourceDB)
 	t.InsertCompressedRowInDb(42, testhelpers.TestCompressedData1, t.Ferry.TargetDB)
 
-	result, err := t.verifier.VerifyOnce()
+	result, err := t.verifier.VerifyOnce(context.Background())
 	t.Require().NotNil(result)
 	t.Require().Nil(err)
 	t.Require().True(result.DataCorrect)
@@ -137,7 +138,7 @@ func (t *IterativeVerifierTestSuite) TestVerifyDifferentCompressedSameDecompress
 	t.InsertCompressedRowInDb(43, testhelpers.TestCompressedData3, t.Ferry.SourceDB)
 	t.InsertCompressedRowInDb(43, testhelpers.TestCompressedData4, t.Ferry.TargetDB)
 
-	result, err := t.verifier.VerifyOnce()
+	result, err := t.verifier.VerifyOnce(context.Background())
 	t.Require().NotNil(result)
 	t.Require().Nil(err)
 	t.Require().True(result.DataCorrect)
@@ -148,10 +149,10 @@ func (t *IterativeVerifierTestSuite) TestBeforeCutoverFailuresFailAgainDuringCut
 	t.InsertRowInDb(42, "foo", t.Ferry.SourceDB)
 	t.InsertRowInDb(42, "bar", t.Ferry.TargetDB)
 
-	err := t.verifier.VerifyBeforeCutover()
+	err := t.verifier.VerifyBeforeCutover(context.Background())
 	t.Require().Nil(err)
 
-	result, err := t.verifier.VerifyDuringCutover()
+	result, err := t.verifier.VerifyDuringCutover(context.Background())
 	t.Require().Nil(err)
 	t.Require().False(result.DataCorrect)
 	t.Require().Equal("verification failed on table: gftest.test_table_1 for pks: 42", result.Message)
@@ -161,10 +162,10 @@ func (t *IterativeVerifierTestSuite) TestBeforeCutoverCompressionFailuresFailAga
 	t.InsertCompressedRowInDb(42, testhelpers.TestCompressedData1, t.Ferry.SourceDB)
 	t.InsertCompressedRowInDb(42, testhelpers.TestCompressedData2, t.Ferry.TargetDB)
 
-	err := t.verifier.VerifyBeforeCutover()
+	err := t.verifier.VerifyBeforeCutover(context.Background())
 	t.Require().Nil(err)
 
-	result, err := t.verifier.VerifyDuringCutover()
+	result, err := t.verifier.VerifyDuringCutover(context.Background())
 	t.Require().Nil(err)
 	t.Require().False(result.DataCorrect)
 	t.Require().Equal(fmt.Sprintf("verification failed on table: %s.%s for pks: %s", "gftest", testhelpers.TestCompressedTable1Name, "42"), result.Message)
@@ -176,10 +177,10 @@ func (t *IterativeVerifierTestSuite) TestBeforeCutoverDifferentCompressedSameDec
 	t.InsertCompressedRowInDb(43, testhelpers.TestCompressedData3, t.Ferry.SourceDB)
 	t.InsertCompressedRowInDb(43, testhelpers.TestCompressedData4, t.Ferry.TargetDB)
 
-	err := t.verifier.VerifyBeforeCutover()
+	err := t.verifier.VerifyBeforeCutover(context.Background())
 	t.Require().Nil(err)
 
-	result, err := t.verifier.VerifyDuringCutover()
+	result, err := t.verifier.VerifyDuringCutover(context.Background())
 	t.Require().Nil(err)
 	t.Require().True(result.DataCorrect)
 	t.Require().Equal("", result.Message)
@@ -190,7 +191,7 @@ func (t *IterativeVerifierTestSuite) TestErrorsIfMaxDowntimeIsSurpassed() {
 	t.InsertRowInDb(42, "bar", t.Ferry.TargetDB)
 
 	t.verifier.MaxExpectedDowntime = 1 * time.Nanosecond
-	err := t.verifier.VerifyBeforeCutover()
+	err := t.verifier.VerifyBeforeCutover(context.Background())
 	t.Require().Regexp("cutover stage verification will not complete within max downtime duration \\(took .*\\)", err.Error())
 }
 
@@ -198,12 +199,12 @@ func (t *IterativeVerifierTestSuite) TestBeforeCutoverFailuresPassDuringCutover(
 	t.InsertRowInDb(42, "foo", t.Ferry.SourceDB)
 	t.InsertRowInDb(42, "bar", t.Ferry.TargetDB)
 
-	err := t.verifier.VerifyBeforeCutover()
+	err := t.verifier.VerifyBeforeCutover(context.Background())
 	t.Require().Nil(err)
 
 	t.UpdateRowInDb(42, "foo", t.Ferry.TargetDB)
 
-	result, err := t.verifier.VerifyDuringCutover()
+	result, err := t.verifier.VerifyDuringCutover(context.Background())
 	t.Require().Nil(err)
 	t.Require().True(result.DataCorrect)
 	t.Require().Equal("", result.Message)

--- a/test/race_conditions_integration_test.go
+++ b/test/race_conditions_integration_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -23,7 +22,7 @@ func TestSelectUpdateBinlogCopy(t *testing.T) {
 		Ferry:       testhelpers.NewTestFerry(),
 	}
 
-	testcase.Ferry.BeforeBatchCopyListener = func(ctx context.Context, batch *ghostferry.RowBatch) error {
+	testcase.Ferry.BeforeBatchCopyListener = func(batch *ghostferry.RowBatch) error {
 		queries := make([]string, len(batch.Values()))
 		for i, row := range batch.Values() {
 			id := row[0].(int64)
@@ -138,7 +137,7 @@ func TestOnlyDeleteRowWithMaxPrimaryKey(t *testing.T) {
 	testcase.Ferry.DataIterationBatchSize = 1
 
 	lastRowDeleted := false
-	testcase.Ferry.BeforeBatchCopyListener = func(ctx context.Context, batch *ghostferry.RowBatch) error {
+	testcase.Ferry.BeforeBatchCopyListener = func(batch *ghostferry.RowBatch) error {
 		if lastRowDeleted {
 			return nil
 		}

--- a/test/race_conditions_integration_test.go
+++ b/test/race_conditions_integration_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -22,7 +23,7 @@ func TestSelectUpdateBinlogCopy(t *testing.T) {
 		Ferry:       testhelpers.NewTestFerry(),
 	}
 
-	testcase.Ferry.BeforeBatchCopyListener = func(batch *ghostferry.RowBatch) error {
+	testcase.Ferry.BeforeBatchCopyListener = func(ctx context.Context, batch *ghostferry.RowBatch) error {
 		queries := make([]string, len(batch.Values()))
 		for i, row := range batch.Values() {
 			id := row[0].(int64)
@@ -137,7 +138,7 @@ func TestOnlyDeleteRowWithMaxPrimaryKey(t *testing.T) {
 	testcase.Ferry.DataIterationBatchSize = 1
 
 	lastRowDeleted := false
-	testcase.Ferry.BeforeBatchCopyListener = func(batch *ghostferry.RowBatch) error {
+	testcase.Ferry.BeforeBatchCopyListener = func(ctx context.Context, batch *ghostferry.RowBatch) error {
 		if lastRowDeleted {
 			return nil
 		}

--- a/test/throttler_test.go
+++ b/test/throttler_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -36,7 +37,7 @@ func (t *ThrottlerTestSuite) TestEnableDisable() {
 
 	t.throttler.SetDisabled(true)
 	t.Require().True(t.throttler.Disabled())
-	ghostferry.WaitForThrottle(t.throttler)
+	ghostferry.WaitForThrottle(context.Background(), t.throttler)
 
 	t.throttler.SetDisabled(false)
 	t.Require().False(t.throttler.Disabled())
@@ -44,7 +45,7 @@ func (t *ThrottlerTestSuite) TestEnableDisable() {
 	done := make(chan bool)
 	resumed := false
 	go func() {
-		ghostferry.WaitForThrottle(t.throttler)
+		ghostferry.WaitForThrottle(context.Background(), t.throttler)
 		resumed = true
 		done <- true
 	}()

--- a/test/verifier_test.go
+++ b/test/verifier_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -36,7 +37,7 @@ func (this *ChecksumTableVerifierTestSuite) SetupTest() {
 }
 
 func (this *ChecksumTableVerifierTestSuite) TestVerifyNoMatchWithEmptyTarget() {
-	err := this.verifier.StartInBackground()
+	err := this.verifier.StartInBackground(context.Background())
 	this.Require().Nil(err)
 	this.verifier.Wait()
 
@@ -46,7 +47,7 @@ func (this *ChecksumTableVerifierTestSuite) TestVerifyNoMatchWithEmptyTarget() {
 func (this *ChecksumTableVerifierTestSuite) TestVerifyNoMatchWithDifferentTargetData() {
 	testhelpers.SeedInitialData(this.Ferry.TargetDB, testhelpers.TestSchemaName, testhelpers.TestTable1Name, 1)
 
-	err := this.verifier.StartInBackground()
+	err := this.verifier.StartInBackground(context.Background())
 	this.Require().Nil(err)
 	this.verifier.Wait()
 	this.AssertVerifierNotMatched()
@@ -55,7 +56,7 @@ func (this *ChecksumTableVerifierTestSuite) TestVerifyNoMatchWithDifferentTarget
 func (this *ChecksumTableVerifierTestSuite) TestVerifyMatchAndRestartable() {
 	this.copyDataFromSourceToTarget()
 
-	err := this.verifier.StartInBackground()
+	err := this.verifier.StartInBackground(context.Background())
 	this.Require().Nil(err)
 	this.verifier.Wait()
 	this.AssertVerifierMatched()
@@ -63,7 +64,7 @@ func (this *ChecksumTableVerifierTestSuite) TestVerifyMatchAndRestartable() {
 	_, err = this.Ferry.TargetDB.Exec(fmt.Sprintf("DROP DATABASE %s", testhelpers.TestSchemaName))
 	this.Require().Nil(err)
 
-	err = this.verifier.StartInBackground()
+	err = this.verifier.StartInBackground(context.Background())
 	this.Require().Nil(err)
 	this.verifier.Wait()
 	this.AssertVerifierErrored("cannot find table gftest.test_table_1 during verification")
@@ -78,7 +79,7 @@ func (this *ChecksumTableVerifierTestSuite) TestVerifyMatchAndRestartable() {
 	_, err = this.Ferry.TargetDB.Exec(query, nil, "New Data")
 	this.Require().Nil(err)
 
-	err = this.verifier.StartInBackground()
+	err = this.verifier.StartInBackground(context.Background())
 	this.Require().Nil(err)
 	this.verifier.Wait()
 	this.AssertVerifierNotMatched()
@@ -91,7 +92,7 @@ func (this *ChecksumTableVerifierTestSuite) TestVerifyWithRewrites() {
 		testhelpers.TestTable1Name: "table2",
 	}
 
-	err := this.verifier.StartInBackground()
+	err := this.verifier.StartInBackground(context.Background())
 	this.Require().Nil(err)
 	this.verifier.Wait()
 	this.AssertVerifierMatched()

--- a/test/wait_until_replica_is_caught_up_to_master_test.go
+++ b/test/wait_until_replica_is_caught_up_to_master_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
@@ -64,13 +65,13 @@ func (s *WaitUntilReplicaIsCaughtUpToMasterSuite) TestIsCaughtUpIsCorrect() {
 	s.Require().Nil(err)
 	s.Require().Equal(1, currentPosition.Compare(s.outdatedMasterPosition), "test setup error, master position did not advance")
 
-	isCaughtUp, err := s.w.IsCaughtUp(currentPosition, 1)
+	isCaughtUp, err := s.w.IsCaughtUp(context.Background(), currentPosition, 1)
 	s.Require().Nil(err)
 	s.Require().False(isCaughtUp)
 
 	s.updateHeartbeatMasterPos(s.w.ReplicaDB, currentPosition)
 
-	isCaughtUp, err = s.w.IsCaughtUp(currentPosition, 1)
+	isCaughtUp, err = s.w.IsCaughtUp(context.Background(), currentPosition, 1)
 	s.Require().Nil(err)
 	s.Require().True(isCaughtUp)
 }

--- a/testhelpers/integration_test_case.go
+++ b/testhelpers/integration_test_case.go
@@ -156,7 +156,7 @@ func (this *IntegrationTestCase) Teardown() {
 }
 
 func (this *IntegrationTestCase) verifyTableChecksum() (ghostferry.VerificationResult, error) {
-	return this.Verifier.Verify()
+	return this.Verifier.Verify(context.Background())
 }
 
 func (this *IntegrationTestCase) callCustomAction(f func(*TestFerry)) {

--- a/testhelpers/integration_test_case.go
+++ b/testhelpers/integration_test_case.go
@@ -93,8 +93,13 @@ func (this *IntegrationTestCase) SetReadonlyOnSourceDbAndStopDataWriter() {
 func (this *IntegrationTestCase) StopStreamingAndWaitForGhostferryFinish() {
 	this.callCustomAction(this.BeforeStoppingBinlogStreaming)
 
-	this.Ferry.FlushBinlogAndStopStreaming(context.TODO())
-	this.wg.Wait()
+	err := this.Ferry.FlushBinlogAndStopStreaming(context.TODO())
+	if err == nil {
+		// TODO: this is probably some buggy test behaviour that needs to be fixed.
+		// Also needs to fix error handling for all other Wait/Flush methods
+		// in the tests
+		this.wg.Wait()
+	}
 
 	this.callCustomAction(this.AfterStoppedBinlogStreaming)
 }

--- a/testhelpers/integration_test_case.go
+++ b/testhelpers/integration_test_case.go
@@ -1,6 +1,7 @@
 package testhelpers
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -75,7 +76,7 @@ func (this *IntegrationTestCase) StartFerryAndDataWriter() {
 }
 
 func (this *IntegrationTestCase) WaitUntilRowCopyIsComplete() {
-	this.Ferry.WaitUntilRowCopyIsComplete()
+	this.Ferry.WaitUntilRowCopyIsComplete(context.TODO())
 	this.callCustomAction(this.AfterRowCopyIsComplete)
 }
 
@@ -92,7 +93,7 @@ func (this *IntegrationTestCase) SetReadonlyOnSourceDbAndStopDataWriter() {
 func (this *IntegrationTestCase) StopStreamingAndWaitForGhostferryFinish() {
 	this.callCustomAction(this.BeforeStoppingBinlogStreaming)
 
-	this.Ferry.FlushBinlogAndStopStreaming()
+	this.Ferry.FlushBinlogAndStopStreaming(context.TODO())
 	this.wg.Wait()
 
 	this.callCustomAction(this.AfterStoppedBinlogStreaming)

--- a/testhelpers/test_ferry.go
+++ b/testhelpers/test_ferry.go
@@ -1,6 +1,7 @@
 package testhelpers
 
 import (
+	"context"
 	"os"
 	"strconv"
 
@@ -10,13 +11,13 @@ import (
 type TestFerry struct {
 	*ghostferry.Ferry
 
-	BeforeBatchCopyListener   func(batch *ghostferry.RowBatch) error
-	BeforeBinlogApplyListener func(events []ghostferry.DMLEvent) error
-	BeforeRowCopyDoneListener func() error
+	BeforeBatchCopyListener   func(ctx context.Context, batch *ghostferry.RowBatch) error
+	BeforeBinlogApplyListener func(ctx context.Context, events []ghostferry.DMLEvent) error
+	BeforeRowCopyDoneListener func(ctx context.Context) error
 
-	AfterBatchCopyListener   func(batch *ghostferry.RowBatch) error
-	AfterBinlogApplyListener func(events []ghostferry.DMLEvent) error
-	AfterRowCopyDoneListener func() error
+	AfterBatchCopyListener   func(ctx context.Context, batch *ghostferry.RowBatch) error
+	AfterBinlogApplyListener func(ctx context.Context, events []ghostferry.DMLEvent) error
+	AfterRowCopyDoneListener func(ctx context.Context) error
 }
 
 var (
@@ -111,7 +112,7 @@ func (this *TestFerry) Start() error {
 }
 
 func (this *TestFerry) Run() {
-	this.Ferry.Run()
+	this.Ferry.Run(context.TODO())
 }
 
 func getPortFromEnv(env string, defaultVal uint64) uint64 {

--- a/testhelpers/test_ferry.go
+++ b/testhelpers/test_ferry.go
@@ -11,12 +11,12 @@ import (
 type TestFerry struct {
 	*ghostferry.Ferry
 
-	BeforeBatchCopyListener   func(ctx context.Context, batch *ghostferry.RowBatch) error
-	BeforeBinlogApplyListener func(ctx context.Context, events []ghostferry.DMLEvent) error
+	BeforeBatchCopyListener   func(batch *ghostferry.RowBatch) error
+	BeforeBinlogApplyListener func(events []ghostferry.DMLEvent) error
 	BeforeRowCopyDoneListener func(ctx context.Context) error
 
-	AfterBatchCopyListener   func(ctx context.Context, batch *ghostferry.RowBatch) error
-	AfterBinlogApplyListener func(ctx context.Context, events []ghostferry.DMLEvent) error
+	AfterBatchCopyListener   func(batch *ghostferry.RowBatch) error
+	AfterBinlogApplyListener func(events []ghostferry.DMLEvent) error
 	AfterRowCopyDoneListener func(ctx context.Context) error
 }
 


### PR DESCRIPTION
The point of this PR is to have the ability to stop goroutines during a run without having to use panic. This will allow us to test the interrupt/resume code. A couple of additional small things are fixed and they're done in different commits, each with their own detailed message. 

One notable commit is the second to last one, where we moved the onFinishedIterations code, which simply waits until `AutomaticCutover` is true so things like copydb could have a manual cutover phase, into Run directly. This is necessary to be able to cancel the main Ferry as well as makes the code cleaner to read (as all the logic goes into one place).