### PR TITLE
Minor code cleanup/refactor

### DIFF
--- a/binlog_streamer.go
+++ b/binlog_streamer.go
@@ -115,7 +115,8 @@ func (s *BinlogStreamer) Run() {
 		var timedOut bool
 
 		err := WithRetries(5, 0, s.logger, "get binlog event", func() (er error) {
-			ctx, _ := context.WithTimeout(context.Background(), 500*time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+			defer cancel()
 			ev, er = s.binlogStreamer.GetEvent(ctx)
 
 			if er == context.DeadlineExceeded {

--- a/copydb/copydb.go
+++ b/copydb/copydb.go
@@ -158,6 +158,8 @@ func (this *CopydbFerry) Run() {
 	// should be identical.
 	copyWG.Wait()
 
+	logrus.Info("ghostferry main operations has terminated but the control server remains online")
+	logrus.Info("press CTRL+C or send an interrupt to stop the control server and end this process")
 	// This is where you cutover from using the source database to
 	// using the target database.
 


### PR DESCRIPTION
As I'm working through the cancellation stuff, I noticed a few things that is wrong. I've been basing all my PRs on these four very small commits, so we might as well review these and merge them into master. This way we'll have an easier way to compare the different approaches of cancellation. 

Notable changes are:

- Removed the onFinishedIterations hack to block if automatic cutover is false. This block is useful if manual cutover is desired (for something like copydb). This also makes the code more "linear" and therefore easier to understand.
- Fixed an issue where a context.WithDeadline is not canceled. This is not really an issue, but it's not recommended practise for go.
- Changed WithRetriesContext to check the context before running the actual method, which could take a long time.
- Made copydb logging to be clearer when the run is complete.

More detailed information are available on each commit message.