### PR TITLE
Updated Ghostferry TLA model with BinlogWriter

### DIFF
--- a/tlaplus/ghostferry.toolbox/ghostferry___GhostferryPrimaryModel.launch
+++ b/tlaplus/ghostferry.toolbox/ghostferry___GhostferryPrimaryModel.launch
@@ -6,7 +6,7 @@
 <intAttribute key="dfidDepth" value="100"/>
 <booleanAttribute key="dfidMode" value="false"/>
 <intAttribute key="distributedFPSetCount" value="0"/>
-<stringAttribute key="distributedNetworkInterface" value="10.0.3.1"/>
+<stringAttribute key="distributedNetworkInterface" value="172.17.0.1"/>
 <intAttribute key="distributedNodesCount" value="1"/>
 <stringAttribute key="distributedTLC" value="off"/>
 <stringAttribute key="distributedTLCVMArgs" value=""/>
@@ -19,7 +19,7 @@
 <stringAttribute key="modelBehaviorNext" value=""/>
 <stringAttribute key="modelBehaviorSpec" value="Spec"/>
 <intAttribute key="modelBehaviorSpecType" value="1"/>
-<stringAttribute key="modelBehaviorVars" value="lastSuccessfulPK, CurrentMaxPrimaryKey, chosenPK, SourceBinlog, currentRow, BinlogStreamingStopRequested, pc, newRecord, oldRecord, TargetTable, TargetBinlogPos, currentBinlogEntry, ApplicationReadonly, SourceTable, lastSuccessfulBinlogPos"/>
+<stringAttribute key="modelBehaviorVars" value="lastSuccessfulPK, CurrentMaxPrimaryKey, BinlogWriteQueue, chosenPK, SourceBinlog, currentRow, BinlogStreamingStopRequested, pc, newRecord, oldRecord, TargetTable, TargetBinlogPos, currentBinlogEntry, lastWrittenBinlogPos, ApplicationReadonly, SourceTable, lastSuccessfulBinlogPos"/>
 <stringAttribute key="modelComments" value=""/>
 <booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
 <listAttribute key="modelCorrectnessInvariants">
@@ -40,6 +40,7 @@
 <listEntry value="BinlogStreamer;;BinlogStreamer;1;0"/>
 <listEntry value="TableIterator;;TableIterator;1;0"/>
 <listEntry value="MaxBinlogSize;;3;0;0"/>
+<listEntry value="BinlogWriter;;BinlogWriter;1;0"/>
 </listAttribute>
 <stringAttribute key="modelParameterContraint" value=""/>
 <listAttribute key="modelParameterDefinitions">


### PR DESCRIPTION
This is an important component of Ghostferry and thus deserves to be modeled. It also has implications when modeling Ghostferry with interrupt + resume.

In the previous TLA+ model, the binlogs are written directly to the target database as they are read by the BinlogStreamer. In the present model, they are send into a queue. This queue is read by a separate process (BinlogWriter) and written to the target database atomically one at a time. No batch writing (multistatement transaction that we have implemented) is modeled as I believe only the order is important, not how many binlog entries are written in a single atomic operation. 

Checking this new specification on the standard model yields no invariant violations. I also tested that the specification is correct by intentionally writing the incorrect data and ensuring that the model checking finds some invariant violations, which it does.

The large diff is due to artifacts from the PlusCal => TLA+ translation and comments. The actual PlusCal source changes are about **15++ 5--**