### PR TITLE
Interrupt Ghostferry via signals and resume from SerializedState

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -114,14 +114,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:22d4ade969b8af6af12062fbd4c68500553aef9366d245421da47dd7a8929a02"
+  digest = "1:6336d25b225c6ec8733bb33d77249c22d41e6ee3adafa89313de71ade2551b7f"
   name = "github.com/siddontang/go-log"
   packages = [
     "log",
     "loggers",
   ]
   pruneopts = "UT"
-  revision = "a4d157e46fa3e08b7e7ff329af341fa3ff86c02c"
+  revision = "8d05993dda0722163e59b0e79e8c6dda6c38d5c0"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -184,6 +184,7 @@
     "github.com/golang/snappy",
     "github.com/gorilla/mux",
     "github.com/shopspring/decimal",
+    "github.com/siddontang/go-log/log",
     "github.com/siddontang/go-mysql/mysql",
     "github.com/siddontang/go-mysql/replication",
     "github.com/siddontang/go-mysql/schema",

--- a/batch_writer.go
+++ b/batch_writer.go
@@ -2,7 +2,6 @@ package ghostferry
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 	"sync"
 
@@ -24,15 +23,9 @@ type BatchWriter struct {
 	logger     *logrus.Entry
 }
 
-func (w *BatchWriter) Initialize() error {
+func (w *BatchWriter) Initialize() {
 	w.statements = make(map[string]*sql.Stmt)
 	w.logger = logrus.WithField("tag", "batch_writer")
-
-	if w.StateTracker == nil {
-		return errors.New("StateTracker must be defined")
-	}
-
-	return nil
 }
 
 func (w *BatchWriter) WriteRowBatch(batch *RowBatch) error {
@@ -74,7 +67,9 @@ func (w *BatchWriter) WriteRowBatch(batch *RowBatch) error {
 
 		// Note that the state tracker expects us the track based on the original
 		// database and table names as opposed to the target ones.
-		w.StateTracker.UpdateLastSuccessfulPK(batch.TableSchema().String(), pkpos)
+		if w.StateTracker != nil {
+			w.StateTracker.UpdateLastSuccessfulPK(batch.TableSchema().String(), pkpos)
+		}
 
 		return nil
 	})

--- a/binlog_streamer.go
+++ b/binlog_streamer.go
@@ -15,8 +15,9 @@ import (
 const caughtUpThreshold = 10 * time.Second
 
 type BinlogStreamer struct {
-	Db           *sql.DB
-	Config       *Config
+	DB           *sql.DB
+	DBConfig     DatabaseConfig
+	MyServerId   uint32
 	ErrorHandler ErrorHandler
 	Filter       CopyFilter
 
@@ -35,25 +36,25 @@ type BinlogStreamer struct {
 	eventListeners []func([]DMLEvent) error
 }
 
-func (s *BinlogStreamer) Initialize() error {
-	s.logger = logrus.WithField("tag", "binlog_streamer")
-	s.stopRequested = false
-	return nil
+func (s *BinlogStreamer) ensureLogger() {
+	if s.logger == nil {
+		s.logger = logrus.WithField("tag", "binlog_streamer")
+	}
 }
 
 func (s *BinlogStreamer) createBinlogSyncer() error {
 	var err error
 	var tlsConfig *tls.Config
 
-	if s.Config.Source.TLS != nil {
-		tlsConfig, err = s.Config.Source.TLS.BuildConfig()
+	if s.DBConfig.TLS != nil {
+		tlsConfig, err = s.DBConfig.TLS.BuildConfig()
 		if err != nil {
 			return err
 		}
 	}
 
-	if s.Config.MyServerId == 0 {
-		s.Config.MyServerId, err = s.generateNewServerId()
+	if s.MyServerId == 0 {
+		s.MyServerId, err = s.generateNewServerId()
 		if err != nil {
 			s.logger.WithError(err).Error("could not generate unique server_id")
 			return err
@@ -61,11 +62,11 @@ func (s *BinlogStreamer) createBinlogSyncer() error {
 	}
 
 	syncerConfig := replication.BinlogSyncerConfig{
-		ServerID:                s.Config.MyServerId,
-		Host:                    s.Config.Source.Host,
-		Port:                    s.Config.Source.Port,
-		User:                    s.Config.Source.User,
-		Password:                s.Config.Source.Pass,
+		ServerID:                s.MyServerId,
+		Host:                    s.DBConfig.Host,
+		Port:                    s.DBConfig.Port,
+		User:                    s.DBConfig.User,
+		Password:                s.DBConfig.Pass,
 		TLSConfig:               tlsConfig,
 		UseDecimal:              true,
 		TimestampStringLocation: time.UTC,
@@ -76,7 +77,9 @@ func (s *BinlogStreamer) createBinlogSyncer() error {
 }
 
 func (s *BinlogStreamer) ConnectBinlogStreamerToMysql() error {
-	currentPosition, err := ShowMasterStatusBinlogPosition(s.Db)
+	s.ensureLogger()
+
+	currentPosition, err := ShowMasterStatusBinlogPosition(s.DB)
 	if err != nil {
 		s.logger.WithError(err).Error("failed to read current binlog position")
 		return err
@@ -86,6 +89,8 @@ func (s *BinlogStreamer) ConnectBinlogStreamerToMysql() error {
 }
 
 func (s *BinlogStreamer) ConnectBinlogStreamerToMysqlFrom(startFromBinlogPosition mysql.Position) error {
+	s.ensureLogger()
+
 	err := s.createBinlogSyncer()
 	if err != nil {
 		return err
@@ -108,6 +113,8 @@ func (s *BinlogStreamer) ConnectBinlogStreamerToMysqlFrom(startFromBinlogPositio
 }
 
 func (s *BinlogStreamer) Run() {
+	s.ensureLogger()
+
 	defer func() {
 		s.logger.Info("exiting binlog streamer")
 		s.binlogSyncer.Close()
@@ -197,7 +204,7 @@ func (s *BinlogStreamer) FlushAndStop() {
 	// passed the initial target position.
 	err := WithRetries(100, 600*time.Millisecond, s.logger, "read current binlog position", func() error {
 		var err error
-		s.targetBinlogPosition, err = ShowMasterStatusBinlogPosition(s.Db)
+		s.targetBinlogPosition, err = ShowMasterStatusBinlogPosition(s.DB)
 		return err
 	})
 
@@ -295,7 +302,7 @@ func (s *BinlogStreamer) generateNewServerId() (uint32, error) {
 	for {
 		id = randomServerId()
 
-		exists, err := idExistsOnServer(id, s.Db)
+		exists, err := idExistsOnServer(id, s.DB)
 		if err != nil {
 			return 0, err
 		}

--- a/config.go
+++ b/config.go
@@ -237,6 +237,11 @@ type Config struct {
 	// Optional: defaults to false
 	AutomaticCutover bool
 
+	// This specifies whether or not Ferry.Run will handle SIGINT and SIGTERM
+	// by dumping the current state to stdout.
+	// This state can be used to resume Ghostferry.
+	DumpStateToStdoutOnSignal bool
+
 	// Config for the ControlServer
 	ServerBindAddr string
 	WebBasedir     string

--- a/config.go
+++ b/config.go
@@ -250,14 +250,6 @@ type Config struct {
 	// If this is null, a new Ghostferry run will be started. Otherwise, the
 	// reconciliation process will start and Ghostferry will resume after that.
 	StateToResumeFrom *SerializableState
-
-	// If GhostferryVersion within StateToResumeFrom mismatch with the actual
-	// Ghostferry version, the config validation will by default fail with an
-	// error. This boolean allows one to override that behaviour.
-	//
-	// Caution: there is no guarentee that setting this variable to true will
-	// be safe.
-	AllowResumeWithMismatchedGhostferryVersion bool
 }
 
 func (c *Config) ValidateConfig() error {
@@ -273,10 +265,8 @@ func (c *Config) ValidateConfig() error {
 		return fmt.Errorf("Table filter function must be provided")
 	}
 
-	if !c.AllowResumeWithMismatchedGhostferryVersion {
-		if c.StateToResumeFrom != nil && c.StateToResumeFrom.GhostferryVersion != VersionString {
-			return fmt.Errorf("StateToResumeFrom version mismatch: resume = %s, current = %s", c.StateToResumeFrom.GhostferryVersion, VersionString)
-		}
+	if c.StateToResumeFrom != nil && c.StateToResumeFrom.GhostferryVersion != VersionString {
+		return fmt.Errorf("StateToResumeFrom version mismatch: resume = %s, current = %s", c.StateToResumeFrom.GhostferryVersion, VersionString)
 	}
 
 	if c.DBWriteRetries == 0 {

--- a/cursor.go
+++ b/cursor.go
@@ -40,22 +40,24 @@ type CursorConfig struct {
 }
 
 // returns a new Cursor with an embedded copy of itself
-func (c *CursorConfig) NewCursor(table *schema.Table, maxPk uint64) *Cursor {
+func (c *CursorConfig) NewCursor(table *schema.Table, startPk, maxPk uint64) *Cursor {
 	return &Cursor{
-		CursorConfig:  *c,
-		Table:         table,
-		MaxPrimaryKey: maxPk,
-		RowLock:       true,
+		CursorConfig:             *c,
+		Table:                    table,
+		MaxPrimaryKey:            maxPk,
+		RowLock:                  true,
+		lastSuccessfulPrimaryKey: startPk,
 	}
 }
 
 // returns a new Cursor with an embedded copy of itself
-func (c *CursorConfig) NewCursorWithoutRowLock(table *schema.Table, maxPk uint64) *Cursor {
+func (c *CursorConfig) NewCursorWithoutRowLock(table *schema.Table, startPk, maxPk uint64) *Cursor {
 	return &Cursor{
-		CursorConfig:  *c,
-		Table:         table,
-		MaxPrimaryKey: maxPk,
-		RowLock:       false,
+		CursorConfig:             *c,
+		Table:                    table,
+		MaxPrimaryKey:            maxPk,
+		RowLock:                  false,
+		lastSuccessfulPrimaryKey: startPk,
 	}
 }
 
@@ -72,7 +74,6 @@ type Cursor struct {
 }
 
 func (c *Cursor) Each(f func(*RowBatch) error) error {
-	c.lastSuccessfulPrimaryKey = 0
 	c.logger = logrus.WithFields(logrus.Fields{
 		"table": c.Table.String(),
 		"tag":   "cursor",

--- a/cursor.go
+++ b/cursor.go
@@ -52,13 +52,9 @@ func (c *CursorConfig) NewCursor(table *schema.Table, startPk, maxPk uint64) *Cu
 
 // returns a new Cursor with an embedded copy of itself
 func (c *CursorConfig) NewCursorWithoutRowLock(table *schema.Table, startPk, maxPk uint64) *Cursor {
-	return &Cursor{
-		CursorConfig:             *c,
-		Table:                    table,
-		MaxPrimaryKey:            maxPk,
-		RowLock:                  false,
-		lastSuccessfulPrimaryKey: startPk,
-	}
+	cursor := c.NewCursor(table, startPk, maxPk)
+	cursor.RowLock = false
+	return cursor
 }
 
 type Cursor struct {

--- a/data_iterator.go
+++ b/data_iterator.go
@@ -47,7 +47,14 @@ func (d *DataIterator) Run() {
 	}
 
 	for table, maxPk := range tablesWithData {
-		d.targetPKs.Store(table.String(), maxPk)
+		tableName := table.String()
+		if d.StateTracker.IsTableComplete(tableName) {
+			// In a previous run, the table may have been completed.
+			// We don't need to reiterate those tables as it has already been done.
+			delete(tablesWithData, table)
+		} else {
+			d.targetPKs.Store(table.String(), maxPk)
+		}
 	}
 
 	tablesQueue := make(chan *schema.Table)

--- a/data_iterator.go
+++ b/data_iterator.go
@@ -2,7 +2,6 @@ package ghostferry
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -26,18 +25,17 @@ type DataIterator struct {
 	logger         *logrus.Entry
 }
 
-func (d *DataIterator) Initialize() error {
+func (d *DataIterator) Run() {
 	d.logger = logrus.WithField("tag", "data_iterator")
 	d.targetPKs = &sync.Map{}
 
+	// If a state tracker is not provided, then the caller doesn't care about
+	// tracking state. However, some methods are still useful so we use initialize
+	// a minimal local instance.
 	if d.StateTracker == nil {
-		return errors.New("StateTracker must be defined")
+		d.StateTracker = NewStateTracker(0)
 	}
 
-	return nil
-}
-
-func (d *DataIterator) Run() {
 	d.logger.WithField("tablesCount", len(d.Tables)).Info("starting data iterator run")
 	tablesWithData, emptyTables, err := MaxPrimaryKeys(d.DB, d.Tables, d.logger)
 	if err != nil {

--- a/data_iterator.go
+++ b/data_iterator.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 
 	"github.com/siddontang/go-mysql/schema"
@@ -38,7 +39,6 @@ func (d *DataIterator) Initialize() error {
 
 func (d *DataIterator) Run() {
 	d.logger.WithField("tablesCount", len(d.Tables)).Info("starting data iterator run")
-
 	tablesWithData, emptyTables, err := MaxPrimaryKeys(d.DB, d.Tables, d.logger)
 	if err != nil {
 		d.ErrorHandler.Fatal("data_iterator", err)
@@ -76,7 +76,15 @@ func (d *DataIterator) Run() {
 					return
 				}
 
-				cursor := d.CursorConfig.NewCursor(table, targetPKInterface.(uint64))
+				startPk := d.StateTracker.LastSuccessfulPK(table.String())
+				if startPk == math.MaxUint64 {
+					err := fmt.Errorf("%v has been marked as completed but a table iterator has been spawned, this is likely a programmer error which resulted in the inconsistent starting state", table.String())
+					logger.WithError(err).Error("this is definitely a bug")
+					d.ErrorHandler.Fatal("data_iterator", err)
+					return
+				}
+
+				cursor := d.CursorConfig.NewCursor(table, startPk, targetPKInterface.(uint64))
 				err := cursor.Each(func(batch *RowBatch) error {
 					metrics.Count("RowEvent", int64(batch.Size()), []MetricTag{
 						MetricTag{"table", table.Name},

--- a/data_iterator.go
+++ b/data_iterator.go
@@ -30,7 +30,7 @@ func (d *DataIterator) Run() {
 	d.targetPKs = &sync.Map{}
 
 	// If a state tracker is not provided, then the caller doesn't care about
-	// tracking state. However, some methods are still useful so we use initialize
+	// tracking state. However, some methods are still useful so we initialize
 	// a minimal local instance.
 	if d.StateTracker == nil {
 		d.StateTracker = NewStateTracker(0)

--- a/ferry.go
+++ b/ferry.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-sql-driver/mysql"
+	siddontanglog "github.com/siddontang/go-log/log"
 	siddontangmysql "github.com/siddontang/go-mysql/mysql"
 	"github.com/siddontang/go-mysql/schema"
 	"github.com/sirupsen/logrus"
@@ -106,6 +107,12 @@ func (f *Ferry) Initialize() (err error) {
 	f.rowCopyCompleteCh = make(chan struct{})
 
 	f.logger.Infof("hello world from %s", VersionString)
+
+	// Suppress siddontang/go-mysql logging as we already log the equivalents.
+	// It also by defaults logs to stdout, which is different from Ghostferry
+	// logging, which all goes to stderr. stdout in Ghostferry is reserved for
+	// dumping states due to an abort.
+	siddontanglog.SetDefaultLogger(siddontanglog.NewDefault(&siddontanglog.NullHandler{}))
 
 	// Connect to the database
 	f.SourceDB, err = f.Source.SqlDB(f.logger.WithField("dbname", "source"))

--- a/ferry.go
+++ b/ferry.go
@@ -116,12 +116,6 @@ func (f *Ferry) NewBinlogStreamer() *BinlogStreamer {
 	}
 }
 
-// Even though this function is identical to NewBinlogStreamer, it is here
-// for consistency so it will lead to less confusion.
-func (f *Ferry) NewBinlogStreamerWithoutStateTracker() *BinlogStreamer {
-	return f.NewBinlogStreamer()
-}
-
 func (f *Ferry) NewBinlogWriter() *BinlogWriter {
 	return &BinlogWriter{
 		DB:               f.TargetDB,

--- a/ferry.go
+++ b/ferry.go
@@ -116,7 +116,7 @@ func (f *Ferry) NewBinlogStreamer() *BinlogStreamer {
 	}
 }
 
-// Even tho this function is identical to NewBinlogStreamer, it is here
+// Even though this function is identical to NewBinlogStreamer, it is here
 // for consistency so it will lead to less confusion.
 func (f *Ferry) NewBinlogStreamerWithoutStateTracker() *BinlogStreamer {
 	return f.NewBinlogStreamer()

--- a/iterative_verifier.go
+++ b/iterative_verifier.go
@@ -397,7 +397,7 @@ func (v *IterativeVerifier) iterateAllTables(mismatchedPkFunc func(uint64, *sche
 func (v *IterativeVerifier) iterateTableFingerprints(table *schema.Table, mismatchedPkFunc func(uint64, *schema.Table) error) error {
 	// The cursor will stop iterating when it cannot find anymore rows,
 	// so it will not iterate until MaxUint64.
-	cursor := v.CursorConfig.NewCursorWithoutRowLock(table, math.MaxUint64)
+	cursor := v.CursorConfig.NewCursorWithoutRowLock(table, 0, math.MaxUint64)
 
 	// It only needs the PKs, not the entire row.
 	cursor.ColumnsToSelect = []string{fmt.Sprintf("`%s`", table.GetPKColumn(0).Name)}

--- a/sharding/testhelpers/unit_test_suite.go
+++ b/sharding/testhelpers/unit_test_suite.go
@@ -71,6 +71,8 @@ func (t *ShardingUnitTestSuite) SetupTest() {
 	t.setupShardingFerry()
 	t.dropTestDbs()
 
+	testhelpers.SetupTest()
+
 	testhelpers.SeedInitialData(t.Ferry.Ferry.SourceDB, sourceDbName, testTable, 1000)
 	testhelpers.SeedInitialData(t.Ferry.Ferry.TargetDB, targetDbName, testTable, 0)
 

--- a/state_tracker.go
+++ b/state_tracker.go
@@ -2,6 +2,7 @@ package ghostferry
 
 import (
 	"container/ring"
+	"math"
 	"sync"
 	"time"
 
@@ -42,6 +43,23 @@ func (s *StateTracker) UpdateLastSuccessfulPK(table string, pk uint64) {
 	s.lastSuccessfulPrimaryKeys[table] = pk
 
 	s.updateSpeedLog(deltaPK)
+}
+
+func (s *StateTracker) LastSuccessfulPK(table string) uint64 {
+	s.tableMutex.RLock()
+	defer s.tableMutex.RUnlock()
+
+	_, found := s.completedTables[table]
+	if found {
+		return math.MaxUint64
+	}
+
+	pk, found := s.lastSuccessfulPrimaryKeys[table]
+	if !found {
+		return 0
+	}
+
+	return pk
 }
 
 func (s *StateTracker) MarkTableAsCompleted(table string) {

--- a/state_tracker.go
+++ b/state_tracker.go
@@ -69,6 +69,13 @@ func (s *StateTracker) MarkTableAsCompleted(table string) {
 	s.completedTables[table] = true
 }
 
+func (s *StateTracker) IsTableComplete(table string) bool {
+	s.tableMutex.Lock()
+	defer s.tableMutex.Unlock()
+
+	return s.completedTables[table]
+}
+
 func (s *StateTracker) UpdateLastWrittenBinlogPosition(pos mysql.Position) {
 	s.binlogMutex.Lock()
 	defer s.binlogMutex.Unlock()

--- a/test/binlog_streamer_test.go
+++ b/test/binlog_streamer_test.go
@@ -45,43 +45,42 @@ func (this *BinlogStreamerTestSuite) SetupTest() {
 	this.Require().Nil(err)
 
 	this.binlogStreamer = &ghostferry.BinlogStreamer{
-		Db:           this.sourceDb,
-		Config:       testFerry.Config,
+		DB:           this.sourceDb,
+		DBConfig:     testFerry.Config.Source,
+		MyServerId:   testFerry.Config.MyServerId,
 		ErrorHandler: testFerry.ErrorHandler,
 		Filter:       testFerry.CopyFilter,
 		TableSchema:  tableSchemaCache,
 	}
-
-	this.Require().Nil(this.binlogStreamer.Initialize())
 }
 
 func (this *BinlogStreamerTestSuite) TestConnectWithIdKeepsId() {
-	this.binlogStreamer.Config.MyServerId = 1421
+	this.binlogStreamer.MyServerId = 1421
 
 	err := this.binlogStreamer.ConnectBinlogStreamerToMysql()
 
 	this.Require().Nil(err)
-	this.Require().Equal(uint32(1421), this.binlogStreamer.Config.MyServerId)
+	this.Require().Equal(uint32(1421), this.binlogStreamer.MyServerId)
 }
 
 func (this *BinlogStreamerTestSuite) TestConnectWithZeroIdGetsRandomServerId() {
-	this.binlogStreamer.Config.MyServerId = 0
+	this.binlogStreamer.MyServerId = 0
 
 	err := this.binlogStreamer.ConnectBinlogStreamerToMysql()
 
 	this.Require().Nil(err)
-	this.Require().NotZero(this.binlogStreamer.Config.MyServerId)
+	this.Require().NotZero(this.binlogStreamer.MyServerId)
 }
 
 func (this *BinlogStreamerTestSuite) TestConnectErrorsOutIfErrorInServerIdGeneration() {
-	this.binlogStreamer.Config.MyServerId = 0
+	this.binlogStreamer.MyServerId = 0
 
-	this.binlogStreamer.Db.Close()
+	this.binlogStreamer.DB.Close()
 
 	err := this.binlogStreamer.ConnectBinlogStreamerToMysql()
 
 	this.Require().NotNil(err)
-	this.Require().Zero(this.binlogStreamer.Config.MyServerId)
+	this.Require().Zero(this.binlogStreamer.MyServerId)
 }
 
 func (this *BinlogStreamerTestSuite) TestBinlogStreamerSetsBinlogPositionOnDMLEvent() {

--- a/test/data_iterator_test.go
+++ b/test/data_iterator_test.go
@@ -58,7 +58,6 @@ func (this *DataIteratorTestSuite) SetupTest() {
 
 	this.receivedRows = make(map[string][]ghostferry.RowData, 0)
 
-	this.di.Initialize()
 	this.di.AddBatchListener(func(ev *ghostferry.RowBatch) error {
 		this.receivedRows[ev.TableSchema().Name] = append(this.receivedRows[ev.TableSchema().Name], ev.Values()...)
 		return nil

--- a/vendor/github.com/siddontang/go-log/log/handler.go
+++ b/vendor/github.com/siddontang/go-log/log/handler.go
@@ -49,6 +49,6 @@ func (h *NullHandler) Write(b []byte) (n int, err error) {
 }
 
 // Close implements Handler interface
-func (h *NullHandler) Close() {
-
+func (h *NullHandler) Close() error {
+	return nil
 }


### PR DESCRIPTION
This PR implements the ability to interrupt Ghostferry via SIGTERM/SIGINT. These signals causes the error handler to dump the current state to stdout and panic to terminate the process.

Resume is also implemented: give a SerializedState as the StateToResumeFrom on the Config object and DataIterator will resume via the LastSuccessfulPrimaryKeys, BinlogStreamer will resume via LastWrittenBinlogPosition, and Ferry uses the table schema cache from the SerializedState.

Testing of this will occur in a PR after this, along with the ruby integration test framework, which I'm still iterating on. The code here stands on its own, however.

**Note: this PR does not implement the reconciliation process. This will be in a subsequent PR.** Interestingly, the implementation is currently already "correct" if no schema change occured, as we resume streaming from LastWrittenBinlogPosition. This will of course be changed during the reconciliation process.

In addition, I also did some quick refactoring:

- Created some public methods to create  components like DataIterator, BinlogStream, etc (Ferry.NewDataIterator, Ferry.NewDataIteratorWithoutStateTracker, etc)
- Made StateTracker optional: this is needed as we will reuse some of these components in places where we don't want them to update the state tracker (think: reconciliation process).

I tried my best to make things incremental, so each commit should stand on their own. It might be best to review in that order.