### PR TITLE
skipping replication.GenericEvent

### DIFF
--- a/binlog_streamer.go
+++ b/binlog_streamer.go
@@ -165,6 +165,10 @@ func (s *BinlogStreamer) Run() {
 			// This event can tell us about table structure change which means
 			// the cached schemas of the tables would be invalidated.
 			// TODO: investigate using this to allow for migrations to occur.
+		case *replication.GenericEvent:
+			// go-mysql don't parse this event, it use GenericEvent instead,
+			// so there's no way to handle this for us.
+			continue
 		default:
 			s.updateLastStreamedPosAndTime(ev)
 		}

--- a/binlog_streamer.go
+++ b/binlog_streamer.go
@@ -166,7 +166,8 @@ func (s *BinlogStreamer) Run() {
 			// the cached schemas of the tables would be invalidated.
 			// TODO: investigate using this to allow for migrations to occur.
 		case *replication.GenericEvent:
-			// go-mysql don't parse this event, it use GenericEvent instead,
+			// go-mysql don't parse all events and unparsed events are denoted
+			// with empty GenericEvent structs.
 			// so there's no way to handle this for us.
 			continue
 		default:


### PR DESCRIPTION
The go-mysql doesn't parse those events, so we can't handle this event.
This should fix the binlog_streamer panic https://github.com/Shopify/ghostferry/issues/79.