### PR TITLE
There is no StateTracker if we fail in Initialize

### DIFF
--- a/ferry.go
+++ b/ferry.go
@@ -498,6 +498,10 @@ func (f *Ferry) FlushBinlogAndStopStreaming() {
 }
 
 func (f *Ferry) SerializeStateToJSON() (string, error) {
+	if f.StateTracker == nil {
+		err := errors.New("no valid StateTracker")
+		return "", err
+	}
 	serializedState := f.StateTracker.Serialize(f.Tables)
 	stateBytes, err := json.MarshalIndent(serializedState, "", "  ")
 	return string(stateBytes), err


### PR DESCRIPTION
If we fail and try to report an error during Initialize, we have to deal with StateTracker not being setup (it shows up later during Initialize).