### PR TITLE
Moved the ownership of IterativeVerifier from sharding/copydb to Ferry

### DIFF
--- a/compression_verifier.go
+++ b/compression_verifier.go
@@ -21,12 +21,10 @@ const (
 )
 
 type (
-	columnCompressionConfig map[string]string
-
 	// TableColumnCompressionConfig represents compression configuration for a
 	// column in a table as table -> column -> compression-type
 	// ex: books -> contents -> snappy
-	TableColumnCompressionConfig map[string]columnCompressionConfig
+	TableColumnCompressionConfig map[string]map[string]string
 )
 
 // UnsupportedCompressionError is used to identify errors resulting

--- a/copydb/config.go
+++ b/copydb/config.go
@@ -35,18 +35,6 @@ func (f FilterAndRewriteConfigs) Validate() error {
 	return nil
 }
 
-const (
-	VerifierTypeChecksumTable  = "ChecksumTable"
-	VerifierTypeIterative      = "Iterative"
-	VerifierTypeNoVerification = "NoVerification"
-)
-
-var validVerifierTypes map[string]struct{} = map[string]struct{}{
-	VerifierTypeChecksumTable:  struct{}{},
-	VerifierTypeIterative:      struct{}{},
-	VerifierTypeNoVerification: struct{}{},
-}
-
 type Config struct {
 	*ghostferry.Config
 
@@ -55,12 +43,6 @@ type Config struct {
 
 	// Filter configuration for tables to copy
 	Tables FilterAndRewriteConfigs
-
-	// The verifier to use during the run. Valid choices are:
-	// ChecksumTable
-	// Iterative
-	// NoVerification
-	VerifierType string
 
 	// If you're running Ghostferry from a read only replica, turn this option
 	// on and specify SourceReplicationMaster and ReplicatedMasterPositionQuery.
@@ -83,10 +65,6 @@ type Config struct {
 }
 
 func (c *Config) InitializeAndValidateConfig() error {
-	if _, valid := validVerifierTypes[c.VerifierType]; !valid {
-		return fmt.Errorf("'%s' is not a valid VerifierType", c.VerifierType)
-	}
-
 	if err := c.Databases.Validate(); err != nil {
 		return err
 	}

--- a/copydb/copydb.go
+++ b/copydb/copydb.go
@@ -14,7 +14,6 @@ type CopydbFerry struct {
 	Ferry         *ghostferry.Ferry
 	controlServer *ghostferry.ControlServer
 	config        *Config
-	verifier      ghostferry.Verifier
 }
 
 func NewFerry(config *Config) *CopydbFerry {
@@ -48,56 +47,13 @@ func (this *CopydbFerry) Initialize() error {
 		return err
 	}
 
+	this.controlServer.Verifier = this.Ferry.Verifier
+
 	return this.controlServer.Initialize()
 }
 
 func (this *CopydbFerry) Start() error {
-	if this.config.VerifierType == VerifierTypeIterative {
-		this.Ferry.DataIterator.AddDoneListener(this.runIterativeVerifierAfterRowCopy)
-	}
-
-	err := this.Ferry.Start()
-	if err != nil {
-		return err
-	}
-
-	if this.config.VerifierType == VerifierTypeIterative {
-		iterativeVerifier := &ghostferry.IterativeVerifier{
-			CursorConfig: &ghostferry.CursorConfig{
-				DB:          this.Ferry.SourceDB,
-				BatchSize:   this.config.DataIterationBatchSize,
-				ReadRetries: this.config.DBReadRetries,
-			},
-			BinlogStreamer:   this.Ferry.BinlogStreamer,
-			TableSchemaCache: this.Ferry.Tables,
-			Tables:           this.Ferry.Tables.AsSlice(),
-			SourceDB:         this.Ferry.SourceDB,
-			TargetDB:         this.Ferry.TargetDB,
-			Concurrency:      this.config.DataIterationConcurrency,
-			DatabaseRewrites: this.Ferry.Config.DatabaseRewrites,
-			TableRewrites:    this.Ferry.Config.TableRewrites,
-		}
-
-		err = iterativeVerifier.Initialize()
-		if err != nil {
-			return err
-		}
-
-		this.verifier = iterativeVerifier
-	} else if this.config.VerifierType == VerifierTypeChecksumTable {
-		this.verifier = &ghostferry.ChecksumTableVerifier{
-			Tables:           this.Ferry.Tables.AsSlice(),
-			SourceDB:         this.Ferry.SourceDB,
-			TargetDB:         this.Ferry.TargetDB,
-			DatabaseRewrites: this.Ferry.Config.DatabaseRewrites,
-			TableRewrites:    this.Ferry.Config.TableRewrites,
-		}
-	} else {
-		this.verifier = nil
-	}
-
-	this.controlServer.Verifier = this.verifier
-	return nil
+	return this.Ferry.Start()
 }
 
 func (this *CopydbFerry) CreateDatabasesAndTables() error {
@@ -121,11 +77,6 @@ func (this *CopydbFerry) CreateDatabasesAndTables() error {
 	}
 
 	return nil
-}
-
-func (this *CopydbFerry) runIterativeVerifierAfterRowCopy() error {
-	err := this.verifier.(*ghostferry.IterativeVerifier).VerifyBeforeCutover()
-	return err
 }
 
 func (this *CopydbFerry) Run() {

--- a/copydb/test/copydb_test.go
+++ b/copydb/test/copydb_test.go
@@ -39,8 +39,6 @@ func (t *CopydbTestSuite) SetupTest() {
 				testTableName: renamedTableName,
 			},
 		},
-
-		VerifierType: copydb.VerifierTypeChecksumTable,
 	}
 
 	// TODO: remove this hack

--- a/data_iterator.go
+++ b/data_iterator.go
@@ -12,7 +12,6 @@ import (
 
 type DataIterator struct {
 	DB          *sql.DB
-	Tables      []*schema.Table
 	Concurrency int
 
 	ErrorHandler ErrorHandler
@@ -25,7 +24,7 @@ type DataIterator struct {
 	logger         *logrus.Entry
 }
 
-func (d *DataIterator) Run() {
+func (d *DataIterator) Run(tables []*schema.Table) {
 	d.logger = logrus.WithField("tag", "data_iterator")
 	d.targetPKs = &sync.Map{}
 
@@ -36,8 +35,8 @@ func (d *DataIterator) Run() {
 		d.StateTracker = NewCopyStateTracker(0)
 	}
 
-	d.logger.WithField("tablesCount", len(d.Tables)).Info("starting data iterator run")
-	tablesWithData, emptyTables, err := MaxPrimaryKeys(d.DB, d.Tables, d.logger)
+	d.logger.WithField("tablesCount", len(tables)).Info("starting data iterator run")
+	tablesWithData, emptyTables, err := MaxPrimaryKeys(d.DB, tables, d.logger)
 	if err != nil {
 		d.ErrorHandler.Fatal("data_iterator", err)
 	}

--- a/ferry.go
+++ b/ferry.go
@@ -344,7 +344,6 @@ func (f *Ferry) Start() error {
 
 	// TODO(pushrax): handle changes to schema during copying and clean this up.
 	f.BinlogStreamer.TableSchema = f.Tables
-	f.DataIterator.Tables = f.Tables.AsSlice()
 
 	return nil
 }
@@ -411,7 +410,7 @@ func (f *Ferry) Run() {
 
 	go func() {
 		defer dataIteratorWg.Done()
-		f.DataIterator.Run()
+		f.DataIterator.Run(f.Tables.AsSlice())
 	}()
 
 	dataIteratorWg.Wait()
@@ -445,11 +444,10 @@ func (f *Ferry) RunStandaloneDataCopy(tables []*schema.Table) error {
 	// will get an error dump even though we should not get one, which could be
 	// misleading.
 
-	dataIterator.Tables = tables
 	dataIterator.AddBatchListener(f.BatchWriter.WriteRowBatch)
 	f.logger.WithField("tables", tables).Info("starting delta table copy in cutover")
 
-	dataIterator.Run()
+	dataIterator.Run(tables)
 
 	return nil
 }

--- a/ferry.go
+++ b/ferry.go
@@ -26,11 +26,12 @@ var (
 )
 
 const (
-	StateStarting          = "starting"
-	StateCopying           = "copying"
-	StateWaitingForCutover = "wait-for-cutover"
-	StateCutover           = "cutover"
-	StateDone              = "done"
+	StateStarting            = "starting"
+	StateCopying             = "copying"
+	StateWaitingForCutover   = "wait-for-cutover"
+	StateVerifyBeforeCutover = "verify-before-cutover"
+	StateCutover             = "cutover"
+	StateDone                = "done"
 )
 
 func quoteField(field string) string {
@@ -59,18 +60,25 @@ type Ferry struct {
 	DataIterator *DataIterator
 	BatchWriter  *BatchWriter
 
-	StateTracker *StateTracker
+	StateTracker                       *StateTracker
+	ErrorHandler                       ErrorHandler
+	Throttler                          Throttler
+	WaitUntilReplicaIsCaughtUpToMaster *WaitUntilReplicaIsCaughtUpToMaster
 
-	ErrorHandler ErrorHandler
-	Throttler    Throttler
+	// This can be specified by the caller. If specified, do not specify
+	// VerifierType in Config (or as an empty string) or an error will be
+	// returned in Initialize.
+	//
+	// If VerifierType is specified and this is nil on Ferry initialization, a
+	// Verifier will be created by Initialize. If an IterativeVerifier is to be
+	// created, IterativeVerifierConfig will be used to create the verifier.
+	Verifier Verifier
 
 	Tables TableSchemaCache
 
 	StartTime    time.Time
 	DoneTime     time.Time
 	OverallState string
-
-	WaitUntilReplicaIsCaughtUpToMaster *WaitUntilReplicaIsCaughtUpToMaster
 
 	logger *logrus.Entry
 
@@ -156,6 +164,70 @@ func (f *Ferry) NewBatchWriterWithoutStateTracker() *BatchWriter {
 	batchWriter := f.NewBatchWriter()
 	batchWriter.StateTracker = nil
 	return batchWriter
+}
+
+func (f *Ferry) NewChecksumTableVerifier() *ChecksumTableVerifier {
+	return &ChecksumTableVerifier{
+		SourceDB:         f.SourceDB,
+		TargetDB:         f.TargetDB,
+		DatabaseRewrites: f.Config.DatabaseRewrites,
+		TableRewrites:    f.Config.TableRewrites,
+	}
+}
+
+func (f *Ferry) NewIterativeVerifier() (*IterativeVerifier, error) {
+	var err error
+	config := f.Config.IterativeVerifierConfig
+
+	var maxExpectedDowntime time.Duration
+	if config.MaxExpectedDowntime != "" {
+		maxExpectedDowntime, err = time.ParseDuration(config.MaxExpectedDowntime)
+		if err != nil {
+			return nil, fmt.Errorf("invalid MaxExpectedDowntime: %v. this error should have been caught via .Validate()", err)
+		}
+	}
+
+	var compressionVerifier *CompressionVerifier
+	if config.TableColumnCompression != nil {
+		compressionVerifier, err = NewCompressionVerifier(config.TableColumnCompression)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	ignoredColumns := make(map[string]map[string]struct{})
+	for table, columns := range config.IgnoredColumns {
+		ignoredColumns[table] = make(map[string]struct{})
+		for _, column := range columns {
+			ignoredColumns[table][column] = struct{}{}
+		}
+	}
+
+	v := &IterativeVerifier{
+		CursorConfig: &CursorConfig{
+			DB:          f.SourceDB,
+			BatchSize:   f.Config.DataIterationBatchSize,
+			ReadRetries: f.Config.DBReadRetries,
+		},
+
+		BinlogStreamer:      f.BinlogStreamer,
+		SourceDB:            f.SourceDB,
+		TargetDB:            f.TargetDB,
+		CompressionVerifier: compressionVerifier,
+
+		IgnoredTables:       config.IgnoredTables,
+		IgnoredColumns:      ignoredColumns,
+		DatabaseRewrites:    f.Config.DatabaseRewrites,
+		TableRewrites:       f.Config.TableRewrites,
+		Concurrency:         config.Concurrency,
+		MaxExpectedDowntime: maxExpectedDowntime,
+	}
+
+	if f.CopyFilter != nil {
+		v.CursorConfig.BuildSelect = f.CopyFilter.BuildSelect
+	}
+
+	return v, v.Initialize()
 }
 
 // Initialize all the components of Ghostferry and connect to the Database
@@ -288,6 +360,26 @@ func (f *Ferry) Initialize() (err error) {
 	f.DataIterator = f.NewDataIterator()
 	f.BatchWriter = f.NewBatchWriter()
 
+	if f.Config.VerifierType != "" {
+		if f.Verifier != nil {
+			return errors.New("VerifierType specified and Verifier is given. these are mutually exclusive options")
+		}
+
+		switch f.Config.VerifierType {
+		case VerifierTypeIterative:
+			f.Verifier, err = f.NewIterativeVerifier()
+			if err != nil {
+				return err
+			}
+		case VerifierTypeChecksumTable:
+			f.Verifier = f.NewChecksumTableVerifier()
+		case VerifierTypeNoVerification:
+			// skip
+		default:
+			return fmt.Errorf("'%s' is not a known VerifierType", f.Config.VerifierType)
+		}
+	}
+
 	f.logger.Info("ferry initialized")
 	return nil
 }
@@ -344,6 +436,12 @@ func (f *Ferry) Start() error {
 
 	// TODO(pushrax): handle changes to schema during copying and clean this up.
 	f.BinlogStreamer.TableSchema = f.Tables
+
+	// TODO: refactor the TableSchemaCache logic to remove this weird post initialize
+	//       set tables hack
+	if f.Verifier != nil {
+		f.Verifier.SetApplicableTableSchemaCache(f.Tables)
+	}
 
 	return nil
 }
@@ -414,6 +512,19 @@ func (f *Ferry) Run() {
 	}()
 
 	dataIteratorWg.Wait()
+
+	if f.Verifier != nil {
+		f.logger.Info("calling VerifyBeforeCutover")
+		f.OverallState = StateVerifyBeforeCutover
+
+		metrics.Measure("VerifyBeforeCutover", nil, 1.0, func() {
+			err := f.Verifier.VerifyBeforeCutover()
+			if err != nil {
+				f.logger.WithError(err).Error("VerifyBeforeCutover failed")
+				f.ErrorHandler.Fatal("verifier", err)
+			}
+		})
+	}
 
 	f.logger.Info("data copy is complete, waiting for cutover")
 	f.OverallState = StateWaitingForCutover

--- a/iterative_verifier.go
+++ b/iterative_verifier.go
@@ -198,8 +198,9 @@ func (v *IterativeVerifier) VerifyOnce() (VerificationResult, error) {
 
 	err := v.iterateAllTables(func(pk uint64, tableSchema *schema.Table) error {
 		return VerificationResult{
-			DataCorrect: false,
-			Message:     fmt.Sprintf("verification failed on table: %s for pk: %d", tableSchema.String(), pk),
+			DataCorrect:     false,
+			Message:         fmt.Sprintf("verification failed on table: %s for pk: %d", tableSchema.String(), pk),
+			IncorrectTables: []string{tableSchema.String()},
 		}
 	})
 
@@ -209,7 +210,7 @@ func (v *IterativeVerifier) VerifyOnce() (VerificationResult, error) {
 	case VerificationResult:
 		return e, nil
 	default:
-		return VerificationResult{true, ""}, e
+		return NewCorrectVerificationResult(), e
 	}
 }
 
@@ -451,7 +452,7 @@ func (v *IterativeVerifier) verifyStore(sourceTag string, additionalTags []Metri
 	v.logger.WithField("batches", len(allBatches)).Debug("reverifying")
 
 	if len(allBatches) == 0 {
-		return VerificationResult{true, ""}, nil
+		return NewCorrectVerificationResult(), nil
 	}
 
 	erroredOrFailed := errors.New("verification of store errored or failed")
@@ -485,7 +486,7 @@ func (v *IterativeVerifier) verifyStore(sourceTag string, additionalTags []Metri
 					v.reverifyStore.Add(ReverifyEntry{Pk: pk, Table: table})
 				}
 
-				resultAndErr.Result = VerificationResult{true, ""}
+				resultAndErr.Result = NewCorrectVerificationResult()
 			}
 
 			if resultAndErr.ErroredOrFailed() {
@@ -532,7 +533,7 @@ func (v *IterativeVerifier) reverifyPks(table *schema.Table, pks []uint64) (Veri
 	}
 
 	if len(mismatchedPks) == 0 {
-		return VerificationResult{true, ""}, mismatchedPks, nil
+		return NewCorrectVerificationResult(), mismatchedPks, nil
 	}
 
 	pkStrings := make([]string, len(mismatchedPks))
@@ -541,8 +542,9 @@ func (v *IterativeVerifier) reverifyPks(table *schema.Table, pks []uint64) (Veri
 	}
 
 	return VerificationResult{
-		DataCorrect: false,
-		Message:     fmt.Sprintf("verification failed on table: %s for pks: %s", table.String(), strings.Join(pkStrings, ",")),
+		DataCorrect:     false,
+		Message:         fmt.Sprintf("verification failed on table: %s for pks: %s", table.String(), strings.Join(pkStrings, ",")),
+		IncorrectTables: []string{table.String()},
 	}, mismatchedPks, nil
 }
 

--- a/iterative_verifier.go
+++ b/iterative_verifier.go
@@ -178,10 +178,6 @@ func (v *IterativeVerifier) SanityCheckParameters() error {
 		return fmt.Errorf("iterative verifier concurrency must be greater than 0, not %d", v.Concurrency)
 	}
 
-	if v.TableSchemaCache == nil {
-		return fmt.Errorf("iterative verifier must be given the table schema cache")
-	}
-
 	return nil
 }
 
@@ -218,6 +214,10 @@ func (v *IterativeVerifier) VerifyOnce() (VerificationResult, error) {
 }
 
 func (v *IterativeVerifier) VerifyBeforeCutover() error {
+	if v.TableSchemaCache == nil {
+		return fmt.Errorf("iterative verifier must be given the table schema cache before starting verify before cutover")
+	}
+
 	v.logger.Info("starting pre-cutover verification")
 
 	v.logger.Debug("attaching binlog event listener")
@@ -242,6 +242,11 @@ func (v *IterativeVerifier) VerifyBeforeCutover() error {
 	v.beforeCutoverVerifyDone = true
 
 	return err
+}
+
+func (v *IterativeVerifier) SetApplicableTableSchemaCache(t TableSchemaCache) {
+	v.Tables = t.AsSlice()
+	v.TableSchemaCache = t
 }
 
 func (v *IterativeVerifier) VerifyDuringCutover() (VerificationResult, error) {

--- a/sharding/config.go
+++ b/sharding/config.go
@@ -21,14 +21,9 @@ type Config struct {
 	CutoverUnlock ghostferry.HTTPCallback
 	ErrorCallback ghostferry.HTTPCallback
 
-	JoinedTables               map[string][]JoinTable
-	IgnoredTables              []string
-	IgnoredVerificationTables  []string
-	IgnoredVerificationColumns map[string][]string
-	PrimaryKeyTables           []string
-
-	VerifierIterationConcurrency int
-	MaxExpectedVerifierDowntime  string
+	JoinedTables     map[string][]JoinTable
+	IgnoredTables    []string
+	PrimaryKeyTables []string
 
 	Throttle *ghostferry.LagThrottlerConfig
 }

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -30,6 +30,8 @@ func NewFerry(config *Config) (*ShardingFerry, error) {
 		JoinedTables:  config.JoinedTables,
 	}
 
+	config.VerifierType = ghostferry.VerifierTypeIterative
+
 	ignored, err := compileRegexps(config.IgnoredTables)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compile ignored tables: %v", err)
@@ -88,80 +90,14 @@ func (r *ShardingFerry) Initialize() error {
 		r.Ferry.ErrorHandler.ReportError("ferry.initialize", err)
 		return err
 	}
+
+	r.verifier = r.Ferry.Verifier.(*ghostferry.IterativeVerifier)
+
 	return nil
 }
 
-func (r *ShardingFerry) newIterativeVerifier() (*ghostferry.IterativeVerifier, error) {
-	verifierConcurrency := r.config.VerifierIterationConcurrency
-	if verifierConcurrency == 0 {
-		verifierConcurrency = r.config.DataIterationConcurrency
-	}
-
-	var maxExpectedDowntime time.Duration
-	if r.config.MaxExpectedVerifierDowntime != "" {
-		var err error
-		maxExpectedDowntime, err = time.ParseDuration(r.config.MaxExpectedVerifierDowntime)
-		if err != nil {
-			return nil, fmt.Errorf("invalid MaxExpectedVerifierDowntime: %s", err)
-		}
-	}
-
-	var compressionVerifier *ghostferry.CompressionVerifier
-	if r.config.TableColumnCompression != nil {
-		var err error
-		compressionVerifier, err = ghostferry.NewCompressionVerifier(r.config.TableColumnCompression)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	ignoredColumns := make(map[string]map[string]struct{})
-	for table, columns := range r.config.IgnoredVerificationColumns {
-		ignoredColumns[table] = make(map[string]struct{})
-		for _, column := range columns {
-			ignoredColumns[table][column] = struct{}{}
-		}
-	}
-
-	return &ghostferry.IterativeVerifier{
-		CursorConfig: &ghostferry.CursorConfig{
-			DB:          r.Ferry.SourceDB,
-			BatchSize:   r.config.DataIterationBatchSize,
-			ReadRetries: r.config.DBReadRetries,
-			BuildSelect: r.config.CopyFilter.BuildSelect,
-		},
-
-		BinlogStreamer:      r.Ferry.BinlogStreamer,
-		CompressionVerifier: compressionVerifier,
-
-		TableSchemaCache: r.Ferry.Tables,
-		Tables:           r.Ferry.Tables.AsSlice(),
-
-		SourceDB: r.Ferry.SourceDB,
-		TargetDB: r.Ferry.TargetDB,
-
-		DatabaseRewrites: r.config.DatabaseRewrites,
-		TableRewrites:    r.config.TableRewrites,
-
-		IgnoredTables:       r.config.IgnoredVerificationTables,
-		IgnoredColumns:      ignoredColumns,
-		Concurrency:         verifierConcurrency,
-		MaxExpectedDowntime: maxExpectedDowntime,
-	}, nil
-}
-
 func (r *ShardingFerry) Start() error {
-	err := r.Ferry.Start()
-	if err != nil {
-		return err
-	}
-
-	r.verifier, err = r.newIterativeVerifier()
-	if err != nil {
-		return err
-	}
-
-	return r.verifier.Initialize()
+	return r.Ferry.Start()
 }
 
 func (r *ShardingFerry) Run() {
@@ -173,14 +109,6 @@ func (r *ShardingFerry) Run() {
 	}()
 
 	r.Ferry.WaitUntilRowCopyIsComplete()
-
-	metrics.Measure("VerifyBeforeCutover", nil, 1.0, func() {
-		err := r.verifier.VerifyBeforeCutover()
-		if err != nil {
-			r.logger.WithField("error", err).Errorf("pre-cutover verification encountered an error, aborting run")
-			r.Ferry.ErrorHandler.Fatal("sharding", err)
-		}
-	})
 
 	ghostferry.WaitForThrottle(r.Ferry.Throttler)
 
@@ -266,17 +194,12 @@ func (r *ShardingFerry) deltaCopyJoinedTables() error {
 		return err
 	}
 
-	verifier, err := r.newIterativeVerifier()
+	verifier, err := r.Ferry.NewIterativeVerifier()
 	if err != nil {
 		return err
 	}
 
 	verifier.Tables = tables
-
-	err = verifier.Initialize()
-	if err != nil {
-		return err
-	}
 
 	verificationResult, err := verifier.VerifyOnce()
 	if err != nil {
@@ -326,18 +249,13 @@ func (r *ShardingFerry) copyPrimaryKeyTables() error {
 		return err
 	}
 
-	verifier, err := r.newIterativeVerifier()
+	verifier, err := r.Ferry.NewIterativeVerifier()
 	if err != nil {
 		return err
 	}
 
 	verifier.TableSchemaCache = sourceDbTables
 	verifier.Tables = tables
-
-	err = verifier.Initialize()
-	if err != nil {
-		return err
-	}
 
 	verificationResult, err := verifier.VerifyOnce()
 	if err != nil {

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -13,10 +13,9 @@ import (
 )
 
 type ShardingFerry struct {
-	Ferry    *ghostferry.Ferry
-	verifier *ghostferry.IterativeVerifier
-	config   *Config
-	logger   *logrus.Entry
+	Ferry  *ghostferry.Ferry
+	config *Config
+	logger *logrus.Entry
 }
 
 func NewFerry(config *Config) (*ShardingFerry, error) {
@@ -91,8 +90,6 @@ func (r *ShardingFerry) Initialize() error {
 		return err
 	}
 
-	r.verifier = r.Ferry.Verifier.(*ghostferry.IterativeVerifier)
-
 	return nil
 }
 
@@ -148,7 +145,7 @@ func (r *ShardingFerry) Run() {
 
 	var verificationResult ghostferry.VerificationResult
 	metrics.Measure("VerifyCutover", nil, 1.0, func() {
-		verificationResult, err = r.verifier.VerifyDuringCutover()
+		verificationResult, err = r.Ferry.Verifier.VerifyDuringCutover()
 	})
 	if err != nil {
 		r.logger.WithField("error", err).Errorf("verification encountered an error, aborting run")

--- a/sharding/test/compression_verifier_test.go
+++ b/sharding/test/compression_verifier_test.go
@@ -26,7 +26,7 @@ func (t *CompressionVerifierTestSuite) TestFailsVerificationForDifferentCompress
 	tableCompressions := make(ghostferry.TableColumnCompressionConfig)
 	tableCompressions[testhelpers.TestCompressedTable1Name] = make(map[string]string)
 	tableCompressions[testhelpers.TestCompressedTable1Name][testhelpers.TestCompressedColumn1Name] = ghostferry.CompressionSnappy
-	t.Config.TableColumnCompression = tableCompressions
+	t.replaceCompressionVerifier(tableCompressions)
 
 	t.Require().NotEqual(testhelpers.TestCompressedData1, testhelpers.TestCompressedData2)
 	t.InsertCompressedRowInDb(43, "gftest1", testhelpers.TestCompressedData1, t.Ferry.Ferry.SourceDB)
@@ -48,7 +48,7 @@ func (t *CompressionVerifierTestSuite) TestCanCopyDifferentCompressedDataButEqua
 	tableCompressions := make(ghostferry.TableColumnCompressionConfig)
 	tableCompressions[testhelpers.TestCompressedTable1Name] = make(map[string]string)
 	tableCompressions[testhelpers.TestCompressedTable1Name][testhelpers.TestCompressedColumn1Name] = ghostferry.CompressionSnappy
-	t.Config.TableColumnCompression = tableCompressions
+	t.replaceCompressionVerifier(tableCompressions)
 
 	t.Require().NotEqual(testhelpers.TestCompressedData3, testhelpers.TestCompressedData4)
 
@@ -64,6 +64,13 @@ func (t *CompressionVerifierTestSuite) TestCanCopyDifferentCompressedDataButEqua
 func (t *CompressionVerifierTestSuite) InsertCompressedRowInDb(id int, schema, data string, db *sql.DB) {
 	tenantId := 2
 	_, err := db.Exec("INSERT INTO "+schema+"."+testhelpers.TestCompressedTable1Name+" VALUES (?,?,?)", id, data, tenantId)
+	t.Require().Nil(err)
+}
+
+func (t *CompressionVerifierTestSuite) replaceCompressionVerifier(tableCompressions ghostferry.TableColumnCompressionConfig) {
+	var err error
+	iterativeVerifier := t.Ferry.Ferry.Verifier.(*ghostferry.IterativeVerifier)
+	iterativeVerifier.CompressionVerifier, err = ghostferry.NewCompressionVerifier(tableCompressions)
 	t.Require().Nil(err)
 }
 

--- a/test/go/data_iterator_test.go
+++ b/test/go/data_iterator_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/siddontang/go-mysql/schema"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/Shopify/ghostferry"
@@ -16,6 +17,7 @@ type DataIteratorTestSuite struct {
 
 	di           *ghostferry.DataIterator
 	wg           *sync.WaitGroup
+	tables       []*schema.Table
 	receivedRows map[string][]ghostferry.RowData
 }
 
@@ -36,6 +38,8 @@ func (this *DataIteratorTestSuite) SetupTest() {
 	tables, err := ghostferry.LoadTables(sourceDb, tableFilter)
 	this.Require().Nil(err)
 
+	this.tables = tables.AsSlice()
+
 	config.DataIterationBatchSize = 2
 
 	this.di = &ghostferry.DataIterator{
@@ -52,8 +56,6 @@ func (this *DataIteratorTestSuite) SetupTest() {
 			ReadRetries: config.DBReadRetries,
 		},
 		StateTracker: ghostferry.NewCopyStateTracker(config.DataIterationConcurrency * 10),
-
-		Tables: tables.AsSlice(),
 	}
 
 	this.receivedRows = make(map[string][]ghostferry.RowData, 0)
@@ -69,7 +71,7 @@ func (this *DataIteratorTestSuite) TestNoEventsForEmptyTable() {
 	_, err = this.Ferry.SourceDB.Query(fmt.Sprintf("DELETE FROM `%s`.`%s`", testhelpers.TestSchemaName, testhelpers.TestCompressedTable1Name))
 	this.Require().Nil(err)
 
-	this.di.Run()
+	this.di.Run(this.tables)
 
 	this.Require().Equal(0, len(this.receivedRows))
 	this.Require().Equal(
@@ -122,7 +124,7 @@ func (this *DataIteratorTestSuite) TestExistingRowsAreIterated() {
 	this.Require().Equal(0, len(this.receivedRows[testhelpers.TestTable1Name]))
 	this.Require().Equal(0, len(this.receivedRows[testhelpers.TestCompressedTable1Name]))
 
-	this.di.Run()
+	this.di.Run(this.tables)
 
 	this.Require().Equal(5, len(this.receivedRows[testhelpers.TestTable1Name]))
 	this.Require().Equal(5, len(this.receivedRows[testhelpers.TestCompressedTable1Name]))
@@ -154,7 +156,7 @@ func (this *DataIteratorTestSuite) TestDoneListenerGetsNotifiedWhenDone() {
 		return nil
 	})
 
-	this.di.Run()
+	this.di.Run(this.tables)
 
 	this.Require().True(wasNotified)
 }

--- a/test/integration/iterative_verifier_test.rb
+++ b/test/integration/iterative_verifier_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class IterativeVerifierTest < GhostferryTestCase
+  def setup
+    seed_simple_database_with_single_table
+  end
+
+  def test_iterative_verifier_succeeds_in_normal_run
+    datawriter = new_source_datawriter
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { enable_iterative_verifier: true })
+
+    start_datawriter_with_ghostferry(datawriter, ghostferry)
+    stop_datawriter_during_cutover(datawriter, ghostferry)
+
+    verification_ran = false
+    ghostferry.on_status(Ghostferry::Status::VERIFIED) do |*incorrect_tables|
+      verification_ran = true
+      assert_equal 0, incorrect_tables.length
+    end
+
+    ghostferry.run
+    assert verification_ran
+    assert_test_table_is_identical
+  end
+
+  def test_iterative_verifier_fails_if_binlog_streamer_incorrectly_copies_data
+    datawriter = new_source_datawriter
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { enable_iterative_verifier: true })
+
+    table_name = DEFAULT_FULL_TABLE_NAME
+
+    chosen_id = 0
+    verification_ran = false
+    ghostferry.on_status(Ghostferry::Status::ROW_COPY_COMPLETED) do
+      result = source_db.query("SELECT id FROM #{table_name} ORDER BY id LIMIT 1")
+      chosen_id = result.first["id"]
+
+      refute chosen_id == 0
+      source_db.query("UPDATE #{table_name} SET data = 'something' WHERE id = #{chosen_id}")
+    end
+
+    ghostferry.on_status(Ghostferry::Status::VERIFY_DURING_CUTOVER) do
+      refute chosen_id == 0
+      source_db.query("DELETE FROM #{table_name} WHERE id = #{chosen_id}")
+    end
+
+    ghostferry.on_status(Ghostferry::Status::VERIFIED) do |*incorrect_tables|
+      verification_ran = true
+
+      assert_equal ["gftest.test_table_1"], incorrect_tables
+    end
+
+    ghostferry.run
+    assert verification_ran
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,10 +21,10 @@ class GhostferryTestCase < Minitest::Test
 
   MINIMAL_GHOSTFERRY = "integrationferry.go"
 
-  def new_ghostferry(filename)
+  def new_ghostferry(filename, config: {})
     # Transform path to something ruby understands
     path = File.join(GO_CODE_PATH, filename)
-    g = Ghostferry.new(path, logger: @logger)
+    g = Ghostferry.new(path, config: config, logger: @logger)
     @ghostferry_instances << g
     g
   end

--- a/testhelpers/integration_test_case.go
+++ b/testhelpers/integration_test_case.go
@@ -155,7 +155,7 @@ func (this *IntegrationTestCase) Teardown() {
 }
 
 func (this *IntegrationTestCase) verifyTableChecksum() (ghostferry.VerificationResult, error) {
-	return this.Verifier.Verify()
+	return this.Verifier.VerifyDuringCutover()
 }
 
 func (this *IntegrationTestCase) callCustomAction(f func(*TestFerry)) {

--- a/verifier.go
+++ b/verifier.go
@@ -18,12 +18,17 @@ func (e IncompleteVerificationError) Error() string {
 }
 
 type VerificationResult struct {
-	DataCorrect bool
-	Message     string
+	DataCorrect     bool
+	Message         string
+	IncorrectTables []string
 }
 
 func (e VerificationResult) Error() string {
 	return e.Message
+}
+
+func NewCorrectVerificationResult() VerificationResult {
+	return VerificationResult{true, "", []string{}}
 }
 
 type VerificationResultAndStatus struct {
@@ -49,6 +54,10 @@ type Verifier interface {
 	// If the Verifier needs to do anything immediately after the DataIterator
 	// finishes copying data and before cutover occurs, implement this function.
 	VerifyBeforeCutover() error
+
+	// This is called during cutover and should give the result of the
+	// verification.
+	VerifyDuringCutover() (VerificationResult, error)
 
 	// The Ferry will use this method to tell the verifier what to check.
 	//
@@ -110,7 +119,7 @@ func (v *ChecksumTableVerifier) SetApplicableTableSchemaCache(t TableSchemaCache
 	v.Tables = t.AsSlice()
 }
 
-func (v *ChecksumTableVerifier) Verify() (VerificationResult, error) {
+func (v *ChecksumTableVerifier) VerifyDuringCutover() (VerificationResult, error) {
 	if v.logger == nil {
 		v.logger = logrus.WithField("tag", "checksum_verifier")
 	}
@@ -179,11 +188,15 @@ func (v *ChecksumTableVerifier) Verify() (VerificationResult, error) {
 			logWithTable.WithFields(logFields).Info("tables on source and target verified to match")
 		} else {
 			logWithTable.WithFields(logFields).Error("tables on source and target DOES NOT MATCH")
-			return VerificationResult{false, fmt.Sprintf("data on table %s (%s) mismatched", sourceTable, targetTable)}, nil
+			return VerificationResult{
+				false,
+				fmt.Sprintf("data on table %s (%s) mismatched", sourceTable, targetTable),
+				[]string{table.String()},
+			}, nil
 		}
 	}
 
-	return VerificationResult{true, ""}, nil
+	return NewCorrectVerificationResult(), nil
 }
 
 func (v *ChecksumTableVerifier) fetchChecksumValueFromRow(row *sql.Row) (int64, error) {
@@ -229,7 +242,7 @@ func (v *ChecksumTableVerifier) StartInBackground() error {
 	go func() {
 		defer v.wg.Done()
 
-		v.verificationResultAndStatus.VerificationResult, v.verificationErr = v.Verify()
+		v.verificationResultAndStatus.VerificationResult, v.verificationErr = v.VerifyDuringCutover()
 		v.verificationResultAndStatus.DoneTime = time.Now()
 		v.started.Set(false)
 	}()


### PR DESCRIPTION
What is done 
----------

This PR moves the initialization and management of IterativeVerifier from the application level to the core library. This is required to interrupt and resume the IterativeVerifier as otherwise the application
layer will have to assume the responsibility of resuming the IterativeVerifier correctly, which is a non-trivial task.

This also removes the `.Tables` member on the DataIterator and made it an argument of `.Run`.

Also added tests in the ruby integration tests for the IterativeVerifier.

Implication for configurations
------------------------------

Since the verifiers will be initialized by the Ferry using configurations specified in Config. The Config interface is almost the same as the previous config, so a small change for sharding is needed:

Before for ghostferry-sharding:

```
{
 "IgnoredVerificationTables": [],
 "IgnoredVerificationColumns": [],
 "MaxExpectedVerifierDowntime": "1m",
 "VerifierIterationConcurrency": 4
}
```

After for ghostferry-sharding:

```
{
  "IterativeVerifierConfig": {
    "IgnoredTables": [],
    "IgnoredColumns": [],
    "MaxExpectedDowntime": "1m"
    "Concurrency": 4
  }
}
```

copydb doesn't require changes because previously it didn't allow for verifier configurations.

Future improvements
-------------------

One issue that exists is the table schema cache must be given to the verifiers after Ferry.Start. This causes some ugly code (Verifier.SetApplicableTableSchemaCache) for now. Once we refactor how the TableSchemaCache is handled, this method should go away.

Another issue is that the VerifyBeforeCutover is no longer controllable by the application level. The application level doesn't even really get an update about this development. This can be addressed in  the future.