### PR TITLE
Partially refactored StateTracker into two stages: copy and verify

### DIFF
--- a/batch_writer.go
+++ b/batch_writer.go
@@ -11,7 +11,7 @@ import (
 
 type BatchWriter struct {
 	DB           *sql.DB
-	StateTracker *StateTracker
+	StateTracker *CopyStateTracker
 
 	DatabaseRewrites map[string]string
 	TableRewrites    map[string]string

--- a/binlog_writer.go
+++ b/binlog_writer.go
@@ -18,7 +18,7 @@ type BinlogWriter struct {
 	WriteRetries int
 
 	ErrorHandler ErrorHandler
-	StateTracker *StateTracker
+	StateTracker *CopyStateTracker
 
 	binlogEventBuffer chan DMLEvent
 	logger            *logrus.Entry

--- a/binlog_writer.go
+++ b/binlog_writer.go
@@ -111,7 +111,7 @@ func (b *BinlogWriter) writeEvents(events []DMLEvent) error {
 	}
 
 	if b.StateTracker != nil {
-		b.StateTracker.UpdateLastWrittenBinlogPosition(events[len(events)-1].BinlogPosition())
+		b.StateTracker.UpdateLastProcessedBinlogPosition(events[len(events)-1].BinlogPosition())
 	}
 
 	return nil

--- a/data_iterator.go
+++ b/data_iterator.go
@@ -17,7 +17,7 @@ type DataIterator struct {
 
 	ErrorHandler ErrorHandler
 	CursorConfig *CursorConfig
-	StateTracker *StateTracker
+	StateTracker *CopyStateTracker
 
 	targetPKs      *sync.Map
 	batchListeners []func(*RowBatch) error
@@ -33,7 +33,7 @@ func (d *DataIterator) Run() {
 	// tracking state. However, some methods are still useful so we initialize
 	// a minimal local instance.
 	if d.StateTracker == nil {
-		d.StateTracker = NewStateTracker(0)
+		d.StateTracker = NewCopyStateTracker(0)
 	}
 
 	d.logger.WithField("tablesCount", len(d.Tables)).Info("starting data iterator run")

--- a/ferry.go
+++ b/ferry.go
@@ -90,7 +90,7 @@ func (f *Ferry) NewDataIterator() *DataIterator {
 			BatchSize:   f.Config.DataIterationBatchSize,
 			ReadRetries: f.Config.DBReadRetries,
 		},
-		StateTracker: f.StateTracker,
+		StateTracker: f.StateTracker.CopyStage,
 	}
 
 	if f.CopyFilter != nil {
@@ -127,7 +127,7 @@ func (f *Ferry) NewBinlogWriter() *BinlogWriter {
 		WriteRetries: f.Config.DBWriteRetries,
 
 		ErrorHandler: f.ErrorHandler,
-		StateTracker: f.StateTracker,
+		StateTracker: f.StateTracker.CopyStage,
 	}
 }
 
@@ -140,7 +140,7 @@ func (f *Ferry) NewBinlogWriterWithoutStateTracker() *BinlogWriter {
 func (f *Ferry) NewBatchWriter() *BatchWriter {
 	batchWriter := &BatchWriter{
 		DB:           f.TargetDB,
-		StateTracker: f.StateTracker,
+		StateTracker: f.StateTracker.CopyStage,
 
 		DatabaseRewrites: f.Config.DatabaseRewrites,
 		TableRewrites:    f.Config.TableRewrites,
@@ -313,7 +313,7 @@ func (f *Ferry) Start() error {
 	var pos siddontangmysql.Position
 	var err error
 	if f.StateToResumeFrom != nil {
-		pos, err = f.BinlogStreamer.ConnectBinlogStreamerToMysqlFrom(f.StateToResumeFrom.LastWrittenBinlogPosition)
+		pos, err = f.BinlogStreamer.ConnectBinlogStreamerToMysqlFrom(f.StateToResumeFrom.MinBinlogPosition())
 	} else {
 		pos, err = f.BinlogStreamer.ConnectBinlogStreamerToMysql()
 	}
@@ -324,7 +324,7 @@ func (f *Ferry) Start() error {
 	// If we don't set this now, there is a race condition where Ghostferry
 	// is terminated with some rows copied but no binlog events are written.
 	// This guarentees that we are able to restart from a valid location.
-	f.StateTracker.UpdateLastWrittenBinlogPosition(pos)
+	f.StateTracker.CopyStage.UpdateLastWrittenBinlogPosition(pos)
 
 	// Loads the schema of the tables that are applicable.
 	// We need to do this at the beginning of the run as this is required

--- a/ferry.go
+++ b/ferry.go
@@ -324,7 +324,7 @@ func (f *Ferry) Start() error {
 	// If we don't set this now, there is a race condition where Ghostferry
 	// is terminated with some rows copied but no binlog events are written.
 	// This guarentees that we are able to restart from a valid location.
-	f.StateTracker.CopyStage.UpdateLastWrittenBinlogPosition(pos)
+	f.StateTracker.CopyStage.UpdateLastProcessedBinlogPosition(pos)
 
 	// Loads the schema of the tables that are applicable.
 	// We need to do this at the beginning of the run as this is required

--- a/state_tracker.go
+++ b/state_tracker.go
@@ -9,13 +9,123 @@ import (
 	"github.com/siddontang/go-mysql/mysql"
 )
 
+// StateTracker design
+// ===================
+//
+// General Overview
+// ----------------
+//
+// The state tracker keeps track of the progress of Ghostferry so it can be
+// interrupted and resumed. The state tracker is supposed to be initialized and
+// managed by the Ferry. Each Ghostferry components, such as the `BatchWriter`
+// and `IterativeVerifier` will get passed an instance of either the
+// `CopyStateTracker` or the `VerifyStateTracker`. During the run, these
+// components will update their last successful components to the state tracker
+// instances given via the state tracker API defined here.
+//
+// The states stored in the state tracker can be copied into a serialization
+// friendly struct (`SerializableState`), which can then be dumped using
+// something like JSON. Assuming the rest of Ghostferry used the API of the
+// state tracker correctly, this can be done at any point during the Ghostferry
+// run and the resulting state is can be resumed from without incurring data
+// loss. The same `SerializableState` can be used as an input to `Ferry`, which
+// if specified will instruct to `Ferry` to start from a particular location.
+//
+// Code Design
+// -----------
+//
+// In a Ghostferry run, there are two "stages" of operation: the copy stage and
+// the verify stage. Both stages must emit their states to the state tracker in
+// order for them to be interruptible and resumable. These two stages are very
+// similar: they both iterate over the data and tail the binlog. However, there
+// are some minor differences. Example: the verifier stage needs to keep track
+// of the reverify store while the copy stage doesn't.
+//
+// In order to not repeat code, "base structs" are created for the state
+// tracking and serializable state: `BinlogAndIterationStateTracker` and
+// `BinlogAndIterationSerializableState`. `BinlogAndIterationStateTracker` have
+// most of the code/definitions required for the state tracker of both stages
+// to function.  To customize them for the different stages, `CopyStateTracker`
+// and `VerifierStateTracker` contain a minor amount of customized code due to
+// the small differences in requirements. The same can be said about
+// `BinlogAndIterationSerializableState` with respect to
+// `CopySerializableState` and `VerifierSerializableState`.
+//
+// These two stages of state tracker (and serializable states) are owned by a
+// "global" `StateTracker`. This struct keeps two member variables pointing to
+// the state tracker of each stage and that's it. The Ferry creates a new
+// instance of the global `StateTracker` and passes out references of the
+// applicable stage of state tracker to components like `BatchWriter` and
+// `IterativeVerifier`.
+//
+// To summarize, what we have is (arrows point from member variables to owner
+// structs):
+//
+//      BinlogAndIterationStateTracker
+//         |                     |
+//         v                     v
+//  CopyStateTracker    VerifierStateTracker
+//         |                     |
+//         +----------+----------+
+//                    |
+//                    v
+//               StateTracker
+//                    |
+//                    v
+//                  Ferry
+//
+// The same relationship exists for the serializable states.
+
+type BinlogAndIterationSerializableState struct {
+	LastSuccessfulPrimaryKeys map[string]uint64
+	CompletedTables           map[string]bool
+	LastWrittenBinlogPosition mysql.Position
+}
+
+type CopySerializableState BinlogAndIterationSerializableState
+
+type VerifierSerializableState struct {
+	*BinlogAndIterationSerializableState
+
+	// This is not efficient because we have to build this map of a different
+	// type from the original ReverifyStore struct.
+	//
+	// TODO: address this inefficiency later.
+	ReverifyStore map[string][]uint64
+}
+
+const (
+	StageCopy   = "COPY"
+	StageVerify = "VERIFY"
+)
+
+// This is the struct that is dumped by Ghostferry when it is interrupted. It
+// is the same struct that is given to Ghostferry when it is resumed.
 type SerializableState struct {
 	GhostferryVersion         string
 	LastKnownTableSchemaCache TableSchemaCache
 
-	LastSuccessfulPrimaryKeys map[string]uint64
-	CompletedTables           map[string]bool
-	LastWrittenBinlogPosition mysql.Position
+	CurrentStage  string
+	CopyStage     *CopySerializableState
+	VerifierStage *VerifierSerializableState
+}
+
+// The binlog writer and the verify binlog positions are different because the
+// binlog writer is buffered in a background go routine. Its position can race
+// with respect to the verifier binlog position. The minimum position between
+// the two are always safe to resume from.
+func (s *SerializableState) MinBinlogPosition() mysql.Position {
+	if s.VerifierStage == nil {
+		return s.CopyStage.LastWrittenBinlogPosition
+	}
+
+	c := s.CopyStage.LastWrittenBinlogPosition.Compare(s.VerifierStage.LastWrittenBinlogPosition)
+
+	if c >= 0 {
+		return s.CopyStage.LastWrittenBinlogPosition
+	} else {
+		return s.VerifierStage.LastWrittenBinlogPosition
+	}
 }
 
 // For tracking the speed of the copy
@@ -24,7 +134,21 @@ type PKPositionLog struct {
 	At       time.Time
 }
 
-type StateTracker struct {
+func newSpeedLogRing(speedLogCount int) *ring.Ring {
+	if speedLogCount <= 0 {
+		return nil
+	}
+
+	speedLog := ring.New(speedLogCount)
+	speedLog.Value = PKPositionLog{
+		Position: 0,
+		At:       time.Now(),
+	}
+
+	return speedLog
+}
+
+type BinlogAndIterationStateTracker struct {
 	lastSuccessfulPrimaryKeys map[string]uint64
 	completedTables           map[string]bool
 	lastWrittenBinlogPosition mysql.Position
@@ -35,7 +159,18 @@ type StateTracker struct {
 	copySpeedLog *ring.Ring
 }
 
-func (s *StateTracker) UpdateLastSuccessfulPK(table string, pk uint64) {
+func NewBinlogAndIterationStateTracker(speedLogCount int) *BinlogAndIterationStateTracker {
+	return &BinlogAndIterationStateTracker{
+		lastSuccessfulPrimaryKeys: make(map[string]uint64),
+		completedTables:           make(map[string]bool),
+		lastWrittenBinlogPosition: mysql.Position{},
+		binlogMutex:               &sync.RWMutex{},
+		tableMutex:                &sync.RWMutex{},
+		copySpeedLog:              newSpeedLogRing(speedLogCount),
+	}
+}
+
+func (s *BinlogAndIterationStateTracker) UpdateLastSuccessfulPK(table string, pk uint64) {
 	s.tableMutex.Lock()
 	defer s.tableMutex.Unlock()
 
@@ -45,7 +180,7 @@ func (s *StateTracker) UpdateLastSuccessfulPK(table string, pk uint64) {
 	s.updateSpeedLog(deltaPK)
 }
 
-func (s *StateTracker) LastSuccessfulPK(table string) uint64 {
+func (s *BinlogAndIterationStateTracker) LastSuccessfulPK(table string) uint64 {
 	s.tableMutex.RLock()
 	defer s.tableMutex.RUnlock()
 
@@ -62,28 +197,28 @@ func (s *StateTracker) LastSuccessfulPK(table string) uint64 {
 	return pk
 }
 
-func (s *StateTracker) MarkTableAsCompleted(table string) {
+func (s *BinlogAndIterationStateTracker) MarkTableAsCompleted(table string) {
 	s.tableMutex.Lock()
 	defer s.tableMutex.Unlock()
 
 	s.completedTables[table] = true
 }
 
-func (s *StateTracker) IsTableComplete(table string) bool {
+func (s *BinlogAndIterationStateTracker) IsTableComplete(table string) bool {
 	s.tableMutex.Lock()
 	defer s.tableMutex.Unlock()
 
 	return s.completedTables[table]
 }
 
-func (s *StateTracker) UpdateLastWrittenBinlogPosition(pos mysql.Position) {
+func (s *BinlogAndIterationStateTracker) UpdateLastWrittenBinlogPosition(pos mysql.Position) {
 	s.binlogMutex.Lock()
 	defer s.binlogMutex.Unlock()
 
 	s.lastWrittenBinlogPosition = pos
 }
 
-func (s *StateTracker) Serialize(lastKnownTableSchemaCache TableSchemaCache) *SerializableState {
+func (s *BinlogAndIterationStateTracker) Serialize() *BinlogAndIterationSerializableState {
 	s.tableMutex.RLock()
 	s.binlogMutex.RLock()
 	defer func() {
@@ -91,10 +226,7 @@ func (s *StateTracker) Serialize(lastKnownTableSchemaCache TableSchemaCache) *Se
 		s.binlogMutex.RUnlock()
 	}()
 
-	state := &SerializableState{
-		GhostferryVersion:         VersionString,
-		LastKnownTableSchemaCache: lastKnownTableSchemaCache,
-
+	state := &BinlogAndIterationSerializableState{
 		LastWrittenBinlogPosition: s.lastWrittenBinlogPosition,
 		LastSuccessfulPrimaryKeys: make(map[string]uint64),
 		CompletedTables:           make(map[string]bool),
@@ -114,7 +246,7 @@ func (s *StateTracker) Serialize(lastKnownTableSchemaCache TableSchemaCache) *Se
 // This is reasonably accurate if the rows copied are distributed uniformly
 // between pk = 0 -> max(pk). It would not be accurate if the distribution is
 // concentrated in a particular region.
-func (s *StateTracker) EstimatedPKCopiedPerSecond() float64 {
+func (s *BinlogAndIterationStateTracker) EstimatedPKsPerSecond() float64 {
 	if s.copySpeedLog == nil {
 		return 0.0
 	}
@@ -139,7 +271,7 @@ func (s *StateTracker) EstimatedPKCopiedPerSecond() float64 {
 	return float64(deltaPK) / deltaT
 }
 
-func (s *StateTracker) updateSpeedLog(deltaPK uint64) {
+func (s *BinlogAndIterationStateTracker) updateSpeedLog(deltaPK uint64) {
 	if s.copySpeedLog == nil {
 		return
 	}
@@ -152,28 +284,44 @@ func (s *StateTracker) updateSpeedLog(deltaPK uint64) {
 	}
 }
 
+type CopyStateTracker struct {
+	*BinlogAndIterationStateTracker
+}
+
+func (s *CopyStateTracker) Serialize() *CopySerializableState {
+	return (*CopySerializableState)(s.BinlogAndIterationStateTracker.Serialize())
+}
+
+func NewCopyStateTracker(speedLogCount int) *CopyStateTracker {
+	return &CopyStateTracker{NewBinlogAndIterationStateTracker(speedLogCount)}
+}
+
+type VerifierStateTracker struct {
+	*BinlogAndIterationStateTracker
+	// TODO: this struct needs to keep track of the reverify store and dump it
+	//       with Serialize.
+}
+
+func (s *VerifierStateTracker) Serialize() *VerifierSerializableState {
+	// TODO: this method needs to dump the reverify store.
+	return &VerifierSerializableState{
+		BinlogAndIterationSerializableState: s.BinlogAndIterationStateTracker.Serialize(),
+	}
+}
+
+type StateTracker struct {
+	CopyStage *CopyStateTracker
+	// TODO: implement this
+	// VerifierStage *VerifierStateTracker
+}
+
 // speedLogCount should be a number that is an order of magnitude or so larger
 // than the number of table iterators. This is to ensure the ring buffer used
 // to calculate the speed is not filled with only data from the last iteration
 // of the cursor and thus would be wildly inaccurate.
 func NewStateTracker(speedLogCount int) *StateTracker {
-	var speedLog *ring.Ring = nil
-
-	if speedLogCount > 0 {
-		speedLog = ring.New(speedLogCount)
-		speedLog.Value = PKPositionLog{
-			Position: 0,
-			At:       time.Now(),
-		}
-	}
-
 	return &StateTracker{
-		lastSuccessfulPrimaryKeys: make(map[string]uint64),
-		completedTables:           make(map[string]bool),
-		lastWrittenBinlogPosition: mysql.Position{},
-		binlogMutex:               &sync.RWMutex{},
-		tableMutex:                &sync.RWMutex{},
-		copySpeedLog:              speedLog,
+		CopyStage: NewCopyStateTracker(speedLogCount),
 	}
 }
 
@@ -181,8 +329,19 @@ func NewStateTracker(speedLogCount int) *StateTracker {
 // starting from the beginning.
 func NewStateTrackerFromSerializedState(speedLogCount int, serializedState *SerializableState) *StateTracker {
 	s := NewStateTracker(speedLogCount)
-	s.lastSuccessfulPrimaryKeys = serializedState.LastSuccessfulPrimaryKeys
-	s.completedTables = serializedState.CompletedTables
-	s.lastWrittenBinlogPosition = serializedState.LastWrittenBinlogPosition
+	s.CopyStage.lastSuccessfulPrimaryKeys = serializedState.CopyStage.LastSuccessfulPrimaryKeys
+	s.CopyStage.completedTables = serializedState.CopyStage.CompletedTables
+	s.CopyStage.lastWrittenBinlogPosition = serializedState.CopyStage.LastWrittenBinlogPosition
 	return s
+}
+
+func (s *StateTracker) Serialize(lastKnownTableSchemaCache TableSchemaCache) *SerializableState {
+	return &SerializableState{
+		GhostferryVersion:         VersionString,
+		LastKnownTableSchemaCache: lastKnownTableSchemaCache,
+
+		// TODO: implement verifier stage
+		CurrentStage: StageCopy,
+		CopyStage:    s.CopyStage.Serialize(),
+	}
 }

--- a/status.go
+++ b/status.go
@@ -82,8 +82,8 @@ func FetchStatus(f *Ferry, v Verifier) *Status {
 
 	serializedState := f.StateTracker.Serialize(nil)
 
-	lastSuccessfulPKs := serializedState.LastSuccessfulPrimaryKeys
-	completedTables := serializedState.CompletedTables
+	lastSuccessfulPKs := serializedState.CopyStage.LastSuccessfulPrimaryKeys
+	completedTables := serializedState.CopyStage.CompletedTables
 
 	targetPKs := make(map[string]uint64)
 	f.DataIterator.targetPKs.Range(func(k, v interface{}) bool {
@@ -178,7 +178,7 @@ func FetchStatus(f *Ferry, v Verifier) *Status {
 	// ASAP. It's not supposed to be that accurate anyway.
 	var totalPKsToCopy uint64 = 0
 	var completedPKs uint64 = 0
-	estimatedPKsPerSecond := f.StateTracker.EstimatedPKCopiedPerSecond()
+	estimatedPKsPerSecond := f.StateTracker.CopyStage.EstimatedPKsPerSecond()
 	for _, targetPK := range targetPKs {
 		totalPKsToCopy += targetPK
 	}

--- a/test/go/data_iterator_test.go
+++ b/test/go/data_iterator_test.go
@@ -51,7 +51,7 @@ func (this *DataIteratorTestSuite) SetupTest() {
 			BatchSize:   config.DataIterationBatchSize,
 			ReadRetries: config.DBReadRetries,
 		},
-		StateTracker: ghostferry.NewStateTracker(config.DataIterationConcurrency * 10),
+		StateTracker: ghostferry.NewCopyStateTracker(config.DataIterationConcurrency * 10),
 
 		Tables: tables.AsSlice(),
 	}
@@ -160,7 +160,7 @@ func (this *DataIteratorTestSuite) TestDoneListenerGetsNotifiedWhenDone() {
 }
 
 func (this *DataIteratorTestSuite) completedTables() map[string]bool {
-	return this.di.StateTracker.Serialize(nil).CompletedTables
+	return this.di.StateTracker.Serialize().CompletedTables
 }
 
 func TestDataIterator(t *testing.T) {

--- a/test/integration/interrupt_resume_test.rb
+++ b/test/integration/interrupt_resume_test.rb
@@ -25,7 +25,7 @@ class InterruptResumeTest < GhostferryTestCase
     result = target_db.query("SELECT MAX(id) AS max_id FROM #{DEFAULT_FULL_TABLE_NAME}")
     last_successful_id = result.first["max_id"]
     assert last_successful_id > 0
-    assert_equal last_successful_id, dumped_state["LastSuccessfulPrimaryKeys"]["#{DEFAULT_DB}.#{DEFAULT_TABLE}"]
+    assert_equal last_successful_id, dumped_state["CopyStage"]["LastSuccessfulPrimaryKeys"]["#{DEFAULT_DB}.#{DEFAULT_TABLE}"]
   end
 
   def test_interrupt_resume_with_writes_to_source

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -102,8 +102,8 @@ class GhostferryTestCase < Minitest::Test
     refute dumped_state.nil?
     refute dumped_state["GhostferryVersion"].nil?
     refute dumped_state["LastKnownTableSchemaCache"].nil?
-    refute dumped_state["LastSuccessfulPrimaryKeys"].nil?
-    refute dumped_state["CompletedTables"].nil?
-    refute dumped_state["LastWrittenBinlogPosition"].nil?
+    refute dumped_state["CopyStage"]["LastSuccessfulPrimaryKeys"].nil?
+    refute dumped_state["CopyStage"]["CompletedTables"].nil?
+    refute dumped_state["CopyStage"]["LastWrittenBinlogPosition"].nil?
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -104,6 +104,6 @@ class GhostferryTestCase < Minitest::Test
     refute dumped_state["LastKnownTableSchemaCache"].nil?
     refute dumped_state["CopyStage"]["LastSuccessfulPrimaryKeys"].nil?
     refute dumped_state["CopyStage"]["CompletedTables"].nil?
-    refute dumped_state["CopyStage"]["LastWrittenBinlogPosition"].nil?
+    refute dumped_state["CopyStage"]["LastProcessedBinlogPosition"].nil?
   end
 end


### PR DESCRIPTION
The previous StateTracker can only handle tracking the copy, not the verify. This commit refactors the StateTracker into two distinct stages: the CopyStateTracker and the VerifierStateTracker, along with their
associated SerializableStates (CopySerializableState and VerifySerializableState).

The Ferry is responsible of initializing and passing the correct stages to the correct components. 

Right now, this PR only really implements the CopyStage. The VerifyStage will be implemented as I make the IterativeVerifier interruptible.