### PR TITLE
Scan SHOW MASTER STATUS row depends on column count #92

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -145,27 +145,22 @@ loop:
 
 func ShowMasterStatusBinlogPosition(db *sql.DB) (mysql.Position, error) {
 	rows, err := db.Query("SHOW MASTER STATUS")
-	if err != nil {
-		return NewMysqlPosition("", 0, err)
-	}
+
 	var file string
 	var position uint32
 	var binlog_do_db, binlog_ignore_db, executed_gtid_set string
+	var cols []string
 	if rows.Next() {
-		cols,_ := rows.Columns()
+		cols, err = rows.Columns()
 		switch len(cols) {
 		case 4:
-			err := rows.Scan(&file, &position, &binlog_do_db, &binlog_ignore_db)
-			return NewMysqlPosition(file, position, err)
-
+			err = rows.Scan(&file, &position, &binlog_do_db, &binlog_ignore_db)
 		default:
-			err := rows.Scan(&file, &position, &binlog_do_db, &binlog_ignore_db, &executed_gtid_set)
-			return NewMysqlPosition(file, position, err)
-
+			err = rows.Scan(&file, &position, &binlog_do_db, &binlog_ignore_db, &executed_gtid_set)
 		}
-	}else{
-		return NewMysqlPosition(file, position, sql.ErrNoRows)
 	}
+	return NewMysqlPosition(file, position, err)
+
 }
 
 func NewMysqlPosition(file string, position uint32, err error) (mysql.Position, error) {


### PR DESCRIPTION
We are currently using MariaDB on production and `Executed_Gtid_Set` column is not returning for `SHOW MASTER STATUS` query
This is causing `sql: expected 4 destination arguments in Scan, not 5 ` when ghostferry wants t read binlog position

Here is our `SHOW MASTER STATUS` result

```
MariaDB [(none)]> SHOW MASTER STATUS;
+--------------------+----------+--------------+------------------+
| File               | Position | Binlog_Do_DB | Binlog_Ignore_DB |
+--------------------+----------+--------------+------------------+
| mariadb-bin.000006 | 39818670 |              |                  |
+--------------------+----------+--------------+------------------+
1 row in set (0.00 sec)
```