### PR TITLE
Scan SHOW MASTER STATUS row depending on column count #92

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -144,11 +144,20 @@ loop:
 }
 
 func ShowMasterStatusBinlogPosition(db *sql.DB) (mysql.Position, error) {
-	row := db.QueryRow("SHOW MASTER STATUS")
+	rows, err := db.Query("SHOW MASTER STATUS")
 	var file string
 	var position uint32
 	var binlog_do_db, binlog_ignore_db, executed_gtid_set string
-	err := row.Scan(&file, &position, &binlog_do_db, &binlog_ignore_db, &executed_gtid_set)
+	var cols []string
+	if rows.Next() {
+		cols, err = rows.Columns()
+		switch len(cols) {
+		case 4:
+			err = rows.Scan(&file, &position, &binlog_do_db, &binlog_ignore_db)
+		default:
+			err = rows.Scan(&file, &position, &binlog_do_db, &binlog_ignore_db, &executed_gtid_set)
+		}
+	}
 	return NewMysqlPosition(file, position, err)
 }
 

--- a/utils.go
+++ b/utils.go
@@ -145,7 +145,9 @@ loop:
 
 func ShowMasterStatusBinlogPosition(db *sql.DB) (mysql.Position, error) {
 	rows, err := db.Query("SHOW MASTER STATUS")
-	defer rows.Close()
+	if rows != nil {
+		defer rows.Close()
+	}
 	if err != nil {
 		return NewMysqlPosition("", 0, err)
 	}

--- a/utils.go
+++ b/utils.go
@@ -145,12 +145,10 @@ loop:
 
 func ShowMasterStatusBinlogPosition(db *sql.DB) (mysql.Position, error) {
 	rows, err := db.Query("SHOW MASTER STATUS")
-	if rows != nil {
-		defer rows.Close()
-	}
 	if err != nil {
 		return NewMysqlPosition("", 0, err)
 	}
+	defer rows.Close()
 	var file string
 	var position uint32
 	var binlog_do_db, binlog_ignore_db, executed_gtid_set string

--- a/utils.go
+++ b/utils.go
@@ -145,12 +145,19 @@ loop:
 
 func ShowMasterStatusBinlogPosition(db *sql.DB) (mysql.Position, error) {
 	rows, err := db.Query("SHOW MASTER STATUS")
+	defer rows.Close()
+	if err != nil {
+		return NewMysqlPosition("", 0, err)
+	}
 	var file string
 	var position uint32
 	var binlog_do_db, binlog_ignore_db, executed_gtid_set string
 	var cols []string
 	if rows.Next() {
 		cols, err = rows.Columns()
+		if err != nil {
+			return NewMysqlPosition(file, position, err)
+		}
 		switch len(cols) {
 		case 4:
 			err = rows.Scan(&file, &position, &binlog_do_db, &binlog_ignore_db)


### PR DESCRIPTION
We are currently using MariaDB on production and `Executed_Gtid_Set` column is not returning for `SHOW MASTER STATUS` query
This is causing `sql: expected 4 destination arguments in Scan, not 5 ` when ghostferry wants t read binlog position

Here is our `SHOW MASTER STATUS` result

```
MariaDB [(none)]> SHOW MASTER STATUS;
+--------------------+----------+--------------+------------------+
| File               | Position | Binlog_Do_DB | Binlog_Ignore_DB |
+--------------------+----------+--------------+------------------+
| mariadb-bin.000006 | 39818670 |              |                  |
+--------------------+----------+--------------+------------------+
1 row in set (0.00 sec)
```