### PR TITLE
Find referenced tables if there is any foreign key to create them first.

### DIFF
--- a/copydb/copydb.go
+++ b/copydb/copydb.go
@@ -2,7 +2,6 @@ package copydb
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -217,7 +216,7 @@ func (this *CopydbFerry) createTableOnTarget(database, table string) error {
 	fullTableName = fmt.Sprintf("%s.%s", database, table)
 
 	if _, created := this.CreatedTables[fullTableName]; created {
-		logrus.WithField("table", fullTableName).Warn("Table already created. Skipping")
+		logrus.WithField("table", fullTableName).Warn("Table already created in this session. Skipping")
 		return nil
 	}
 
@@ -274,8 +273,7 @@ func (this *CopydbFerry) createReferencedTablesIfAny(database, table string) err
 	stmt, err := this.Ferry.SourceDB.Prepare(constraintsSql)
 
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error preparing constraints sql : %s\n", constraintsSql)
-		return err
+		return fmt.Errorf("error preparing constraints sql : %s", constraintsSql)
 	}
 
 	rows, err := stmt.Query(table, database)
@@ -283,8 +281,8 @@ func (this *CopydbFerry) createReferencedTablesIfAny(database, table string) err
 		defer rows.Close()
 	}
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error executing constraints sql : %s\n", constraintsSql)
-		return err
+		return fmt.Errorf("error executing constraints sql : %s", constraintsSql)
+
 	}
 
 	for rows.Next() {

--- a/copydb/test/copydb_test.go
+++ b/copydb/test/copydb_test.go
@@ -56,6 +56,7 @@ func (t *CopydbTestSuite) SetupTest() {
 	t.ferry = t.copydbFerry.Ferry
 
 	testhelpers.SeedInitialData(t.ferry.SourceDB, testSchemaName, testTableName, 10)
+	testhelpers.SeedInitialForeignKeyData(t.ferry.SourceDB, testSchemaName,  testTableName, 10)
 }
 
 func (t *CopydbTestSuite) TearDownTest() {


### PR DESCRIPTION
This PR Fixes #95 ,
Needed to check foreign keys before creating a table and check / create referenced tables first from INFORMATION_SCHEMA. Also needed to create another map to keep tables that created in current session to prevent recreating tables that created due to reference before their turn. Will update that request with unit tests too. Just keeping here for any feedback and/or commits from you. 