### PR TITLE
Fixed JSON column with binlog streamer

### DIFF
--- a/row_batch.go
+++ b/row_batch.go
@@ -41,10 +41,11 @@ func (e *RowBatch) TableSchema() *schema.Table {
 }
 
 func (e *RowBatch) AsSQLQuery(target *schema.Table) (string, []interface{}, error) {
-	columns, err := loadColumnsForTable(&e.table, e.values...)
-	if err != nil {
+	if err := verifyValuesHasTheSameLengthAsColumns(&e.table, e.values...); err != nil {
 		return "", nil, err
 	}
+
+	columns := quotedColumnNames(&e.table)
 
 	valuesStr := "(" + strings.Repeat("?,", len(columns)-1) + "?)"
 	valuesStr = strings.Repeat(valuesStr+",", len(e.values)-1) + valuesStr

--- a/test/integration/types_test.rb
+++ b/test/integration/types_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class TypesTest < GhostferryTestCase
+  def test_json_data
+    [source_db, target_db].each do |db|
+      db.query("CREATE DATABASE IF NOT EXISTS #{DEFAULT_DB}")
+      db.query("CREATE TABLE IF NOT EXISTS #{DEFAULT_FULL_TABLE_NAME} (id bigint(20) not null auto_increment, data JSON, primary key(id))")
+    end
+
+    json_obj = '{"data": {"quote": "\\\'", "value": [1]}}'
+    empty_json = '{}'
+    json_array = '[\"test_data\", \"test_data_2\"]'
+    source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (1, '#{json_obj}')")
+    source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (2, '#{json_array}')")
+    source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (3, '#{empty_json}')")
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+
+    ghostferry.on_status(Ghostferry::Status::BINLOG_STREAMING_STARTED) do
+      source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (4, '#{json_obj}')")
+    end
+
+    ghostferry.run
+
+    # We cannot use assert_test_table_is_identical because CHECKSUM TABLE
+    # with a JSON column is broken on 5.7.
+    # See: https://bugs.mysql.com/bug.php?id=87847
+    res = target_db.query("SELECT COUNT(*) AS cnt FROM #{DEFAULT_FULL_TABLE_NAME}")
+    assert_equal 4, res.first["cnt"]
+
+    expected = [
+      {"id"=>1, "data"=>"{\"data\": {\"quote\": \"'\", \"value\": [1]}}"},
+      {"id"=>2, "data"=>"[\"test_data\", \"test_data_2\"]"},
+      {"id"=>3, "data"=>"{}"},
+      {"id"=>4, "data"=>"{\"data\": {\"quote\": \"'\", \"value\": [1]}}"},
+    ]
+
+    res = target_db.query("SELECT * FROM #{DEFAULT_FULL_TABLE_NAME} ORDER BY id ASC")
+    res.zip(expected).each do |row, expected_row|
+      assert_equal expected_row, row
+    end
+  end
+end


### PR DESCRIPTION
JSON column was previously being recognized as a []byte array in the BinlogWriter. This causes the INSERT/UPDATE/DELETE query generated to be with something like `_binary'{"data": 1}'`. However, JSON data are not binary, thus MySQL will return errors  errors such as:

> Error 3144: Cannot create a JSON value from a string with CHARACTER SET binary error.

Fixing this requires us to pass the column types into the methods actually escaping the values (`appendEscapedValues`), as we cannot infer that something is a JSON type from the Go type alone. This turned out to be a rather large list of methods.

To do this the most generic way, I just pass down the table columns all the way (in case we need something else from it in the future).

Fixes #86.