### PR TITLE
Moved TableSchemaCache loading from Ferry.Start to Ferry.Initialize

### DIFF
--- a/ferry.go
+++ b/ferry.go
@@ -121,6 +121,7 @@ func (f *Ferry) NewBinlogStreamer() *BinlogStreamer {
 		MyServerId:   f.Config.MyServerId,
 		ErrorHandler: f.ErrorHandler,
 		Filter:       f.CopyFilter,
+		TableSchema:  f.Tables,
 	}
 }
 
@@ -351,8 +352,21 @@ func (f *Ferry) Initialize() (err error) {
 
 	if f.StateToResumeFrom == nil {
 		f.StateTracker = NewStateTracker(f.DataIterationConcurrency * 10)
+
+		// Loads the schema of the tables that are applicable.
+		// We need to do this at the beginning of the run as this is required
+		// in order to determine the PrimaryKey of each table as well as finding
+		// which value in the binlog event correspond to which field in the
+		// table.
+		metrics.Measure("LoadTables", nil, 1.0, func() {
+			f.Tables, err = LoadTables(f.SourceDB, f.TableFilter)
+		})
+		if err != nil {
+			return err
+		}
 	} else {
 		f.StateTracker = NewStateTrackerFromSerializedState(f.DataIterationConcurrency*10, f.StateToResumeFrom)
+		f.Tables = f.StateToResumeFrom.LastKnownTableSchemaCache
 	}
 
 	f.BinlogStreamer = f.NewBinlogStreamer()
@@ -417,25 +431,6 @@ func (f *Ferry) Start() error {
 	// is terminated with some rows copied but no binlog events are written.
 	// This guarentees that we are able to restart from a valid location.
 	f.StateTracker.CopyStage.UpdateLastProcessedBinlogPosition(pos)
-
-	// Loads the schema of the tables that are applicable.
-	// We need to do this at the beginning of the run as this is required
-	// in order to determine the PrimaryKey of each table as well as finding
-	// which value in the binlog event correspond to which field in the
-	// table.
-	if f.StateToResumeFrom != nil {
-		f.Tables = f.StateToResumeFrom.LastKnownTableSchemaCache
-	} else {
-		metrics.Measure("LoadTables", nil, 1.0, func() {
-			f.Tables, err = LoadTables(f.SourceDB, f.TableFilter)
-		})
-		if err != nil {
-			return err
-		}
-	}
-
-	// TODO(pushrax): handle changes to schema during copying and clean this up.
-	f.BinlogStreamer.TableSchema = f.Tables
 
 	// TODO: refactor the TableSchemaCache logic to remove this weird post initialize
 	//       set tables hack

--- a/iterative_verifier.go
+++ b/iterative_verifier.go
@@ -245,11 +245,6 @@ func (v *IterativeVerifier) VerifyBeforeCutover() error {
 	return err
 }
 
-func (v *IterativeVerifier) SetApplicableTableSchemaCache(t TableSchemaCache) {
-	v.Tables = t.AsSlice()
-	v.TableSchemaCache = t
-}
-
 func (v *IterativeVerifier) VerifyDuringCutover() (VerificationResult, error) {
 	v.logger.Info("starting verification during cutover")
 	v.verifyDuringCutoverStarted.Set(true)

--- a/sharding/test/trivial_integration_test.go
+++ b/sharding/test/trivial_integration_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func setupSingleTableDatabase(f *testhelpers.TestFerry) {
-	testhelpers.SeedInitialData(f.SourceDB, "gftest", "table1", 1000)
-	testhelpers.SeedInitialData(f.TargetDB, "gftest", "table1", 0)
+func setupSingleTableDatabase(f *testhelpers.TestFerry, sourceDB, targetDB *sql.DB) {
+	testhelpers.SeedInitialData(sourceDB, "gftest", "table1", 1000)
+	testhelpers.SeedInitialData(targetDB, "gftest", "table1", 0)
 
-	testhelpers.AddTenantID(f.SourceDB, "gftest", "table1", 3)
-	testhelpers.AddTenantID(f.TargetDB, "gftest", "table1", 3)
+	testhelpers.AddTenantID(sourceDB, "gftest", "table1", 3)
+	testhelpers.AddTenantID(targetDB, "gftest", "table1", 3)
 }
 
 func selectiveFerry(tenantId interface{}) *testhelpers.TestFerry {

--- a/test/go/types_integration_test.go
+++ b/test/go/types_integration_test.go
@@ -38,14 +38,14 @@ func addTypesToTable(db *sql.DB, dbName, tableName string) {
 	testhelpers.PanicIfError(err)
 }
 
-func setupMultiTypeTable(f *testhelpers.TestFerry) {
-	testhelpers.SeedInitialData(f.SourceDB, "gftest", "table1", 0)
-	testhelpers.SeedInitialData(f.TargetDB, "gftest", "table1", 0)
+func setupMultiTypeTable(f *testhelpers.TestFerry, sourceDB, targetDB *sql.DB) {
+	testhelpers.SeedInitialData(sourceDB, "gftest", "table1", 0)
+	testhelpers.SeedInitialData(targetDB, "gftest", "table1", 0)
 
-	addTypesToTable(f.SourceDB, "gftest", "table1")
-	addTypesToTable(f.TargetDB, "gftest", "table1")
+	addTypesToTable(sourceDB, "gftest", "table1")
+	addTypesToTable(targetDB, "gftest", "table1")
 
-	tx, err := f.SourceDB.Begin()
+	tx, err := sourceDB.Begin()
 	testhelpers.PanicIfError(err)
 
 	for i := 0; i < 100; i++ {
@@ -69,17 +69,17 @@ func setupMultiTypeTable(f *testhelpers.TestFerry) {
 	testhelpers.PanicIfError(tx.Commit())
 }
 
-func setupFixedPointDecimalTypeTable(f *testhelpers.TestFerry) {
-	testhelpers.SeedInitialData(f.SourceDB, "gftest", "table1", 0)
-	testhelpers.SeedInitialData(f.TargetDB, "gftest", "table1", 0)
+func setupFixedPointDecimalTypeTable(f *testhelpers.TestFerry, sourceDB, targetDB *sql.DB) {
+	testhelpers.SeedInitialData(sourceDB, "gftest", "table1", 0)
+	testhelpers.SeedInitialData(targetDB, "gftest", "table1", 0)
 
 	query := "ALTER TABLE gftest.table1 " +
 		"ADD decimal_col DECIMAL(18, 14)"
 
-	_, err := f.SourceDB.Exec(query)
+	_, err := sourceDB.Exec(query)
 	testhelpers.PanicIfError(err)
 
-	_, err = f.TargetDB.Exec(query)
+	_, err = targetDB.Exec(query)
 	testhelpers.PanicIfError(err)
 }
 
@@ -107,8 +107,8 @@ func TestCopyDataWithFixedPointDecimalTypes(t *testing.T) {
 		T:           t,
 		SetupAction: setupFixedPointDecimalTypeTable,
 		DataWriter:  nil,
-		AfterRowCopyIsComplete: func(f *testhelpers.TestFerry) {
-			_, err := f.SourceDB.Exec("INSERT INTO gftest.table1 (id, decimal_col) values (null,-96.78850375986021)")
+		AfterRowCopyIsComplete: func(f *testhelpers.TestFerry, sourceDB, targetDB *sql.DB) {
+			_, err := sourceDB.Exec("INSERT INTO gftest.table1 (id, decimal_col) values (null,-96.78850375986021)")
 			testhelpers.PanicIfError(err)
 		},
 		Ferry: testhelpers.NewTestFerry(),

--- a/verifier.go
+++ b/verifier.go
@@ -59,12 +59,6 @@ type Verifier interface {
 	// verification.
 	VerifyDuringCutover() (VerificationResult, error)
 
-	// The Ferry will use this method to tell the verifier what to check.
-	//
-	// TODO: this will be removed once we refactor how the TableSchemaCache is
-	// handled.
-	SetApplicableTableSchemaCache(TableSchemaCache)
-
 	// Start the verifier in the background during the cutover phase.
 	// Traditionally, this is called from within the ControlServer.
 	//
@@ -113,10 +107,6 @@ type ChecksumTableVerifier struct {
 func (v *ChecksumTableVerifier) VerifyBeforeCutover() error {
 	// All verification occurs in cutover for this verifier.
 	return nil
-}
-
-func (v *ChecksumTableVerifier) SetApplicableTableSchemaCache(t TableSchemaCache) {
-	v.Tables = t.AsSlice()
 }
 
 func (v *ChecksumTableVerifier) VerifyDuringCutover() (VerificationResult, error) {


### PR DESCRIPTION
We want to do this because having the TableSchemaCache be first loaded in Ferry.Start means we have to then set the instance variables of BinlogStreamer and the verifiers after it is loaded. This effectively means the initializing of the BinlogStreamer and verifiers are split between Initialize and Start, an ugly situation.

This is a surprisingly complicated task, as there is a dependency within the tests: 

1. The tests uses Ferry.SourceDB to seed the database.
2. Ferry.SourceDB is created in Ferry.Initialize()
3. Once f.Tables is populated during Ferry.Initialize(), it means all the tests will see an empty table schema cache.
4. Seeing an empty table schema cache will cause failures.

Instead, what we have to do is to create separate sql.DB instances for the tests to connect to the source and target db without using Ferry. All the seeding logic can thus be moved prior to Ferry.Initialize. However, this results in a rather large PR (mostly one line changing ferry.SourceDB -> testSuite.SourceDB)