### PR TITLE
Retry acquisition of cutover lock on error

### DIFF
--- a/sharding/config.go
+++ b/sharding/config.go
@@ -26,4 +26,22 @@ type Config struct {
 	PrimaryKeyTables []string
 
 	Throttle *ghostferry.LagThrottlerConfig
+
+	// These two values configure the amount of times Ferry should attempt to
+	// retry acquiring the cutover lock, and for how long the Ferry should wait
+	// before attempting another lock acquisition
+	MaxCutoverRetries       int
+	CutoverRetryWaitSeconds int
+}
+
+func (c *Config) ValidateConfig() error {
+	if c.MaxCutoverRetries == 0 {
+		c.MaxCutoverRetries = 1
+	}
+
+	if c.CutoverRetryWaitSeconds == 0 {
+		c.CutoverRetryWaitSeconds = 1
+	}
+
+	return c.Config.ValidateConfig()
 }


### PR DESCRIPTION
First step of https://github.com/Shopify/ghostferry/issues/101. 

With this change, the ShardingFerry will now attempt to retry acquiring the cutover lock a configurable number of times while also waiting a configurable number of seconds between each attempt. Later, we can add a "retry-after" header or similar to tell the ferry to wait a dynamic period of time.