### PR TITLE
Hook up interrupt/resume to copydb and sharding

### DIFF
--- a/config.go
+++ b/config.go
@@ -279,9 +279,9 @@ type Config struct {
 	AutomaticCutover bool
 
 	// This specifies whether or not Ferry.Run will handle SIGINT and SIGTERM
-	// by dumping the current state to stdout.
-	// This state can be used to resume Ghostferry.
-	DumpStateToStdoutOnSignal bool
+	// by dumping the current state to stdout and the error HTTP callback.
+	// The dumped state can be used to resume Ghostferry.
+	DumpStateOnSignal bool
 
 	// Config for the ControlServer
 	ServerBindAddr string

--- a/copydb/cmd/main.go
+++ b/copydb/cmd/main.go
@@ -121,9 +121,11 @@ func main() {
 		return
 	}
 
-	err = ferry.CreateDatabasesAndTables()
-	if err != nil {
-		errorAndExit(fmt.Sprintf("failed to create databases and tables: %v", err))
+	if resumeState == nil {
+		err = ferry.CreateDatabasesAndTables()
+		if err != nil {
+			errorAndExit(fmt.Sprintf("failed to create databases and tables: %v", err))
+		}
 	}
 
 	ferry.Run()

--- a/copydb/copydb.go
+++ b/copydb/copydb.go
@@ -2,11 +2,8 @@ package copydb
 
 import (
 	"fmt"
-	"os"
-	"os/signal"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/Shopify/ghostferry"
@@ -114,17 +111,6 @@ func (this *CopydbFerry) Run() {
 
 	// This is where you cutover from using the source database to
 	// using the target database.
-
-	// We have to listen to signals because the Ghostferry builtin signal handler
-	// has quit but this process is still alive
-	go func() {
-		c := make(chan os.Signal, 1)
-		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
-
-		<-c
-		os.Exit(0)
-	}()
-
 	logrus.Info("ghostferry main operations has terminated but the control server remains online")
 	logrus.Info("press CTRL+C or send an interrupt to stop the control server and end this process")
 

--- a/error_handler.go
+++ b/error_handler.go
@@ -43,6 +43,7 @@ func (this *PanicErrorHandler) ReportError(from string, err error) {
 		errorData := make(map[string]string)
 		errorData["ErrFrom"] = from
 		errorData["ErrMessage"] = err.Error()
+		errorData["StateDump"] = stateJSON
 
 		errorDataBytes, jsonErr := json.MarshalIndent(errorData, "", "  ")
 		if jsonErr != nil {

--- a/examples/copydb/conf.json
+++ b/examples/copydb/conf.json
@@ -29,5 +29,7 @@
     "Blacklist": ["schema_migrations"]
   },
 
+  "DumpStateOnSignal": true,
+
   "VerifierType": "ChecksumTable"
 }

--- a/ferry.go
+++ b/ferry.go
@@ -476,20 +476,17 @@ func (f *Ferry) Run() {
 	}()
 
 	if f.DumpStateOnSignal {
-		supportingServicesWg.Add(1)
-
 		go func() {
-			defer supportingServicesWg.Done()
-
 			c := make(chan os.Signal, 1)
 			signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
 
-			select {
-			case <-ctx.Done():
-				f.logger.Debug("shutting down signal monitoring goroutine")
-				return
-			case s := <-c:
+			s := <-c
+			if ctx.Err() == nil {
+				// Ghostferry is still running
 				f.ErrorHandler.Fatal("user", fmt.Errorf("signal received: %v", s.String()))
+			} else {
+				// shutdown() has been called and Ghostferry is done.
+				os.Exit(0)
 			}
 		}()
 

--- a/ferry.go
+++ b/ferry.go
@@ -475,7 +475,7 @@ func (f *Ferry) Run() {
 		handleError("throttler", f.Throttler.Run(ctx))
 	}()
 
-	if f.DumpStateToStdoutOnSignal {
+	if f.DumpStateOnSignal {
 		supportingServicesWg.Add(1)
 
 		go func() {

--- a/sharding/test/callbacks_test.go
+++ b/sharding/test/callbacks_test.go
@@ -69,12 +69,12 @@ func (t *CallbacksTestSuite) TestFailsRunOnPanicError() {
 
 		resp := t.requestMap(r)
 		errorData := make(map[string]string)
-		errorData["ErrFrom"] = "test_error"
-		errorData["ErrMessage"] = "test error"
-
-		errorDataBytes, jsonErr := json.MarshalIndent(errorData, "", "  ")
+		jsonErr := json.Unmarshal([]byte(resp["Payload"]), &errorData)
 		t.Require().Nil(jsonErr)
-		t.Require().Equal(string(errorDataBytes), resp["Payload"])
+
+		t.Require().Equal("test_error", errorData["ErrFrom"])
+		t.Require().Equal("test error", errorData["ErrMessage"])
+		t.Require().True(errorData["StateDump"] != "")
 
 		w.WriteHeader(http.StatusInternalServerError)
 	})

--- a/sharding/test/callbacks_test.go
+++ b/sharding/test/callbacks_test.go
@@ -74,7 +74,12 @@ func (t *CallbacksTestSuite) TestFailsRunOnPanicError() {
 
 		t.Require().Equal("test_error", errorData["ErrFrom"])
 		t.Require().Equal("test error", errorData["ErrMessage"])
-		t.Require().True(errorData["StateDump"] != "")
+
+		stateDump := &ghostferry.SerializableState{}
+		jsonErr = json.Unmarshal([]byte(errorData["StateDump"]), stateDump)
+		t.Require().Nil(jsonErr)
+		t.Require().NotNil(stateDump.CopyStage)
+		t.Require().True(len(stateDump.LastKnownTableSchemaCache) > 0)
 
 		w.WriteHeader(http.StatusInternalServerError)
 	})

--- a/test/lib/go/integrationferry.go
+++ b/test/lib/go/integrationferry.go
@@ -198,7 +198,7 @@ func NewStandardConfig() (*ghostferry.Config, error) {
 			TablesFunc: nil,
 		},
 
-		DumpStateToStdoutOnSignal: true,
+		DumpStateOnSignal: true,
 	}
 
 	resumeStateJSON, err := ioutil.ReadAll(os.Stdin)


### PR DESCRIPTION
A couple of minor things done in this PR:

- Added StateDump to the Error HTTP callback so it can be posted during the ghostferry-sharding usage.
- Changed the flag DumpStateToStdoutOnSignal to DumpStateOnSignal to reflect the fact that we dump the state to not just stdout but also via HTTP.
- Added the ability to pass in a state file to CopyDB.
- Also for CopyDB: Fix the SIGTERM/SIGINT going no where when Ferry.Run finishes but the control server is still up.

I'm doing the CopyDB changes because there's a big chance that we might need to use interrupt/resume with copydb in the next couple of weeks.