### PR TITLE
Updated public documentations on interrupt & resume

### DIFF
--- a/docs/source/copydbinprod.rst
+++ b/docs/source/copydbinprod.rst
@@ -51,6 +51,8 @@ to consider about this are:
 .. _`FULL image`: https://dev.mysql.com/doc/refman/5.7/en/replication-options-binary-log.html#sysvar_binlog_row_image
 .. _`ROW based replication`: https://dev.mysql.com/doc/refman/5.6/en/replication-options-binary-log.html#sysvar_binlog_format
 
+.. _prodtesting:
+
 Testing Ghostferry with Production Data
 ---------------------------------------
 
@@ -110,15 +112,15 @@ issues after the fact:
 Dealing with Errors and Restarting Runs
 ---------------------------------------
 
-It is possible for Ghostferry to encounter an error and exit. In these
-scenarios, the target will be left alone and Ghostferry will stop
-selecting/tailing data from the source database. For the time being, there is
-no support for resuming a run from a previously saved coordinate. See
-`<https://github.com/Shopify/ghostferry/issues/17>`_.
+It is possible for Ghostferry to encounter an unrecoverable error (such as a
+network partition with the database). In these scenarios, the target will be
+left alone as the Ghostferry process panics and quits. It may be possible to
+resume these runs using the experimental interrupt & resume feature. See
+:ref:`copydbinterruptresume`.
 
-Starting another Ghostferry run is perfectly fine. For copydb specifically, you
-need to drop the databases created by copydb on the target as it will try to
-recreate it.
+If the resume doesn't work, starting a brand new Ghostferry run is perfectly
+fine.  For copydb specifically, you need to drop the databases created by
+copydb on the target as it will try to recreate it.
 
 Configuration for ``ghostferry-copydb``
 ---------------------------------------

--- a/docs/source/copydbinterruptresume.rst
+++ b/docs/source/copydbinterruptresume.rst
@@ -1,0 +1,118 @@
+.. _copydbinterruptresume:
+
+============================================
+Interrupt and resuming ``ghostferry-copydb``
+============================================
+
+*Note that this is a new and experimental feature. Please ensure you test it
+thoroughly in your environment to ensure there are no data loss. See the bottom
+of this page for important information on caveats of using this feature.*
+
+To enable state dumps of Ghostferry on panic (and thus interrupt & resume), the
+configuration given to copydb must have the entry ``"DumpStateOnSignal":
+true``. Once this is configured, any time the process panics, which can be
+caused by both SIGTERM/SIGINT or due to an error within Ghostferry, the run
+state will be dumped to stdout with JSON. An example of this can be seen below:
+
+.. code-block:: json
+
+  {
+    "GhostferryVersion": "1.1.0+20190311205252+88a1c5c",
+    "LastKnownTableSchemaCache": {
+      "abc.table1": {
+        "Schema": "abc",
+        "Name": "table1",
+        "Columns": [
+          {
+            "Name": "id",
+            "Type": 1,
+            "Collation": "",
+            "RawType": "bigint(20)",
+            "IsAuto": true,
+            "IsUnsigned": false,
+            "EnumValues": null,
+            "SetValues": null
+          },
+          {
+            "Name": "data",
+            "Type": 5,
+            "Collation": "utf8mb4_unicode_ci",
+            "RawType": "varchar(16)",
+            "IsAuto": false,
+            "IsUnsigned": false,
+            "EnumValues": null,
+            "SetValues": null
+          }
+        ],
+        "Indexes": [
+          {
+            "Name": "PRIMARY",
+            "Columns": [
+              "id"
+            ],
+            "Cardinality": [
+              1
+            ]
+          }
+        ],
+        "PKColumns": [
+          0
+        ],
+        "UnsignedColumns": null
+      }
+    },
+    "CurrentStage": "COPY",
+    "CopyStage": {
+      "LastProcessedBinlogPosition": {
+        "Name": "mysql-bin.000008",
+        "Pos": 193989
+      },
+      "LastSuccessfulPrimaryKeys": {
+        "abc.table1": 200
+      },
+      "CompletedTables": {}
+    },
+    "VerifierStage": null
+  }
+
+
+To resume, you first need to save this JSON into a file. Alternatively, you
+could pipe the stdout of ``ghostferry-copydb`` directly into a file via:
+
+.. code-block:: shell-session
+
+  $ ghostferry-copydb -verbose conf.json >state-dump.json 2>ghostferry.log
+
+Theoretically, ``ghostferry-copydb`` should write only the state dump json into
+stdout and all logs in stderr. However, check the files to make sure this is
+true. If not, file a bug report.
+
+To resume, pass ``state-dump.json`` as a flag back to ``ghostferry-copydb``:
+
+.. code-block:: shell-session
+
+  $ ghostferry-copydb -verbose -resumestate state-dump.json conf.json
+
+**Note: if you interrupt Ghostferry for a period of time longer than your
+binlog retention time, you will not be able to resume Ghostferry. Ensure that
+the binlog at the position recorded in the state dump is available when
+resuming Ghostferry.**
+
+Some other considerations/notes:
+
+* While Ghostferry will dump the state when it encounters an unrecoverable
+  error (such as a network issue to the databases), the only tested use case
+  for now is due to an interrupt with SIGTERM/SIGINT.
+
+  * Errored runs *should* be theoretically safe to resume, but this is not
+    validated in any form.  If you resume an errored run, it is recommended to
+    validate the correctness of the data using the CHECKSUM TABLE verifier.
+  * As the project develops, we want to validate the safety of resuming errored
+    runs.
+  * To test resuming errored runs further, see :ref:`prodtesting`.
+
+* Verifiers are not resumable, including the IterativeVerifier. This may change
+  in the future.
+* While we are confident that the algorithm to be correct, this is still a
+  highly experimental feature. USE AT YOUR OWN RISK.
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,6 +14,7 @@ Welcome to Ghostferry's documentation!
    technicaloverview
    tutorialcopydb
    copydbinprod
+   copydbinterruptresume
    verifiers
    howtousecustom
 

--- a/docs/source/tutorialcopydb.rst
+++ b/docs/source/tutorialcopydb.rst
@@ -299,3 +299,7 @@ the target database.
 
 The control server UI will stay up indefinitely, to stop it, simply press
 CTRL+C to interrupt the ghostferry-copydb process.
+
+To run Ghostferry in production, you should read through :ref:`copydbinprod`.
+If you need to interrupt and resume Ghostferry, you should also read through
+:ref:`copydbinterruptresume`.


### PR DESCRIPTION
Added some brief documentations on how to use interrupt and resume.

The website won't be updated until I merge it into master. I tried to build it for my fork, but Github pages builds are currently degraded due to some incident on their end. When it's back up, a preview of the docs can be seen at https://shuhaowu.github.io/ghostferry/interrupt-resume-docs/index.html