### PR TITLE
Made interrupt more explicit in ErrorHandler

### DIFF
--- a/ferry.go
+++ b/ferry.go
@@ -483,7 +483,7 @@ func (f *Ferry) Run() {
 			s := <-c
 			if ctx.Err() == nil {
 				// Ghostferry is still running
-				f.ErrorHandler.Fatal("user", fmt.Errorf("signal received: %v", s.String()))
+				f.ErrorHandler.Fatal("user_interrupt", fmt.Errorf("signal received: %v", s.String()))
 			} else {
 				// shutdown() has been called and Ghostferry is done.
 				os.Exit(0)


### PR DESCRIPTION
`user` is a pretty ambiguous ErrorHandler `from` tag. Changed to `user_interrupt` to make it more explicit, allowing us to more easily distinguish which Ghostferry run has been interrupted.