### PR TITLE
Fix state dump not showing due to concurrent Fatal

### DIFF
--- a/testhelpers/error_handler.go
+++ b/testhelpers/error_handler.go
@@ -4,8 +4,9 @@ type ErrorHandler struct {
 	LastError error
 }
 
-func (this *ErrorHandler) ReportError(from string, err error) {
+func (this *ErrorHandler) ReportError(from string, err error) bool {
 	this.Fatal(from, err)
+	return true
 }
 
 func (this *ErrorHandler) Fatal(from string, err error) {


### PR DESCRIPTION
If multiple Fatal calls to the ErrorHandler is received from multiple goroutines, the current implementation will only dump the state once using an atomic integer.  Subsequent calls will not dump the state anymore. After dumping the state, panic is called, ending the process.

However, since at some point in the past, the method Fatal was refactored such that it first calls ReportError, which dumps the states, then it panics. However, the atomic integer checking logic is within ReportError. This means, if there are multiple racing goroutines calling .Fatal, there is a chance that the state dump is either incomplete or non-existent.

This PR fixes this issue by restoring the behaviour prior to the Fatal method split by returning a boolean from ReportError, letting Fatal know if it should panic.