### PR TITLE
Resume Ghostferry without LastKnownSchemaCache

### DIFF
--- a/test/integration/interrupt_resume_test.rb
+++ b/test/integration/interrupt_resume_test.rb
@@ -28,6 +28,26 @@ class InterruptResumeTest < GhostferryTestCase
     assert_equal last_successful_id, dumped_state["CopyStage"]["LastSuccessfulPrimaryKeys"]["#{DEFAULT_DB}.#{DEFAULT_TABLE}"]
   end
 
+  def test_interrupt_and_resume_without_last_known_schema_cache
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+
+    # Writes one batch
+    ghostferry.on_status(Ghostferry::Status::AFTER_ROW_COPY) do
+      ghostferry.send_signal("TERM")
+    end
+
+    dumped_state = ghostferry.run_expecting_interrupt
+    assert_basic_fields_exist_in_dumped_state(dumped_state)
+    dumped_state["LastKnownTableSchemaCache"] = nil
+
+    # Resume Ghostferry with dumped state
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+
+    ghostferry.run(dumped_state)
+
+    assert_test_table_is_identical
+  end
+
   def test_interrupt_resume_with_writes_to_source
     # Start a ghostferry run expecting it to be interrupted.
     datawriter = new_source_datawriter


### PR DESCRIPTION
If LastKnownSchemaCache is nil, Ghostferry resumes by first loading the tables on the source database.

This is useful if one doesn't want to save the LastKnownSchemaCache, which could be many megabytes of data.