### PR TITLE
Moved error handler atomic check to Fatal

### DIFF
--- a/testhelpers/error_handler.go
+++ b/testhelpers/error_handler.go
@@ -4,9 +4,8 @@ type ErrorHandler struct {
 	LastError error
 }
 
-func (this *ErrorHandler) ReportError(from string, err error) bool {
+func (this *ErrorHandler) ReportError(from string, err error) {
 	this.Fatal(from, err)
-	return true
 }
 
 func (this *ErrorHandler) Fatal(from string, err error) {


### PR DESCRIPTION
Follow up to #106: moved atomic check from `ReportError` to `Fatal` to avoid returning a boolean on `ReportError`.