### PR TITLE
Optional state dumping to stdout

### DIFF
--- a/ferry.go
+++ b/ferry.go
@@ -357,7 +357,8 @@ func (f *Ferry) Initialize() (err error) {
 	// Initializing the necessary components of Ghostferry.
 	if f.ErrorHandler == nil {
 		f.ErrorHandler = &PanicErrorHandler{
-			Ferry: f,
+			Ferry:             f,
+			DumpStateToStdout: true,
 		}
 	}
 

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -64,8 +64,9 @@ func NewFerry(config *Config) (*ShardingFerry, error) {
 	logger := logrus.WithField("tag", "sharding")
 
 	ferry.ErrorHandler = &ghostferry.PanicErrorHandler{
-		Ferry:         ferry,
-		ErrorCallback: config.ErrorCallback,
+		Ferry:             ferry,
+		ErrorCallback:     config.ErrorCallback,
+		DumpStateToStdout: false,
 	}
 
 	return &ShardingFerry{


### PR DESCRIPTION
Since the state dump can be very noisy due to large schema caches, this commit adds an option to not dump it into stdout. This should help with any downstream logging system being clogged up by the dump into stdout.

The default has been changed such that:

- Ghostferry library: will dump to stdout if ErrorHandler is not specified
- Ghostferry-copydb: will dump to stdout
- Ghostferry-sharding: will NOT dump to stdout

Note: PanicErrorHandler.ErrorCallback will always receive the state and this remains unchanged.