### PR TITLE
Use a custom TableSchema struct

### DIFF
--- a/batch_writer.go
+++ b/batch_writer.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/siddontang/go-mysql/schema"
 	"github.com/sirupsen/logrus"
 )
 
@@ -55,7 +54,7 @@ func (w *BatchWriter) WriteRowBatch(batch *RowBatch) error {
 			table = targetTableName
 		}
 
-		query, args, err := batch.AsSQLQuery(&schema.Table{Schema: db, Name: table})
+		query, args, err := batch.AsSQLQuery(db, table)
 		if err != nil {
 			return fmt.Errorf("during generating sql query at pk %v -> %v: %v", startPkpos, endPkpos, err)
 		}

--- a/binlog_writer.go
+++ b/binlog_writer.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/siddontang/go-mysql/schema"
 	"github.com/sirupsen/logrus"
 )
 
@@ -91,7 +90,7 @@ func (b *BinlogWriter) writeEvents(events []DMLEvent) error {
 			eventTableName = targetTableName
 		}
 
-		sql, err := ev.AsSQLString(&schema.Table{Schema: eventDatabaseName, Name: eventTableName})
+		sql, err := ev.AsSQLString(eventDatabaseName, eventTableName)
 		if err != nil {
 			return fmt.Errorf("generating sql query at pos %v: %v", ev.BinlogPosition(), err)
 		}

--- a/copydb/filter.go
+++ b/copydb/filter.go
@@ -1,8 +1,6 @@
 package copydb
 
-import (
-	"github.com/siddontang/go-mysql/schema"
-)
+import "github.com/Shopify/ghostferry"
 
 type StaticTableFilter struct {
 	Dbs            []string
@@ -64,8 +62,8 @@ func (s *StaticTableFilter) ApplicableDatabases(dbs []string) ([]string, error) 
 	return applicableDbs, nil
 }
 
-func (s *StaticTableFilter) ApplicableTables(tables []*schema.Table) ([]*schema.Table, error) {
-	applicableTables := make([]*schema.Table, 0, len(tables))
+func (s *StaticTableFilter) ApplicableTables(tables []*ghostferry.TableSchema) ([]*ghostferry.TableSchema, error) {
+	applicableTables := make([]*ghostferry.TableSchema, 0, len(tables))
 
 	for _, tableSchema := range tables {
 		var applicable bool

--- a/copydb/test/filter_test.go
+++ b/copydb/test/filter_test.go
@@ -125,9 +125,11 @@ func (this *FilterTestSuite) assertBothFilters(expected []string, filter copydb.
 	this.Require().Nil(err)
 	this.Require().Equal(expected, actual)
 
-	var schemas []*sqlSchema.Table
+	var schemas []*ghostferry.TableSchema
 	for _, table := range list {
-		schemas = append(schemas, &sqlSchema.Table{Name: table})
+		schemas = append(schemas, &ghostferry.TableSchema{
+			Table: &sqlSchema.Table{Name: table},
+		})
 	}
 
 	filtered, err := tableFilter.ApplicableTables(schemas)

--- a/cursor.go
+++ b/cursor.go
@@ -34,13 +34,13 @@ type CursorConfig struct {
 	Throttler Throttler
 
 	ColumnsToSelect []string
-	BuildSelect     func([]string, *schema.Table, uint64, uint64) (squirrel.SelectBuilder, error)
+	BuildSelect     func([]string, *TableSchema, uint64, uint64) (squirrel.SelectBuilder, error)
 	BatchSize       uint64
 	ReadRetries     int
 }
 
 // returns a new Cursor with an embedded copy of itself
-func (c *CursorConfig) NewCursor(table *schema.Table, startPk, maxPk uint64) *Cursor {
+func (c *CursorConfig) NewCursor(table *TableSchema, startPk, maxPk uint64) *Cursor {
 	return &Cursor{
 		CursorConfig:             *c,
 		Table:                    table,
@@ -51,7 +51,7 @@ func (c *CursorConfig) NewCursor(table *schema.Table, startPk, maxPk uint64) *Cu
 }
 
 // returns a new Cursor with an embedded copy of itself
-func (c *CursorConfig) NewCursorWithoutRowLock(table *schema.Table, startPk, maxPk uint64) *Cursor {
+func (c *CursorConfig) NewCursorWithoutRowLock(table *TableSchema, startPk, maxPk uint64) *Cursor {
 	cursor := c.NewCursor(table, startPk, maxPk)
 	cursor.RowLock = false
 	return cursor
@@ -60,7 +60,7 @@ func (c *CursorConfig) NewCursorWithoutRowLock(table *schema.Table, startPk, max
 type Cursor struct {
 	CursorConfig
 
-	Table         *schema.Table
+	Table         *TableSchema
 	MaxPrimaryKey uint64
 	RowLock       bool
 
@@ -267,7 +267,7 @@ func ScanByteRow(rows *sql.Rows, columnCount int) ([][]byte, error) {
 	return values, err
 }
 
-func DefaultBuildSelect(columns []string, table *schema.Table, lastPk, batchSize uint64) squirrel.SelectBuilder {
+func DefaultBuildSelect(columns []string, table *TableSchema, lastPk, batchSize uint64) squirrel.SelectBuilder {
 	quotedPK := quoteField(table.GetPKColumn(0).Name)
 
 	return squirrel.Select(columns...).

--- a/data_iterator.go
+++ b/data_iterator.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"sync"
 
-	"github.com/siddontang/go-mysql/schema"
 	"github.com/sirupsen/logrus"
 )
 
@@ -24,7 +23,7 @@ type DataIterator struct {
 	logger         *logrus.Entry
 }
 
-func (d *DataIterator) Run(tables []*schema.Table) {
+func (d *DataIterator) Run(tables []*TableSchema) {
 	d.logger = logrus.WithField("tag", "data_iterator")
 	d.targetPKs = &sync.Map{}
 
@@ -56,7 +55,7 @@ func (d *DataIterator) Run(tables []*schema.Table) {
 		}
 	}
 
-	tablesQueue := make(chan *schema.Table)
+	tablesQueue := make(chan *TableSchema)
 	wg := &sync.WaitGroup{}
 	wg.Add(d.Concurrency)
 

--- a/ferry.go
+++ b/ferry.go
@@ -16,7 +16,6 @@ import (
 	"github.com/go-sql-driver/mysql"
 	siddontanglog "github.com/siddontang/go-log/log"
 	siddontangmysql "github.com/siddontang/go-mysql/mysql"
-	"github.com/siddontang/go-mysql/schema"
 	"github.com/sirupsen/logrus"
 )
 
@@ -556,7 +555,7 @@ func (f *Ferry) Run() {
 	supportingServicesWg.Wait()
 }
 
-func (f *Ferry) RunStandaloneDataCopy(tables []*schema.Table) error {
+func (f *Ferry) RunStandaloneDataCopy(tables []*TableSchema) error {
 	if len(tables) == 0 {
 		return nil
 	}

--- a/filter.go
+++ b/filter.go
@@ -2,7 +2,6 @@ package ghostferry
 
 import (
 	sq "github.com/Masterminds/squirrel"
-	"github.com/siddontang/go-mysql/schema"
 )
 
 // CopyFilter provides an interface for restricting the copying to a subset of
@@ -16,7 +15,7 @@ type CopyFilter interface {
 	// the columns to be selected, table being copied, the last primary key value
 	// from the previous batch, and the batch size. Call DefaultBuildSelect to
 	// generate the default query, which may be used as a starting point.
-	BuildSelect([]string, *schema.Table, uint64, uint64) (sq.SelectBuilder, error)
+	BuildSelect([]string, *TableSchema, uint64, uint64) (sq.SelectBuilder, error)
 
 	// ApplicableEvent is used to filter events for rows that have been
 	// filtered in ConstrainSelect. ApplicableEvent should return true if the
@@ -27,6 +26,6 @@ type CopyFilter interface {
 }
 
 type TableFilter interface {
-	ApplicableTables([]*schema.Table) ([]*schema.Table, error)
+	ApplicableTables([]*TableSchema) ([]*TableSchema, error)
 	ApplicableDatabases([]string) ([]string, error)
 }

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/Shopify/ghostferry"
-	"github.com/siddontang/go-mysql/schema"
 	"github.com/sirupsen/logrus"
 )
 
@@ -185,7 +184,7 @@ func (r *ShardingFerry) Run() {
 }
 
 func (r *ShardingFerry) deltaCopyJoinedTables() error {
-	tables := []*schema.Table{}
+	tables := []*ghostferry.TableSchema{}
 
 	for _, table := range r.Ferry.Tables {
 		if _, exists := r.config.JoinedTables[table.Name]; exists {
@@ -234,7 +233,7 @@ func (r *ShardingFerry) copyPrimaryKeyTables() error {
 		return err
 	}
 
-	tables := []*schema.Table{}
+	tables := []*ghostferry.TableSchema{}
 	for _, table := range sourceDbTables.AsSlice() {
 		if _, exists := pkTables[table.Name]; exists {
 			if len(table.PKColumns) != 1 {

--- a/sharding/test/copy_filter_test.go
+++ b/sharding/test/copy_filter_test.go
@@ -19,7 +19,7 @@ type CopyFilterTestSuite struct {
 	shardingValue int64
 	pkCursor      uint64
 
-	normalTable, joinedTable, pkTable *schema.Table
+	normalTable, joinedTable, pkTable *ghostferry.TableSchema
 
 	filter *sharding.ShardedCopyFilter
 }
@@ -28,31 +28,37 @@ func (t *CopyFilterTestSuite) SetupTest() {
 	t.shardingValue = int64(1)
 	t.pkCursor = uint64(12345)
 
-	t.normalTable = &schema.Table{
-		Schema:    "shard_1",
-		Name:      "normaltable",
-		Columns:   []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}, {Name: "data"}},
-		PKColumns: []int{0},
-		Indexes: []*schema.Index{
-			{Name: "unrelated_index", Columns: []string{"tenant_id", "data"}},
-			{Name: "less_good_sharding_index", Columns: []string{"tenant_id"}},
-			{Name: "good_sharding_index", Columns: []string{"tenant_id", "id"}},
-			{Name: "unrelated_index2", Columns: []string{"data"}},
+	t.normalTable = &ghostferry.TableSchema{
+		Table: &schema.Table{
+			Schema:    "shard_1",
+			Name:      "normaltable",
+			Columns:   []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}, {Name: "data"}},
+			PKColumns: []int{0},
+			Indexes: []*schema.Index{
+				{Name: "unrelated_index", Columns: []string{"tenant_id", "data"}},
+				{Name: "less_good_sharding_index", Columns: []string{"tenant_id"}},
+				{Name: "good_sharding_index", Columns: []string{"tenant_id", "id"}},
+				{Name: "unrelated_index2", Columns: []string{"data"}},
+			},
 		},
 	}
 
-	t.joinedTable = &schema.Table{
-		Schema:    "shard_1",
-		Name:      "joinedtable",
-		Columns:   []schema.TableColumn{{Name: "joined_pk"}},
-		PKColumns: []int{0},
+	t.joinedTable = &ghostferry.TableSchema{
+		Table: &schema.Table{
+			Schema:    "shard_1",
+			Name:      "joinedtable",
+			Columns:   []schema.TableColumn{{Name: "joined_pk"}},
+			PKColumns: []int{0},
+		},
 	}
 
-	t.pkTable = &schema.Table{
-		Schema:    "shard_1",
-		Name:      "pktable",
-		Columns:   []schema.TableColumn{{Name: "tenant_id"}},
-		PKColumns: []int{0},
+	t.pkTable = &ghostferry.TableSchema{
+		Table: &schema.Table{
+			Schema:    "shard_1",
+			Name:      "pktable",
+			Columns:   []schema.TableColumn{{Name: "tenant_id"}},
+			PKColumns: []int{0},
+		},
 	}
 
 	t.filter = &sharding.ShardedCopyFilter{

--- a/sharding/test/table_filter_test.go
+++ b/sharding/test/table_filter_test.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/Shopify/ghostferry"
 	"github.com/Shopify/ghostferry/sharding"
 	"github.com/siddontang/go-mysql/schema"
 	"github.com/stretchr/testify/assert"
@@ -32,19 +33,19 @@ func TestShardedTableFilterRejectsIgnoredTables(t *testing.T) {
 		},
 	}
 
-	tables := []*schema.Table{
-		{Schema: "shard_42", Name: "_table_name_new", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}},
-		{Schema: "shard_42", Name: "_table_name_old", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}},
-		{Schema: "shard_42", Name: "_table_name_gho", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}},
-		{Schema: "shard_42", Name: "lhma_1234_table_name", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}},
-		{Schema: "shard_42", Name: "lhmn_1234_table_name", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}},
-		{Schema: "shard_42", Name: "new", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}},
-		{Schema: "shard_42", Name: "old", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}},
-		{Schema: "shard_42", Name: "table_new", Columns: []schema.TableColumn{{Name: "foo"}, {Name: "tenant_id"}}},
-		{Schema: "shard_42", Name: "ghost", Columns: []schema.TableColumn{{Name: "foo"}, {Name: "tenant_id"}}},
-		{Schema: "shard_42", Name: "lhm_test", Columns: []schema.TableColumn{{Name: "foo"}, {Name: "tenant_id"}}},
-		{Schema: "shard_42", Name: "x_lhmn_table_name", Columns: []schema.TableColumn{{Name: "bar"}, {Name: "tenant_id"}}},
-		{Schema: "shard_42", Name: "table_name", Columns: []schema.TableColumn{{Name: "bar"}, {Name: "tenant_id"}}},
+	tables := []*ghostferry.TableSchema{
+		{&schema.Table{Schema: "shard_42", Name: "_table_name_new", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}, nil},
+		{&schema.Table{Schema: "shard_42", Name: "_table_name_old", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}, nil},
+		{&schema.Table{Schema: "shard_42", Name: "_table_name_gho", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}, nil},
+		{&schema.Table{Schema: "shard_42", Name: "lhma_1234_table_name", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}, nil},
+		{&schema.Table{Schema: "shard_42", Name: "lhmn_1234_table_name", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}, nil},
+		{&schema.Table{Schema: "shard_42", Name: "new", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}, nil},
+		{&schema.Table{Schema: "shard_42", Name: "old", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}, nil},
+		{&schema.Table{Schema: "shard_42", Name: "table_new", Columns: []schema.TableColumn{{Name: "foo"}, {Name: "tenant_id"}}}, nil},
+		{&schema.Table{Schema: "shard_42", Name: "ghost", Columns: []schema.TableColumn{{Name: "foo"}, {Name: "tenant_id"}}}, nil},
+		{&schema.Table{Schema: "shard_42", Name: "lhm_test", Columns: []schema.TableColumn{{Name: "foo"}, {Name: "tenant_id"}}}, nil},
+		{&schema.Table{Schema: "shard_42", Name: "x_lhmn_table_name", Columns: []schema.TableColumn{{Name: "bar"}, {Name: "tenant_id"}}}, nil},
+		{&schema.Table{Schema: "shard_42", Name: "table_name", Columns: []schema.TableColumn{{Name: "bar"}, {Name: "tenant_id"}}}, nil},
 	}
 
 	applicable, err := filter.ApplicableTables(tables)
@@ -55,11 +56,11 @@ func TestShardedTableFilterRejectsIgnoredTables(t *testing.T) {
 func TestShardedTableFilterSelectsTablesWithShardingKey(t *testing.T) {
 	filter := &sharding.ShardedTableFilter{SourceShard: "shard_42", ShardingKey: "tenant_id"}
 
-	tables := []*schema.Table{
-		{Schema: "shard_42", Name: "table1", Columns: []schema.TableColumn{{Name: "id"}}},
-		{Schema: "shard_42", Name: "table2", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}},
-		{Schema: "shard_42", Name: "table3", Columns: []schema.TableColumn{{Name: "foo"}, {Name: "tenant_id"}}},
-		{Schema: "shard_42", Name: "table4", Columns: []schema.TableColumn{{Name: "bar"}}},
+	tables := []*ghostferry.TableSchema{
+		{&schema.Table{Schema: "shard_42", Name: "table1", Columns: []schema.TableColumn{{Name: "id"}}}, nil},
+		{&schema.Table{Schema: "shard_42", Name: "table2", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}, nil},
+		{&schema.Table{Schema: "shard_42", Name: "table3", Columns: []schema.TableColumn{{Name: "foo"}, {Name: "tenant_id"}}}, nil},
+		{&schema.Table{Schema: "shard_42", Name: "table4", Columns: []schema.TableColumn{{Name: "bar"}}}, nil},
 	}
 
 	applicable, err := filter.ApplicableTables(tables)
@@ -74,9 +75,9 @@ func TestShardedTableFilterSelectsJoinedTables(t *testing.T) {
 		JoinedTables: map[string][]sharding.JoinTable{"table2": nil},
 	}
 
-	tables := []*schema.Table{
-		{Schema: "shard_42", Name: "table1", Columns: []schema.TableColumn{{Name: "id"}}},
-		{Schema: "shard_42", Name: "table2", Columns: []schema.TableColumn{{Name: "id"}}},
+	tables := []*ghostferry.TableSchema{
+		{&schema.Table{Schema: "shard_42", Name: "table1", Columns: []schema.TableColumn{{Name: "id"}}}, nil},
+		{&schema.Table{Schema: "shard_42", Name: "table2", Columns: []schema.TableColumn{{Name: "id"}}}, nil},
 	}
 
 	applicable, err := filter.ApplicableTables(tables)

--- a/test/go/data_iterator_test.go
+++ b/test/go/data_iterator_test.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/siddontang/go-mysql/schema"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/Shopify/ghostferry"
@@ -17,7 +16,7 @@ type DataIteratorTestSuite struct {
 
 	di           *ghostferry.DataIterator
 	wg           *sync.WaitGroup
-	tables       []*schema.Table
+	tables       []*ghostferry.TableSchema
 	receivedRows map[string][]ghostferry.RowData
 }
 

--- a/test/go/iterative_verifier_test.go
+++ b/test/go/iterative_verifier_test.go
@@ -18,7 +18,7 @@ type IterativeVerifierTestSuite struct {
 
 	verifier *ghostferry.IterativeVerifier
 	db       *sql.DB
-	table    *schema.Table
+	table    *ghostferry.TableSchema
 }
 
 func (t *IterativeVerifierTestSuite) SetupTest() {
@@ -393,12 +393,12 @@ func (t *ReverifyStoreTestSuite) SetupTest() {
 func (t *ReverifyStoreTestSuite) TestAddEntryIntoReverifyStoreWillDeduplicate() {
 	pk1 := uint64(100)
 	pk2 := uint64(101)
-	// different references to schema.Table shouldn't cause an issue.
-	t.store.Add(ghostferry.ReverifyEntry{Pk: pk1, Table: &schema.Table{Schema: "gftest", Name: "table1"}})
-	t.store.Add(ghostferry.ReverifyEntry{Pk: pk1, Table: &schema.Table{Schema: "gftest", Name: "table1"}})
-	t.store.Add(ghostferry.ReverifyEntry{Pk: pk1, Table: &schema.Table{Schema: "gftest", Name: "table1"}})
-	t.store.Add(ghostferry.ReverifyEntry{Pk: pk2, Table: &schema.Table{Schema: "gftest", Name: "table1"}})
-	t.store.Add(ghostferry.ReverifyEntry{Pk: pk2, Table: &schema.Table{Schema: "gftest", Name: "table1"}})
+	table1 := &ghostferry.TableSchema{Table: &schema.Table{Schema: "gftest", Name: "table1"}}
+	t.store.Add(ghostferry.ReverifyEntry{Pk: pk1, Table: table1})
+	t.store.Add(ghostferry.ReverifyEntry{Pk: pk1, Table: table1})
+	t.store.Add(ghostferry.ReverifyEntry{Pk: pk1, Table: table1})
+	t.store.Add(ghostferry.ReverifyEntry{Pk: pk2, Table: table1})
+	t.store.Add(ghostferry.ReverifyEntry{Pk: pk2, Table: table1})
 
 	t.Require().Equal(uint64(2), t.store.RowCount)
 	t.Require().Equal(1, len(t.store.MapStore))
@@ -413,14 +413,16 @@ func (t *ReverifyStoreTestSuite) TestAddEntryIntoReverifyStoreWillDeduplicate() 
 
 func (t *ReverifyStoreTestSuite) TestFlushAndBatchByTableWillCreateReverifyBatchesAndClearTheMapStore() {
 	expectedTable1Pks := make([]uint64, 0, 55)
+	table1 := &ghostferry.TableSchema{Table: &schema.Table{Schema: "gftest", Name: "table1"}}
+	table2 := &ghostferry.TableSchema{Table: &schema.Table{Schema: "gftest", Name: "table2"}}
 	for i := uint64(100); i < 155; i++ {
-		t.store.Add(ghostferry.ReverifyEntry{Pk: i, Table: &schema.Table{Schema: "gftest", Name: "table1"}})
+		t.store.Add(ghostferry.ReverifyEntry{Pk: i, Table: table1})
 		expectedTable1Pks = append(expectedTable1Pks, i)
 	}
 
 	expectedTable2Pks := make([]uint64, 0, 45)
 	for i := uint64(200); i < 245; i++ {
-		t.store.Add(ghostferry.ReverifyEntry{Pk: i, Table: &schema.Table{Schema: "gftest", Name: "table2"}})
+		t.store.Add(ghostferry.ReverifyEntry{Pk: i, Table: table2})
 		expectedTable2Pks = append(expectedTable2Pks, i)
 	}
 

--- a/test/go/table_schema_cache_test.go
+++ b/test/go/table_schema_cache_test.go
@@ -98,7 +98,7 @@ func (this *TableSchemaCacheTestSuite) TestAllTableNames() {
 func (this *TableSchemaCacheTestSuite) TestAllTableNamesEmpty() {
 	tableFilter := &testhelpers.TestTableFilter{
 		DbsFunc:    testhelpers.DbApplicabilityFilter([]string{testhelpers.TestSchemaName}),
-		TablesFunc: func(tables []*sqlSchema.Table) []*sqlSchema.Table { return []*sqlSchema.Table{} },
+		TablesFunc: func(tables []*ghostferry.TableSchema) []*ghostferry.TableSchema { return []*ghostferry.TableSchema{} },
 	}
 
 	tables, err := ghostferry.LoadTables(this.Ferry.SourceDB, tableFilter)
@@ -125,7 +125,7 @@ func (this *TableSchemaCacheTestSuite) TestAsSlice() {
 func (this *TableSchemaCacheTestSuite) TestAsSliceEmpty() {
 	tableFilter := &testhelpers.TestTableFilter{
 		DbsFunc:    testhelpers.DbApplicabilityFilter([]string{testhelpers.TestSchemaName}),
-		TablesFunc: func(tables []*sqlSchema.Table) []*sqlSchema.Table { return []*sqlSchema.Table{} },
+		TablesFunc: func(tables []*ghostferry.TableSchema) []*ghostferry.TableSchema { return []*ghostferry.TableSchema{} },
 	}
 
 	tables, err := ghostferry.LoadTables(this.Ferry.SourceDB, tableFilter)
@@ -137,12 +137,11 @@ func (this *TableSchemaCacheTestSuite) TestAsSliceEmpty() {
 }
 
 func (this *TableSchemaCacheTestSuite) TestQuotedTableName() {
-	table := &sqlSchema.Table{}
-	this.Require().Equal("``.``", ghostferry.QuotedTableName(table))
-
-	table = &sqlSchema.Table{
-		Schema: "schema",
-		Name:   "table",
+	table := &ghostferry.TableSchema{
+		Table: &sqlSchema.Table{
+			Schema: "schema",
+			Name:   "table",
+		},
 	}
 	this.Require().Equal("`schema`.`table`", ghostferry.QuotedTableName(table))
 }

--- a/test/go/verifier_test.go
+++ b/test/go/verifier_test.go
@@ -21,10 +21,12 @@ func (this *ChecksumTableVerifierTestSuite) SetupTest() {
 	this.GhostferryUnitTestSuite.SetupTest()
 
 	this.verifier = &ghostferry.ChecksumTableVerifier{
-		Tables: []*schema.Table{
-			&schema.Table{
-				Name:   testhelpers.TestTable1Name,
-				Schema: testhelpers.TestSchemaName,
+		Tables: []*ghostferry.TableSchema{
+			&ghostferry.TableSchema{
+				Table: &schema.Table{
+					Name:   testhelpers.TestTable1Name,
+					Schema: testhelpers.TestSchemaName,
+				},
 			},
 		},
 

--- a/testhelpers/test_table_filter.go
+++ b/testhelpers/test_table_filter.go
@@ -1,10 +1,10 @@
 package testhelpers
 
-import "github.com/siddontang/go-mysql/schema"
+import "github.com/Shopify/ghostferry"
 
 type TestTableFilter struct {
 	DbsFunc    func([]string) []string
-	TablesFunc func([]*schema.Table) []*schema.Table
+	TablesFunc func([]*ghostferry.TableSchema) []*ghostferry.TableSchema
 }
 
 func (t *TestTableFilter) ApplicableDatabases(dbs []string) ([]string, error) {
@@ -15,7 +15,7 @@ func (t *TestTableFilter) ApplicableDatabases(dbs []string) ([]string, error) {
 	return dbs, nil
 }
 
-func (t *TestTableFilter) ApplicableTables(tables []*schema.Table) ([]*schema.Table, error) {
+func (t *TestTableFilter) ApplicableTables(tables []*ghostferry.TableSchema) ([]*ghostferry.TableSchema, error) {
 	if t.TablesFunc != nil {
 		return t.TablesFunc(tables), nil
 	}

--- a/verifier.go
+++ b/verifier.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/siddontang/go-mysql/schema"
 	"github.com/sirupsen/logrus"
 )
 
@@ -89,7 +88,7 @@ type Verifier interface {
 }
 
 type ChecksumTableVerifier struct {
-	Tables           []*schema.Table
+	Tables           []*TableSchema
 	DatabaseRewrites map[string]string
 	TableRewrites    map[string]string
 	SourceDB         *sql.DB


### PR DESCRIPTION
Instead of relying on a third party struct for such a crucial piece of information, we use an extended version of this struct so we can store custom information on it. The main purpose is to store which columns are compressed to help with implementing the InlineVerifier.

DMLEvents and RowBatch also no longer hold their own copy of the table schema structure. They originally held their own copy as we thought about dealing with schema changes dynamically. Since our present plan is to pause when a schema change occurs and resume later, we don't need this anymore. This simplifies the code as all schema structures comes from the TableSchemaCache.

Lastly, RowBatch.AsSQLQuery and DMLEvent.AsSQLString have been changed such that they take the schema and table name as string arguments instead of the *schema.Table struct.