### PR TITLE
Report Ghostferry internal progress to a HTTP endpoint

### DIFF
--- a/config.go
+++ b/config.go
@@ -287,6 +287,12 @@ type Config struct {
 	ServerBindAddr string
 	WebBasedir     string
 
+	// Report progress via an HTTP callback. The Payload field of the callback
+	// will be sent to the server as the CustomPayload field in the Progress
+	// struct The unit of ProgressReportFrequency is in milliseconds.
+	ProgressCallback        HTTPCallback
+	ProgressReportFrequency int
+
 	// The state to resume from as dumped by the PanicErrorHandler.
 	// If this is null, a new Ghostferry run will be started. Otherwise, the
 	// reconciliation process will start and Ghostferry will resume after that.

--- a/control_server.go
+++ b/control_server.go
@@ -83,7 +83,7 @@ func (this *ControlServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (this *ControlServer) HandleIndex(w http.ResponseWriter, r *http.Request) {
-	status := FetchStatus(this.F, this.Verifier)
+	status := FetchStatusDeprecated(this.F, this.Verifier)
 
 	err := this.templates.ExecuteTemplate(w, "index.html", status)
 	if err != nil {

--- a/data_iterator.go
+++ b/data_iterator.go
@@ -111,6 +111,10 @@ func (d *DataIterator) Run(tables []*TableSchema) {
 				}
 
 				logger.Debug("table iteration completed")
+
+				// Right now the BatchWriter.WriteRowBatch happens synchronously in
+				// this method. If it ever becomes async, this MarkTableAsCompleted
+				// call MUST be done in WriteRowBatch somehow.
 				d.StateTracker.MarkTableAsCompleted(table.String())
 			}
 		}()

--- a/http_callback.go
+++ b/http_callback.go
@@ -34,11 +34,11 @@ func postCallback(client *http.Client, uri string, body interface{}) error {
 	}
 
 	logger := logrus.WithFields(logrus.Fields{
-		"tag": "sharding-http",
+		"tag": "http-callback",
 		"uri": uri,
 	})
 
-	logger.Infof("sending callback")
+	logger.Debug("sending callback")
 
 	res, err := client.Post(uri, "application/json", &buf)
 	if err != nil {

--- a/iterative_verifier.go
+++ b/iterative_verifier.go
@@ -16,19 +16,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// A comparable and lightweight type that stores the schema and table name.
-type TableIdentifier struct {
-	SchemaName string
-	TableName  string
-}
-
-func NewTableIdentifierFromSchemaTable(table *TableSchema) TableIdentifier {
-	return TableIdentifier{
-		SchemaName: table.Schema,
-		TableName:  table.Name,
-	}
-}
-
 type ReverifyBatch struct {
 	Pks   []uint64
 	Table TableIdentifier

--- a/progress.go
+++ b/progress.go
@@ -1,0 +1,47 @@
+package ghostferry
+
+import (
+	"github.com/siddontang/go-mysql/mysql"
+)
+
+const (
+	TableActionWaiting   = "waiting"
+	TableActionCopying   = "copying"
+	TableActionCompleted = "completed"
+)
+
+type TableProgress struct {
+	LastSuccessfulPK uint64
+	TargetPK         uint64
+	CurrentAction    string // Possible values are defined via the constants TableAction*
+}
+
+type Progress struct {
+	// Possible values are defined in ferry.go
+	// Shows what the ferry is currently doing in one word.
+	CurrentState string
+
+	// The Payload field of the ProgressCallback config will be copied to here
+	// verbatim.
+	// Example usecase: you can be sending all the status to some aggregation
+	// server and you want some sort of custom identification with this field.
+	CustomPayload string
+
+	Tables                  map[string]TableProgress
+	LastSuccessfulBinlogPos mysql.Position
+	BinlogStreamerLag       float64 // seconds
+	Throttled               bool
+
+	// The behaviour of Ghostferry varies with respect to the VerifierType.
+	// For example: a long cutover is OK if
+	VerifierType string
+
+	// These are some variables that are only filled when CurrentState == done.
+	FinalBinlogPos mysql.Position
+
+	// A best estimate on the speed at which the copying is taking place. If
+	// there are large gaps in the PK space, this probably will be inaccurate.
+	PKsPerSecond uint64
+	ETA          float64 // seconds
+	TimeTaken    float64 // seconds
+}

--- a/status_deprecated.go
+++ b/status_deprecated.go
@@ -10,7 +10,7 @@ import (
 )
 
 // NOTE: This file is only used for the ControlServer for now.
-// TODO: merge this back with the Status object.
+// TODO: eventually merge this into the ControlServer and use the Progress struct.
 
 type TableStatusDeprecated struct {
 	TableName        string

--- a/status_deprecated.go
+++ b/status_deprecated.go
@@ -9,7 +9,10 @@ import (
 	"github.com/siddontang/go-mysql/mysql"
 )
 
-type TableStatus struct {
+// NOTE: This file is only used for the ControlServer for now.
+// TODO: merge this back with the Status object.
+
+type TableStatusDeprecated struct {
 	TableName        string
 	PrimaryKeyName   string
 	Status           string
@@ -17,7 +20,7 @@ type TableStatus struct {
 	TargetPK         uint64
 }
 
-type Status struct {
+type StatusDeprecated struct {
 	GhostferryVersion string
 
 	SourceHostPort string
@@ -40,7 +43,7 @@ type Status struct {
 
 	CompletedTableCount int
 	TotalTableCount     int
-	TableStatuses       []*TableStatus
+	TableStatuses       []*TableStatusDeprecated
 	AllTableNames       []string
 	AllDatabaseNames    []string
 
@@ -52,8 +55,8 @@ type Status struct {
 	VerificationErr     error
 }
 
-func FetchStatus(f *Ferry, v Verifier) *Status {
-	status := &Status{}
+func FetchStatusDeprecated(f *Ferry, v Verifier) *StatusDeprecated {
+	status := &StatusDeprecated{}
 
 	status.GhostferryVersion = VersionString
 
@@ -78,7 +81,7 @@ func FetchStatus(f *Ferry, v Verifier) *Status {
 	status.Throttled = f.Throttler.Throttled()
 
 	// Getting all table statuses
-	status.TableStatuses = make([]*TableStatus, 0, len(f.Tables))
+	status.TableStatuses = make([]*TableStatusDeprecated, 0, len(f.Tables))
 
 	serializedState := f.StateTracker.Serialize(nil)
 
@@ -144,7 +147,7 @@ func FetchStatus(f *Ferry, v Verifier) *Status {
 	sort.Strings(waitingTableNames)
 
 	for _, tableName := range completedTableNames {
-		status.TableStatuses = append(status.TableStatuses, &TableStatus{
+		status.TableStatuses = append(status.TableStatuses, &TableStatusDeprecated{
 			TableName:        tableName,
 			PrimaryKeyName:   f.Tables[tableName].GetPKColumn(0).Name,
 			Status:           "complete",
@@ -154,7 +157,7 @@ func FetchStatus(f *Ferry, v Verifier) *Status {
 	}
 
 	for _, tableName := range copyingTableNames {
-		status.TableStatuses = append(status.TableStatuses, &TableStatus{
+		status.TableStatuses = append(status.TableStatuses, &TableStatusDeprecated{
 			TableName:        tableName,
 			PrimaryKeyName:   f.Tables[tableName].GetPKColumn(0).Name,
 			Status:           "copying",
@@ -164,7 +167,7 @@ func FetchStatus(f *Ferry, v Verifier) *Status {
 	}
 
 	for _, tableName := range waitingTableNames {
-		status.TableStatuses = append(status.TableStatuses, &TableStatus{
+		status.TableStatuses = append(status.TableStatuses, &TableStatusDeprecated{
 			TableName:        tableName,
 			PrimaryKeyName:   f.Tables[tableName].GetPKColumn(0).Name,
 			Status:           "waiting",

--- a/table_schema_cache.go
+++ b/table_schema_cache.go
@@ -16,6 +16,19 @@ var ignoredDatabases = map[string]bool{
 	"sys":                true,
 }
 
+// A comparable and lightweight type that stores the schema and table name.
+type TableIdentifier struct {
+	SchemaName string
+	TableName  string
+}
+
+func NewTableIdentifierFromSchemaTable(table *TableSchema) TableIdentifier {
+	return TableIdentifier{
+		SchemaName: table.Schema,
+		TableName:  table.Name,
+	}
+}
+
 // This is a wrapper on schema.Table with some custom information we need.
 type TableSchema struct {
 	*schema.Table

--- a/test/helpers/db_helper.rb
+++ b/test/helpers/db_helper.rb
@@ -108,7 +108,7 @@ module DbHelper
     # Create some holes in the data.
     delete_statement = source_db.prepare("DELETE FROM #{full_table_name(DEFAULT_DB, DEFAULT_TABLE)} WHERE id = ?")
     140.times do
-      delete_statement.execute(Random.rand(max_id) + 1)
+      delete_statement.execute(Random.rand(max_id))
     end
 
     # Setup the target database with no data but the correct schema.

--- a/test/integration/callbacks_test.rb
+++ b/test/integration/callbacks_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class CallbacksTest < GhostferryTestCase
+  def test_progress_callback
+    seed_simple_database_with_single_table
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+    progress = []
+    ghostferry.on_callback("progress") do |progress_data|
+      progress << progress_data
+    end
+
+    ghostferry.run
+
+    assert progress.length >= 1
+
+    assert_equal "done", progress.last["CurrentState"]
+
+    assert_equal 1111, progress.last["Tables"]["gftest.test_table_1"]["LastSuccessfulPK"]
+    assert_equal 1111, progress.last["Tables"]["gftest.test_table_1"]["TargetPK"]
+    assert_equal "completed", progress.last["Tables"]["gftest.test_table_1"]["CurrentAction"]
+
+    refute progress.last["LastSuccessfulBinlogPos"]["Name"].nil?
+    refute progress.last["LastSuccessfulBinlogPos"]["Pos"].nil?
+    assert progress.last["BinlogStreamerLag"] > 0
+    assert_equal progress.last["LastSuccessfulBinlogPos"], progress.last["FinalBinlogPos"]
+
+    assert_equal false, progress.last["Throttled"]
+
+    refute progress.last["PKsPerSecond"].nil?
+    refute progress.last["ETA"].nil?
+    assert progress.last["TimeTaken"] > 0
+  end
+end

--- a/test/lib/go/integrationferry.go
+++ b/test/lib/go/integrationferry.go
@@ -201,6 +201,16 @@ func NewStandardConfig() (*ghostferry.Config, error) {
 		DumpStateOnSignal: true,
 	}
 
+	integrationPort := os.Getenv(portEnvName)
+	if integrationPort == "" {
+		return nil, fmt.Errorf("environment variable %s must be specified", portEnvName)
+	}
+
+	config.ProgressCallback = ghostferry.HTTPCallback{
+		URI: fmt.Sprintf("http://localhost:%s/callbacks/progress", integrationPort),
+	}
+	config.ProgressReportFrequency = 500
+
 	resumeStateJSON, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR allows progress to be reported to an HTTP endpoint periodically so an Ghostferry management software can display more detailed information about a move.

The data looks like this:

```
{
    "CurrentState"=>"done", 
    "CustomPayload"=>"", 
    "Tables"=>{
        "gftest.test_table_1"=>{"LastSuccessfulPK"=>1111, "TargetPK"=>1111, "CurrentAction"=>"completed"}
    }, 
    "LastSuccessfulBinlogPos"=>{"Name"=>"mysql-bin.000005", "Pos"=>31730235}, 
    "BinlogStreamerLag"=>0.100753822, 
    "Throttled"=>false,
    "VerifierType"=>"", 
    "FinalBinlogPos"=>{"Name"=>"mysql-bin.000005", "Pos"=>31730235},
    "PKsPerSecond"=>9400,
    "ETA"=>0, 
    "TimeTaken"=>0.996557813
}
```

This PR does not have detailed progress reporting for the IterativeVerifier (no detailed table information). The `CurrentState` field will be changed to `verify-before-cutover` when the IterativeVerifier is running so we're not completely in the dark. Since we are still on track to remove the IterativeVerifier, I did not bother to hook up the progress from the verifier as it will need a lot of work. 

Note on implementation: there was a `Status` struct in the code previously. However, the way it is structured was too coupled with the `ControlServer`. I don't want to untangle that right now so I created a brand new `Progress` struct. In the future, we should remove the `Status` struct and have the control server rely on the `Progress` struct directly. The `Status` struct is renamed as `StatusDeprecated` to reflect this future.