### PR TITLE
InlineVerifier for DataIterator/BatchWriter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ $(GOBIN):
 
 test:
 	@go version
-	go test ./test/go ./copydb/test ./sharding/test -p 1 -v
+	go test ./test/go ./copydb/test ./sharding/test -p 1 -v -count 1
 	bundle install && bundle exec rake test DEBUG=1 TESTOPTS="-v"
 
 clean:

--- a/batch_writer.go
+++ b/batch_writer.go
@@ -3,7 +3,6 @@ package ghostferry
 import (
 	"database/sql"
 	"fmt"
-	"sync"
 
 	"github.com/sirupsen/logrus"
 )
@@ -17,13 +16,12 @@ type BatchWriter struct {
 
 	WriteRetries int
 
-	mut        sync.RWMutex
-	statements map[string]*sql.Stmt
-	logger     *logrus.Entry
+	stmtCache *StmtCache
+	logger    *logrus.Entry
 }
 
 func (w *BatchWriter) Initialize() {
-	w.statements = make(map[string]*sql.Stmt)
+	w.stmtCache = NewStmtCache()
 	w.logger = logrus.WithField("tag", "batch_writer")
 }
 
@@ -59,9 +57,9 @@ func (w *BatchWriter) WriteRowBatch(batch *RowBatch) error {
 			return fmt.Errorf("during generating sql query at pk %v -> %v: %v", startPkpos, endPkpos, err)
 		}
 
-		stmt, err := w.stmtFor(query)
+		stmt, err := w.stmtCache.StmtFor(w.DB, query)
 		if err != nil {
-			return fmt.Errorf("during preparing query near pk %v -> %v (%s): %v", startPkpos, endPkpos, query, err)
+			return fmt.Errorf("during prepare query near pk %v -> %v (%s): %v", startPkpos, endPkpos, query, err)
 		}
 
 		_, err = stmt.Exec(args...)
@@ -77,35 +75,4 @@ func (w *BatchWriter) WriteRowBatch(batch *RowBatch) error {
 
 		return nil
 	})
-}
-
-func (w *BatchWriter) stmtFor(query string) (*sql.Stmt, error) {
-	stmt, exists := w.getStmt(query)
-	if !exists {
-		return w.newStmtFor(query)
-	}
-	return stmt, nil
-}
-
-func (w *BatchWriter) newStmtFor(query string) (*sql.Stmt, error) {
-	stmt, err := w.DB.Prepare(query)
-	if err != nil {
-		return nil, err
-	}
-
-	w.storeStmt(query, stmt)
-	return stmt, nil
-}
-
-func (w *BatchWriter) storeStmt(query string, stmt *sql.Stmt) {
-	w.mut.Lock()
-	defer w.mut.Unlock()
-	w.statements[query] = stmt
-}
-
-func (w *BatchWriter) getStmt(query string) (*sql.Stmt, bool) {
-	w.mut.RLock()
-	defer w.mut.RUnlock()
-	stmt, exists := w.statements[query]
-	return stmt, exists
 }

--- a/config.go
+++ b/config.go
@@ -200,17 +200,17 @@ func (c *IterativeVerifierConfig) Validate() error {
 type ColumnCompressionConfig map[string]map[string]map[string]string
 
 func (c ColumnCompressionConfig) CompressedColumnsFor(schemaName, tableName string) map[string]string {
-	t1, found := c[schemaName]
+	tableConfig, found := c[schemaName]
 	if !found {
 		return nil
 	}
 
-	t2, found := t1[tableName]
+	columnsConfig, found := tableConfig[tableName]
 	if !found {
 		return nil
 	}
 
-	return t2
+	return columnsConfig
 }
 
 type Config struct {
@@ -334,24 +334,23 @@ type Config struct {
 	// Only useful if VerifierType == Iterative.
 	// This specifies the configurations to the IterativeVerifier.
 	//
-	// This option is being in the processing of being deprecated.
+	// This option is in the process of being deprecated.
 	IterativeVerifierConfig IterativeVerifierConfig
 
 	// For old versions mysql<5.6.2, MariaDB<10.1.6 which has no related var
 	// Make sure you have binlog_row_image=FULL when turning on this
 	SkipBinlogRowImageCheck bool
 
-	// This config is necessary for a special case of Ghostferry:
+	// This config is necessary for inline verification for a special case of
+	// Ghostferry:
 	//
 	// - If you are copying a table where the data is already partially on the
 	//   target through some other means.
-	//   - In this case, for an applicable row: the PK on both the source and the
-	//     target are the same. INSERT IGNORE will simply skip copying that row.
-	//     This leaves the target data without modifications.
-	//   - While this is not a supported use case, careful examination of your
-	//     data may reveal that Ghostferry will not cause a data corruption.
-	//     This is left as an exercise for the reader.
-	// - In this case, the InlineVerifier will verify the data to be correct.
+	//   - Specifically, the PK of this row on both the source and the target are
+	//     the same. Thus, INSERT IGNORE will skip copying this row, leaving the
+	//     data on the target unchanged.
+	//   - If the data on the target is already identical to the source, then
+	//     verification will pass and all is well.
 	// - However, if this data is compressed with a non-determinstic algorithm
 	//   such as snappy, the compressed blob may not be equal even when the
 	//   uncompressed data is equal.

--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ import (
 const (
 	VerifierTypeChecksumTable  = "ChecksumTable"
 	VerifierTypeIterative      = "Iterative"
+	VerifierTypeInline         = "Inline"
 	VerifierTypeNoVerification = "NoVerification"
 )
 

--- a/copydb/test/copydb_test.go
+++ b/copydb/test/copydb_test.go
@@ -67,7 +67,7 @@ func (t *CopydbTestSuite) TearDownTest() {
 
 func (t *CopydbTestSuite) TestCreateDatabaseAndTableWithRewrites() {
 	var err error
-	t.copydbFerry.Ferry.Tables, err = ghostferry.LoadTables(t.ferry.SourceDB, t.copydbFerry.Ferry.TableFilter)
+	t.copydbFerry.Ferry.Tables, err = ghostferry.LoadTables(t.ferry.SourceDB, t.copydbFerry.Ferry.TableFilter, nil)
 	t.Require().Nil(err)
 
 	err = t.copydbFerry.CreateDatabasesAndTables()

--- a/copydb/test/filter_test.go
+++ b/copydb/test/filter_test.go
@@ -37,6 +37,7 @@ func (this *FilterTestSuite) TestLoadTablesWithWhitelist() {
 				Whitelist: []string{"test_table_2"},
 			},
 		),
+		nil,
 	)
 
 	this.Require().Nil(err)
@@ -60,6 +61,7 @@ func (this *FilterTestSuite) TestLoadTablesWithBlacklist() {
 				Blacklist: []string{"test_table_2"},
 			},
 		),
+		nil,
 	)
 
 	this.Require().Nil(err)

--- a/cursor.go
+++ b/cursor.go
@@ -33,10 +33,11 @@ type CursorConfig struct {
 	DB        *sql.DB
 	Throttler Throttler
 
-	ColumnsToSelect []string
-	BuildSelect     func([]string, *TableSchema, uint64, uint64) (squirrel.SelectBuilder, error)
-	BatchSize       uint64
-	ReadRetries     int
+	ColumnsToSelect   []string
+	BuildSelect       func([]string, *TableSchema, uint64, uint64) (squirrel.SelectBuilder, error)
+	BatchSize         uint64
+	ReadRetries       int
+	SelectFingerprint bool
 }
 
 // returns a new Cursor with an embedded copy of itself

--- a/ferry.go
+++ b/ferry.go
@@ -73,7 +73,8 @@ type Ferry struct {
 	// If VerifierType is specified and this is nil on Ferry initialization, a
 	// Verifier will be created by Initialize. If an IterativeVerifier is to be
 	// created, IterativeVerifierConfig will be used to create the verifier.
-	Verifier Verifier
+	Verifier       Verifier
+	inlineVerifier *InlineVerifier
 
 	Tables TableSchemaCache
 
@@ -158,8 +159,9 @@ func (f *Ferry) NewBatchWriter() *BatchWriter {
 	f.ensureInitialized()
 
 	batchWriter := &BatchWriter{
-		DB:           f.TargetDB,
-		StateTracker: f.StateTracker.CopyStage,
+		DB:             f.TargetDB,
+		InlineVerifier: f.inlineVerifier,
+		StateTracker:   f.StateTracker.CopyStage,
 
 		DatabaseRewrites: f.Config.DatabaseRewrites,
 		TableRewrites:    f.Config.TableRewrites,
@@ -407,10 +409,9 @@ func (f *Ferry) Initialize() (err error) {
 		f.Tables = f.StateToResumeFrom.LastKnownTableSchemaCache
 	}
 
+	// The iterative verifier needs the binlog streamer so this has to be first.
+	// Eventually this can be moved below the verifier initialization.
 	f.BinlogStreamer = f.NewBinlogStreamer()
-	f.BinlogWriter = f.NewBinlogWriter()
-	f.DataIterator = f.NewDataIterator()
-	f.BatchWriter = f.NewBatchWriter()
 
 	if f.Config.VerifierType != "" {
 		if f.Verifier != nil {
@@ -426,13 +427,27 @@ func (f *Ferry) Initialize() (err error) {
 		case VerifierTypeChecksumTable:
 			f.Verifier = f.NewChecksumTableVerifier()
 		case VerifierTypeInline:
-			f.Verifier = f.NewInlineVerifier()
+			// need a private copy as the BatchWriter and the Reverifier will
+			// need this.
+			//
+			// In the future, the inlineVerifier might be an "always on" component,
+			// so f.Verifier can be set to the checksum table verifier.
+			f.inlineVerifier = f.NewInlineVerifier()
+			f.Verifier = f.inlineVerifier
 		case VerifierTypeNoVerification:
 			// skip
 		default:
 			return fmt.Errorf("'%s' is not a known VerifierType", f.Config.VerifierType)
 		}
 	}
+
+	// TODO: evaluate if this is the best strategy. Maybe we should always
+	// initialize the InlineVerifier even now.
+	// Since the InlineVerifier is passed to some components, the components are
+	// initialized after the verifiers.
+	f.BinlogWriter = f.NewBinlogWriter()
+	f.DataIterator = f.NewDataIterator()
+	f.BatchWriter = f.NewBatchWriter()
 
 	f.logger.Info("ferry initialized")
 	return nil

--- a/ferry.go
+++ b/ferry.go
@@ -384,7 +384,7 @@ func (f *Ferry) Initialize() (err error) {
 	// changed.
 	if f.StateToResumeFrom == nil || f.StateToResumeFrom.LastKnownTableSchemaCache == nil {
 		metrics.Measure("LoadTables", nil, 1.0, func() {
-			f.Tables, err = LoadTables(f.SourceDB, f.TableFilter)
+			f.Tables, err = LoadTables(f.SourceDB, f.TableFilter, f.ColumnCompressionConfig)
 		})
 		if err != nil {
 			return err

--- a/ferry.go
+++ b/ferry.go
@@ -90,17 +90,17 @@ func (f *Ferry) NewDataIterator() *DataIterator {
 	f.ensureInitialized()
 
 	dataIterator := &DataIterator{
-		DB:          f.SourceDB,
-		Concurrency: f.Config.DataIterationConcurrency,
+		DB:                f.SourceDB,
+		Concurrency:       f.Config.DataIterationConcurrency,
+		SelectFingerprint: f.Config.VerifierType == VerifierTypeInline,
 
 		ErrorHandler: f.ErrorHandler,
 		CursorConfig: &CursorConfig{
 			DB:        f.SourceDB,
 			Throttler: f.Throttler,
 
-			BatchSize:         f.Config.DataIterationBatchSize,
-			ReadRetries:       f.Config.DBReadRetries,
-			SelectFingerprint: f.Config.VerifierType == VerifierTypeInline,
+			BatchSize:   f.Config.DataIterationBatchSize,
+			ReadRetries: f.Config.DBReadRetries,
 		},
 		StateTracker: f.StateTracker.CopyStage,
 	}

--- a/inline_verifier.go
+++ b/inline_verifier.go
@@ -1,0 +1,44 @@
+package ghostferry
+
+import (
+	"database/sql"
+
+	"github.com/sirupsen/logrus"
+)
+
+type InlineVerifier struct {
+	SourceDB *sql.DB
+	TargetDB *sql.DB
+
+	sourceStmtCache *StmtCache
+	targetStmtCache *StmtCache
+	logger          *logrus.Entry
+}
+
+func (v *InlineVerifier) VerifyBeforeCutover() error {
+	// TODO: Iterate until the reverify queue is small enough
+	return nil
+}
+
+func (v *InlineVerifier) VerifyDuringCutover() (VerificationResult, error) {
+	// TODO: verify everything within the reverify queue.
+	return VerificationResult{}, nil
+}
+
+func (v *InlineVerifier) StartInBackground() error {
+	// not needed?
+	return nil
+}
+
+func (v *InlineVerifier) Wait() {
+	// not needed?
+}
+
+func (v *InlineVerifier) Result() (VerificationResultAndStatus, error) {
+	// not implemented for now
+	return VerificationResultAndStatus{}, nil
+}
+
+func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetDb, targetTable string, sourceBatch *RowBatch) ([]uint64, error) {
+	return nil, nil
+}

--- a/inline_verifier.go
+++ b/inline_verifier.go
@@ -1,8 +1,13 @@
 package ghostferry
 
 import (
+	"bytes"
 	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
 
+	"github.com/golang/snappy"
 	"github.com/sirupsen/logrus"
 )
 
@@ -40,5 +45,179 @@ func (v *InlineVerifier) Result() (VerificationResultAndStatus, error) {
 }
 
 func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetDb, targetTable string, sourceBatch *RowBatch) ([]uint64, error) {
-	return nil, nil
+	table := sourceBatch.TableSchema()
+
+	fingerprintQuery := table.FingerprintQuery(targetDb, targetTable, sourceBatch.Size())
+	stmt, err := v.targetStmtCache.StmtFor(v.TargetDB, fingerprintQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	args := make([]interface{}, len(sourceBatch.Values()))
+	for i, row := range sourceBatch.Values() {
+		pk, err := row.GetUint64(sourceBatch.PkIndex())
+		if err != nil {
+			return nil, err
+		}
+
+		args[i] = pk
+	}
+
+	rows, err := tx.Stmt(stmt).Query(args...)
+	if err != nil {
+		return nil, err
+	}
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch target data
+	targetFingerprints := make(map[uint64][]byte)                // pk -> fingerprint
+	targetDecompressedData := make(map[uint64]map[string][]byte) // pk -> columnName -> compressedData
+
+	for rows.Next() {
+		rowData, err := ScanByteRow(rows, len(columns))
+		if err != nil {
+			return nil, err
+		}
+
+		pk, err := strconv.ParseUint(string(rowData[0]), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+
+		targetFingerprints[pk] = rowData[1]
+		targetDecompressedData[pk] = make(map[string][]byte)
+
+		for i := 2; i < len(columns); i++ {
+			targetDecompressedData[pk][columns[i]], err = v.DecompressData(table, columns[i], rowData[i])
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Fetch source data
+	sourceFingerprints := sourceBatch.Fingerprints()
+	sourceDecompressedData := make(map[uint64]map[string][]byte)
+
+	for _, rowData := range sourceBatch.Values() {
+		pk, err := rowData.GetUint64(sourceBatch.PkIndex())
+		if err != nil {
+			return nil, err
+		}
+
+		sourceDecompressedData[pk] = make(map[string][]byte)
+		for idx, col := range table.Columns {
+			var compressedData []byte
+			var ok bool
+			if _, ok = table.CompressedColumns[col.Name]; !ok {
+				continue
+			}
+
+			compressedData, ok = rowData[idx].([]byte)
+			if !ok {
+				return nil, fmt.Errorf("cannot convert column %v to []byte", col.Name)
+			}
+
+			sourceDecompressedData[pk][col.Name], err = v.DecompressData(table, col.Name, compressedData)
+		}
+	}
+
+	mismatches := v.CompareHashes(sourceFingerprints, targetFingerprints)
+	if len(mismatches) > 0 {
+		return mismatches, nil
+	}
+
+	mismatches = v.CompareDecompressedData(sourceDecompressedData, targetDecompressedData)
+	return mismatches, nil
+}
+
+func (v *InlineVerifier) DecompressData(table *TableSchema, column string, compressed []byte) ([]byte, error) {
+	var decompressed []byte
+	algorithm, isCompressed := table.CompressedColumns[column]
+	if !isCompressed {
+		return nil, fmt.Errorf("%v is not a compressed column", column)
+	}
+
+	switch strings.ToUpper(algorithm) {
+	case CompressionSnappy:
+		return snappy.Decode(decompressed, compressed)
+	default:
+		return nil, UnsupportedCompressionError{
+			table:     table.String(),
+			column:    column,
+			algorithm: algorithm,
+		}
+	}
+}
+
+func (v *InlineVerifier) CompareHashes(source, target map[uint64][]byte) []uint64 {
+	mismatchSet := map[uint64]struct{}{}
+
+	for pk, targetHash := range target {
+		sourceHash, exists := source[pk]
+		if !bytes.Equal(sourceHash, targetHash) || !exists {
+			mismatchSet[pk] = struct{}{}
+		}
+	}
+
+	for pk, sourceHash := range source {
+		targetHash, exists := target[pk]
+		if !bytes.Equal(sourceHash, targetHash) || !exists {
+			mismatchSet[pk] = struct{}{}
+		}
+	}
+
+	mismatches := make([]uint64, 0, len(mismatchSet))
+	for mismatch, _ := range mismatchSet {
+		mismatches = append(mismatches, mismatch)
+	}
+
+	return mismatches
+}
+
+func (v *InlineVerifier) CompareDecompressedData(source, target map[uint64]map[string][]byte) []uint64 {
+	mismatchSet := map[uint64]struct{}{}
+
+	for pk, targetDecompressedColumns := range target {
+		sourceDecompressedColumns, exists := source[pk]
+		if !exists {
+			mismatchSet[pk] = struct{}{}
+			continue
+		}
+
+		for colName, targetData := range targetDecompressedColumns {
+			sourceData, exists := sourceDecompressedColumns[colName]
+			if !exists || !bytes.Equal(sourceData, targetData) {
+				mismatchSet[pk] = struct{}{}
+				break // no need to compare other columns
+			}
+		}
+	}
+
+	for pk, sourceDecompressedColumns := range source {
+		targetDecompressedColumns, exists := target[pk]
+		if !exists {
+			mismatchSet[pk] = struct{}{}
+			continue
+		}
+
+		for colName, sourceData := range sourceDecompressedColumns {
+			targetData, exists := targetDecompressedColumns[colName]
+			if !exists || !bytes.Equal(sourceData, targetData) {
+				mismatchSet[pk] = struct{}{}
+				break
+			}
+		}
+	}
+
+	mismatches := make([]uint64, 0, len(mismatchSet))
+	for mismatch, _ := range mismatchSet {
+		mismatches = append(mismatches, mismatch)
+	}
+
+	return mismatches
 }

--- a/inline_verifier.go
+++ b/inline_verifier.go
@@ -48,22 +48,22 @@ func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetDb, targetTabl
 	table := sourceBatch.TableSchema()
 
 	fingerprintQuery := table.FingerprintQuery(targetDb, targetTable, sourceBatch.Size())
-	stmt, err := v.targetStmtCache.StmtFor(v.TargetDB, fingerprintQuery)
+	fingerprintStmt, err := v.targetStmtCache.StmtFor(v.TargetDB, fingerprintQuery)
 	if err != nil {
 		return nil, err
 	}
 
-	args := make([]interface{}, len(sourceBatch.Values()))
+	pks := make([]interface{}, len(sourceBatch.Values()))
 	for i, row := range sourceBatch.Values() {
 		pk, err := row.GetUint64(sourceBatch.PkIndex())
 		if err != nil {
 			return nil, err
 		}
 
-		args[i] = pk
+		pks[i] = pk
 	}
 
-	rows, err := tx.Stmt(stmt).Query(args...)
+	rows, err := tx.Stmt(fingerprintStmt).Query(pks...)
 	if err != nil {
 		return nil, err
 	}

--- a/inline_verifier.go
+++ b/inline_verifier.go
@@ -91,6 +91,9 @@ func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetDb, targetTabl
 		targetFingerprints[pk] = rowData[1]
 		targetDecompressedData[pk] = make(map[string][]byte)
 
+		// Note that the FingerprintQuery returns the columns: pk, fingerprint,
+		// compressedData1, compressedData2, ...
+		// If there are no compressed data, only 2 columns are returned.
 		for i := 2; i < len(columns); i++ {
 			targetDecompressedData[pk][columns[i]], err = v.DecompressData(table, columns[i], rowData[i])
 			if err != nil {

--- a/row_batch.go
+++ b/row_batch.go
@@ -5,9 +5,10 @@ import (
 )
 
 type RowBatch struct {
-	values  []RowData
-	pkIndex int
-	table   *TableSchema
+	values       []RowData
+	pkIndex      int
+	table        *TableSchema
+	fingerprints map[uint64][]byte
 }
 
 func NewRowBatch(table *TableSchema, values []RowData, pkIndex int) *RowBatch {
@@ -36,6 +37,10 @@ func (e *RowBatch) Size() int {
 
 func (e *RowBatch) TableSchema() *TableSchema {
 	return e.table
+}
+
+func (e *RowBatch) Fingerprints() map[uint64][]byte {
+	return e.fingerprints
 }
 
 func (e *RowBatch) AsSQLQuery(schemaName, tableName string) (string, []interface{}, error) {

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -228,7 +228,7 @@ func (r *ShardingFerry) copyPrimaryKeyTables() error {
 	r.config.TableFilter.(*ShardedTableFilter).PrimaryKeyTables = pkTables
 	r.config.CopyFilter.(*ShardedCopyFilter).PrimaryKeyTables = pkTables
 
-	sourceDbTables, err := ghostferry.LoadTables(r.Ferry.SourceDB, r.config.TableFilter)
+	sourceDbTables, err := ghostferry.LoadTables(r.Ferry.SourceDB, r.config.TableFilter, r.config.ColumnCompressionConfig)
 	if err != nil {
 		return err
 	}

--- a/sharding/test/table_filter_test.go
+++ b/sharding/test/table_filter_test.go
@@ -34,18 +34,18 @@ func TestShardedTableFilterRejectsIgnoredTables(t *testing.T) {
 	}
 
 	tables := []*ghostferry.TableSchema{
-		{&schema.Table{Schema: "shard_42", Name: "_table_name_new", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}, nil},
-		{&schema.Table{Schema: "shard_42", Name: "_table_name_old", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}, nil},
-		{&schema.Table{Schema: "shard_42", Name: "_table_name_gho", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}, nil},
-		{&schema.Table{Schema: "shard_42", Name: "lhma_1234_table_name", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}, nil},
-		{&schema.Table{Schema: "shard_42", Name: "lhmn_1234_table_name", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}, nil},
-		{&schema.Table{Schema: "shard_42", Name: "new", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}, nil},
-		{&schema.Table{Schema: "shard_42", Name: "old", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}, nil},
-		{&schema.Table{Schema: "shard_42", Name: "table_new", Columns: []schema.TableColumn{{Name: "foo"}, {Name: "tenant_id"}}}, nil},
-		{&schema.Table{Schema: "shard_42", Name: "ghost", Columns: []schema.TableColumn{{Name: "foo"}, {Name: "tenant_id"}}}, nil},
-		{&schema.Table{Schema: "shard_42", Name: "lhm_test", Columns: []schema.TableColumn{{Name: "foo"}, {Name: "tenant_id"}}}, nil},
-		{&schema.Table{Schema: "shard_42", Name: "x_lhmn_table_name", Columns: []schema.TableColumn{{Name: "bar"}, {Name: "tenant_id"}}}, nil},
-		{&schema.Table{Schema: "shard_42", Name: "table_name", Columns: []schema.TableColumn{{Name: "bar"}, {Name: "tenant_id"}}}, nil},
+		{Table: &schema.Table{Schema: "shard_42", Name: "_table_name_new", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}},
+		{Table: &schema.Table{Schema: "shard_42", Name: "_table_name_old", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}},
+		{Table: &schema.Table{Schema: "shard_42", Name: "_table_name_gho", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}},
+		{Table: &schema.Table{Schema: "shard_42", Name: "lhma_1234_table_name", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}},
+		{Table: &schema.Table{Schema: "shard_42", Name: "lhmn_1234_table_name", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}},
+		{Table: &schema.Table{Schema: "shard_42", Name: "new", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}},
+		{Table: &schema.Table{Schema: "shard_42", Name: "old", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}},
+		{Table: &schema.Table{Schema: "shard_42", Name: "table_new", Columns: []schema.TableColumn{{Name: "foo"}, {Name: "tenant_id"}}}},
+		{Table: &schema.Table{Schema: "shard_42", Name: "ghost", Columns: []schema.TableColumn{{Name: "foo"}, {Name: "tenant_id"}}}},
+		{Table: &schema.Table{Schema: "shard_42", Name: "lhm_test", Columns: []schema.TableColumn{{Name: "foo"}, {Name: "tenant_id"}}}},
+		{Table: &schema.Table{Schema: "shard_42", Name: "x_lhmn_table_name", Columns: []schema.TableColumn{{Name: "bar"}, {Name: "tenant_id"}}}},
+		{Table: &schema.Table{Schema: "shard_42", Name: "table_name", Columns: []schema.TableColumn{{Name: "bar"}, {Name: "tenant_id"}}}},
 	}
 
 	applicable, err := filter.ApplicableTables(tables)
@@ -57,10 +57,10 @@ func TestShardedTableFilterSelectsTablesWithShardingKey(t *testing.T) {
 	filter := &sharding.ShardedTableFilter{SourceShard: "shard_42", ShardingKey: "tenant_id"}
 
 	tables := []*ghostferry.TableSchema{
-		{&schema.Table{Schema: "shard_42", Name: "table1", Columns: []schema.TableColumn{{Name: "id"}}}, nil},
-		{&schema.Table{Schema: "shard_42", Name: "table2", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}, nil},
-		{&schema.Table{Schema: "shard_42", Name: "table3", Columns: []schema.TableColumn{{Name: "foo"}, {Name: "tenant_id"}}}, nil},
-		{&schema.Table{Schema: "shard_42", Name: "table4", Columns: []schema.TableColumn{{Name: "bar"}}}, nil},
+		{Table: &schema.Table{Schema: "shard_42", Name: "table1", Columns: []schema.TableColumn{{Name: "id"}}}},
+		{Table: &schema.Table{Schema: "shard_42", Name: "table2", Columns: []schema.TableColumn{{Name: "id"}, {Name: "tenant_id"}}}},
+		{Table: &schema.Table{Schema: "shard_42", Name: "table3", Columns: []schema.TableColumn{{Name: "foo"}, {Name: "tenant_id"}}}},
+		{Table: &schema.Table{Schema: "shard_42", Name: "table4", Columns: []schema.TableColumn{{Name: "bar"}}}},
 	}
 
 	applicable, err := filter.ApplicableTables(tables)
@@ -76,8 +76,8 @@ func TestShardedTableFilterSelectsJoinedTables(t *testing.T) {
 	}
 
 	tables := []*ghostferry.TableSchema{
-		{&schema.Table{Schema: "shard_42", Name: "table1", Columns: []schema.TableColumn{{Name: "id"}}}, nil},
-		{&schema.Table{Schema: "shard_42", Name: "table2", Columns: []schema.TableColumn{{Name: "id"}}}, nil},
+		{Table: &schema.Table{Schema: "shard_42", Name: "table1", Columns: []schema.TableColumn{{Name: "id"}}}},
+		{Table: &schema.Table{Schema: "shard_42", Name: "table2", Columns: []schema.TableColumn{{Name: "id"}}}},
 	}
 
 	applicable, err := filter.ApplicableTables(tables)

--- a/table_schema_cache.go
+++ b/table_schema_cache.go
@@ -71,7 +71,7 @@ func MaxPrimaryKeys(db *sql.DB, tables []*TableSchema, logger *logrus.Entry) (ma
 	return tablesWithData, emptyTables, nil
 }
 
-func LoadTables(db *sql.DB, tableFilter TableFilter) (TableSchemaCache, error) {
+func LoadTables(db *sql.DB, tableFilter TableFilter, columnCompressionConfig ColumnCompressionConfig) (TableSchemaCache, error) {
 	logger := logrus.WithField("tag", "table_schema_cache")
 
 	tableSchemaCache := make(TableSchemaCache)
@@ -108,8 +108,10 @@ func LoadTables(db *sql.DB, tableFilter TableFilter) (TableSchemaCache, error) {
 				tableLog.WithError(err).Error("cannot fetch table schema from source db")
 				return tableSchemaCache, err
 			}
+
 			tableSchemas = append(tableSchemas, &TableSchema{
-				Table: tableSchema,
+				Table:             tableSchema,
+				CompressedColumns: columnCompressionConfig.CompressedColumnsFor(dbname, table),
 			})
 		}
 

--- a/table_schema_cache.go
+++ b/table_schema_cache.go
@@ -54,7 +54,7 @@ func (t *TableSchema) FingerprintQuery(schemaName, tableName string, numRows int
 	columnsToSelect[1] = t.RowMd5Query()
 	i := 2
 	for columnName, _ := range t.CompressedColumns {
-		columnsToSelect[i] = columnName
+		columnsToSelect[i] = quoteField(columnName)
 		i += 1
 	}
 

--- a/test/go/binlog_streamer_test.go
+++ b/test/go/binlog_streamer_test.go
@@ -41,6 +41,7 @@ func (this *BinlogStreamerTestSuite) SetupTest() {
 			DbsFunc:    testhelpers.DbApplicabilityFilter([]string{testhelpers.TestSchemaName}),
 			TablesFunc: nil,
 		},
+		nil,
 	)
 	this.Require().Nil(err)
 

--- a/test/go/data_iterator_test.go
+++ b/test/go/data_iterator_test.go
@@ -34,7 +34,7 @@ func (this *DataIteratorTestSuite) SetupTest() {
 		TablesFunc: nil,
 	}
 
-	tables, err := ghostferry.LoadTables(sourceDb, tableFilter)
+	tables, err := ghostferry.LoadTables(sourceDb, tableFilter, nil)
 	this.Require().Nil(err)
 
 	this.tables = tables.AsSlice()

--- a/test/go/iterative_verifier_test.go
+++ b/test/go/iterative_verifier_test.go
@@ -369,7 +369,7 @@ func (t *IterativeVerifierTestSuite) reloadTables() {
 		TablesFunc: nil,
 	}
 
-	tables, err := ghostferry.LoadTables(t.db, tableFilter)
+	tables, err := ghostferry.LoadTables(t.db, tableFilter, nil)
 	t.Require().Nil(err)
 
 	t.Ferry.Tables = tables

--- a/test/go/table_schema_cache_test.go
+++ b/test/go/table_schema_cache_test.go
@@ -41,6 +41,7 @@ func (this *TableSchemaCacheTestSuite) TestLoadTablesWithoutFiltering() {
 	tables, err := ghostferry.LoadTables(
 		this.Ferry.SourceDB,
 		this.tableFilter,
+		nil,
 	)
 
 	this.Require().Nil(err)
@@ -67,7 +68,7 @@ func (this *TableSchemaCacheTestSuite) TestLoadTablesRejectTablesWithoutNumericP
 	_, err := this.Ferry.SourceDB.Exec(query)
 	this.Require().Nil(err)
 
-	_, err = ghostferry.LoadTables(this.Ferry.SourceDB, this.tableFilter)
+	_, err = ghostferry.LoadTables(this.Ferry.SourceDB, this.tableFilter, nil)
 
 	this.Require().NotNil(err)
 	this.Require().Contains(err.Error(), "non-numeric primary key")
@@ -79,14 +80,14 @@ func (this *TableSchemaCacheTestSuite) TestLoadTablesRejectTablesWithoutAnyPK() 
 	_, err := this.Ferry.SourceDB.Exec(query)
 	this.Require().Nil(err)
 
-	_, err = ghostferry.LoadTables(this.Ferry.SourceDB, this.tableFilter)
+	_, err = ghostferry.LoadTables(this.Ferry.SourceDB, this.tableFilter, nil)
 
 	this.Require().NotNil(err)
 	this.Require().Contains(err.Error(), "table test_table_4 has 0 primary key columns")
 }
 
 func (this *TableSchemaCacheTestSuite) TestAllTableNames() {
-	tables, err := ghostferry.LoadTables(this.Ferry.SourceDB, this.tableFilter)
+	tables, err := ghostferry.LoadTables(this.Ferry.SourceDB, this.tableFilter, nil)
 	this.Require().Nil(err)
 
 	tablesList := tables.AllTableNames()
@@ -101,7 +102,7 @@ func (this *TableSchemaCacheTestSuite) TestAllTableNamesEmpty() {
 		TablesFunc: func(tables []*ghostferry.TableSchema) []*ghostferry.TableSchema { return []*ghostferry.TableSchema{} },
 	}
 
-	tables, err := ghostferry.LoadTables(this.Ferry.SourceDB, tableFilter)
+	tables, err := ghostferry.LoadTables(this.Ferry.SourceDB, tableFilter, nil)
 
 	this.Require().Nil(err)
 	this.Require().Equal(ghostferry.TableSchemaCache{}, tables)
@@ -111,7 +112,7 @@ func (this *TableSchemaCacheTestSuite) TestAllTableNamesEmpty() {
 }
 
 func (this *TableSchemaCacheTestSuite) TestAsSlice() {
-	tables, err := ghostferry.LoadTables(this.Ferry.SourceDB, this.tableFilter)
+	tables, err := ghostferry.LoadTables(this.Ferry.SourceDB, this.tableFilter, nil)
 	this.Require().Nil(err)
 
 	tablesSlice := tables.AsSlice()
@@ -128,7 +129,7 @@ func (this *TableSchemaCacheTestSuite) TestAsSliceEmpty() {
 		TablesFunc: func(tables []*ghostferry.TableSchema) []*ghostferry.TableSchema { return []*ghostferry.TableSchema{} },
 	}
 
-	tables, err := ghostferry.LoadTables(this.Ferry.SourceDB, tableFilter)
+	tables, err := ghostferry.LoadTables(this.Ferry.SourceDB, tableFilter, nil)
 
 	this.Require().Nil(err)
 	this.Require().Equal(ghostferry.TableSchemaCache{}, tables)

--- a/test/go/table_schema_cache_test.go
+++ b/test/go/table_schema_cache_test.go
@@ -137,6 +137,29 @@ func (this *TableSchemaCacheTestSuite) TestAsSliceEmpty() {
 	this.Require().Nil(tables.AsSlice())
 }
 
+func (this *TableSchemaCacheTestSuite) TestFingerprintQuery() {
+	tables, err := ghostferry.LoadTables(this.Ferry.SourceDB, this.tableFilter, nil)
+	this.Require().Nil(err)
+
+	table := tables.AsSlice()[0]
+	query := table.FingerprintQuery("s", "t", 10)
+	this.Require().Equal("SELECT `id`,MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')),MD5(COALESCE(`data`, 'NULL')))) AS __ghostferry_row_md5 FROM `s`.`t` WHERE `id` IN (?,?,?,?,?,?,?,?,?,?)", query)
+
+	table = tables.AsSlice()[1]
+	table.CompressedColumns = map[string]string{"data": "SNAPPY"}
+	query = table.FingerprintQuery("s", "t", 10)
+	this.Require().Equal("SELECT `id`,MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')))) AS __ghostferry_row_md5,`data` FROM `s`.`t` WHERE `id` IN (?,?,?,?,?,?,?,?,?,?)", query)
+}
+
+func (this *TableSchemaCacheTestSuite) TestTableRowMd5Query() {
+	tables, err := ghostferry.LoadTables(this.Ferry.SourceDB, this.tableFilter, nil)
+	this.Require().Nil(err)
+
+	table := tables.AsSlice()[0]
+	query := table.RowMd5Query()
+	this.Require().Equal("MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')),MD5(COALESCE(`data`, 'NULL')))) AS __ghostferry_row_md5", query)
+}
+
 func (this *TableSchemaCacheTestSuite) TestQuotedTableName() {
 	table := &ghostferry.TableSchema{
 		Table: &sqlSchema.Table{

--- a/test/helpers/ghostferry_helper.rb
+++ b/test/helpers/ghostferry_helper.rb
@@ -221,6 +221,10 @@ module GhostferryHelper
           environment["GHOSTFERRY_VERIFIER_TYPE"] = @config[:verifier_type]
         end
 
+        if @config[:compressed_data]
+          environment["GHOSTFERRY_DATA_COLUMN_SNAPPY"] = "1"
+        end
+
         @logger.info("starting ghostferry test binary #{@compiled_binary_path}")
         Open3.popen3(environment, @compiled_binary_path) do |stdin, stdout, stderr, wait_thr|
           stdin.puts(resuming_state) unless resuming_state.nil?

--- a/test/helpers/ghostferry_helper.rb
+++ b/test/helpers/ghostferry_helper.rb
@@ -47,7 +47,7 @@ module GhostferryHelper
       AFTER_BINLOG_APPLY = "AFTER_BINLOG_APPLY"
     end
 
-    attr_reader :stdout, :stderr, :exit_status, :pid
+    attr_reader :stdout, :stderr, :exit_status, :pid, :error
 
     def initialize(main_path, config: {}, logger: nil, message_timeout: 30, port: 39393)
       @logger = logger
@@ -76,6 +76,7 @@ module GhostferryHelper
       @exit_status = nil
       @stdout = []
       @stderr = []
+      @error = nil
 
       # Setup the directory to the compiled binary under the system temporary
       # directory.
@@ -193,6 +194,10 @@ module GhostferryHelper
         end
       end
 
+      @server.mount_proc "/callbacks/error" do |req, resp|
+        @error = JSON.parse(JSON.parse(req.body)["Payload"])
+      end
+
       @server_thread = Thread.new do
         @logger.info("starting server thread")
         @server.start
@@ -212,8 +217,8 @@ module GhostferryHelper
 
         # TODO: maybe in the future we'll have a better way to specify the
         # configurations.
-        if @config[:enable_iterative_verifier]
-          environment["GHOSTFERRY_ITERATIVE_VERIFIER"] = "1"
+        if @config[:verifier_type]
+          environment["GHOSTFERRY_VERIFIER_TYPE"] = @config[:verifier_type]
         end
 
         @logger.info("starting ghostferry test binary #{@compiled_binary_path}")

--- a/test/integration/inline_verifier_test.rb
+++ b/test/integration/inline_verifier_test.rb
@@ -11,7 +11,7 @@ class InlineVerifierTest < GhostferryTestCase
     seed_random_data(source_db, number_of_rows: 3)
     seed_random_data(target_db, number_of_rows: 0)
 
-    result = source_db.query("SELECT id FROM #{DEFAULT_FULL_TABLE_NAME} LIMIT 1")
+    result = source_db.query("SELECT id FROM #{DEFAULT_FULL_TABLE_NAME} ORDER BY RAND() LIMIT 1")
     corrupting_id = result.first["id"]
 
     enable_corrupting_insert_trigger(corrupting_id)

--- a/test/integration/inline_verifier_test.rb
+++ b/test/integration/inline_verifier_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+
+class InlineVerifierTest < GhostferryTestCase
+  INSERT_TRIGGER_NAME = "corrupting_insert_trigger"
+
+  def teardown
+    drop_triggers
+  end
+
+  def test_corrupted_insert_is_detected_inline_with_batch_writer
+    seed_random_data(source_db, number_of_rows: 3)
+    seed_random_data(target_db, number_of_rows: 0)
+
+    result = source_db.query("SELECT id FROM #{DEFAULT_FULL_TABLE_NAME} LIMIT 1")
+    corrupting_id = result.first["id"]
+
+    enable_corrupting_insert_trigger(corrupting_id)
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline" })
+    ghostferry.run_expecting_interrupt
+
+    refute_nil ghostferry.error
+    err_msg = ghostferry.error["ErrMessage"]
+    assert err_msg.include?("row fingerprints for pks [#{corrupting_id}] does not match"), message: err_msg
+
+    # Make sure it is not inserted into the target
+    results = target_db.query("SELECT * FROM #{DEFAULT_FULL_TABLE_NAME} WHERE id = #{corrupting_id}")
+    assert_equal 0, results.count
+  end
+
+  def test_different_compressed_data_is_detected_inline_with_batch_writer
+    [source_db, target_db].each do |db|
+      db.query("CREATE DATABASE IF NOT EXISTS #{DEFAULT_DB}")
+      db.query("CREATE TABLE IF NOT EXISTS #{DEFAULT_FULL_TABLE_NAME} (id bigint(20) not null auto_increment, data BLOB, primary key(id))")
+    end
+
+    compressed_data1 = "\x08" + "\x0cabcd" + "\x01\x02" # abcdcdcd
+    compressed_data2 = "\x08" + "\x0cabcd" + "\x01\x01" # abcddddd
+
+    source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} (id, data) VALUES (1, _binary'#{compressed_data1}')")
+    target_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} (id, data) VALUES (1, _binary'#{compressed_data2}')")
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline", compressed_data: true })
+    ghostferry.run_expecting_interrupt
+
+    refute_nil ghostferry.error
+    err_msg = ghostferry.error["ErrMessage"]
+    assert err_msg.include?("row fingerprints for pks [1] does not match"), message: err_msg
+  end
+
+  def test_same_decompressed_data_different_compressed_test_passes_inline_verification
+    [source_db, target_db].each do |db|
+      db.query("CREATE DATABASE IF NOT EXISTS #{DEFAULT_DB}")
+      db.query("CREATE TABLE IF NOT EXISTS #{DEFAULT_FULL_TABLE_NAME} (id bigint(20) not null auto_increment, data BLOB, primary key(id))")
+    end
+
+    compressed_data1 = load_fixture("urls1.snappy")
+    compressed_data2 = load_fixture("urls2.snappy")
+
+    source_db.prepare("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} (id, data) VALUES (?, ?)").execute(1, compressed_data1)
+    target_db.prepare("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} (id, data) VALUES (?, ?)").execute(1, compressed_data2)
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline", compressed_data: true })
+    ghostferry.run
+
+    assert_nil ghostferry.error
+  end
+
+  private
+
+  def enable_corrupting_insert_trigger(corrupting_id)
+    query = [
+      "CREATE TRIGGER #{INSERT_TRIGGER_NAME} BEFORE INSERT ON #{DEFAULT_TABLE}",
+      "FOR EACH ROW BEGIN",
+      "IF NEW.id = #{corrupting_id} THEN",
+      "SET NEW.data = 'corrupted';",
+      "END IF;",
+      "END",
+    ].join("\n")
+
+    target_db_conn_with_db_selected.query(query)
+  end
+
+  def drop_triggers
+    target_db_conn_with_db_selected.query("DROP TRIGGER IF EXISTS #{INSERT_TRIGGER_NAME}")
+  end
+
+  def target_db_conn_with_db_selected
+    @target_db_conn_with_db_selected ||= begin
+      conf = target_db_config
+      conf[:database] = DEFAULT_DB
+      Mysql2::Client.new(conf)
+    end
+  end
+end

--- a/test/integration/inline_verifier_test.rb
+++ b/test/integration/inline_verifier_test.rb
@@ -21,7 +21,7 @@ class InlineVerifierTest < GhostferryTestCase
 
     refute_nil ghostferry.error
     err_msg = ghostferry.error["ErrMessage"]
-    assert err_msg.include?("row fingerprints for pks [#{corrupting_id}] does not match"), message: err_msg
+    assert err_msg.include?("row fingerprints for pks [#{corrupting_id}] do not match"), message: err_msg
 
     # Make sure it is not inserted into the target
     results = target_db.query("SELECT * FROM #{DEFAULT_FULL_TABLE_NAME} WHERE id = #{corrupting_id}")
@@ -45,7 +45,7 @@ class InlineVerifierTest < GhostferryTestCase
 
     refute_nil ghostferry.error
     err_msg = ghostferry.error["ErrMessage"]
-    assert err_msg.include?("row fingerprints for pks [1] does not match"), message: err_msg
+    assert err_msg.include?("row fingerprints for pks [1] do not match"), message: err_msg
   end
 
   def test_same_decompressed_data_different_compressed_test_passes_inline_verification

--- a/test/integration/iterative_verifier_test.rb
+++ b/test/integration/iterative_verifier_test.rb
@@ -7,7 +7,7 @@ class IterativeVerifierTest < GhostferryTestCase
 
   def test_iterative_verifier_succeeds_in_normal_run
     datawriter = new_source_datawriter
-    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { enable_iterative_verifier: true })
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Iterative" })
 
     start_datawriter_with_ghostferry(datawriter, ghostferry)
     stop_datawriter_during_cutover(datawriter, ghostferry)
@@ -25,7 +25,7 @@ class IterativeVerifierTest < GhostferryTestCase
 
   def test_iterative_verifier_fails_if_binlog_streamer_incorrectly_copies_data
     datawriter = new_source_datawriter
-    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { enable_iterative_verifier: true })
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Iterative" })
 
     table_name = DEFAULT_FULL_TABLE_NAME
 

--- a/test/lib/go/integrationferry.go
+++ b/test/lib/go/integrationferry.go
@@ -246,6 +246,19 @@ func main() {
 		config.VerifierType = verifierType
 	}
 
+	// This is currently a hack to customize the Ghostferry configuration.
+	// TODO: allow Ghostferry config to be specified by the ruby test directly.
+	compressedDataColumn := os.Getenv("GHOSTFERRY_DATA_COLUMN_SNAPPY")
+	if compressedDataColumn != "" {
+		config.ColumnCompressionConfig = map[string]map[string]map[string]string{
+			"gftest": map[string]map[string]string{
+				"test_table_1": map[string]string{
+					"data": "SNAPPY",
+				},
+			},
+		}
+	}
+
 	f := &IntegrationFerry{
 		Ferry: &ghostferry.Ferry{
 			Config: config,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require "minitest/autorun"
 require "minitest/hooks/test"
 
 GO_CODE_PATH = File.join(File.absolute_path(File.dirname(__FILE__)), "lib", "go")
+FIXTURE_PATH = File.join(File.absolute_path(File.dirname(__FILE__)), "fixtures")
 
 require "db_helper"
 require "ghostferry_helper"
@@ -33,6 +34,10 @@ class GhostferryTestCase < Minitest::Test
     dw = DataWriter.new(source_db_config, *args, logger: @logger)
     @datawriter_instances << dw
     dw
+  end
+
+  def load_fixture(filename)
+    File.read(File.join(FIXTURE_PATH, filename))
   end
 
   ##############


### PR DESCRIPTION
This PR adds verification inline while selecting data in DataIterator (Cursor) and writing data in BatchWriter. It does not add the verification to the BinlogStreamer so the PR is a reasonable size. That will come next. 

### Motivation

Some more notes on the InlineVerifier topic is available in #99. The tl;dr of it is:

1. Making the IterativeVerifier interruptible will significantly complicate the code base.
2. The InlineVerifier will allow us to get interrupt/resume for almost free.
3. The only type of corruption that both the IterativeVerifier and the InlineVerifier can guarantee detection is corruption due to an encoding-type bug.
4. The IterativeVerifier have can detect some additional types of corruption  (such as implementation bugs in interrupt/resume like an incorrect restart location). However, in none of these types can it guarantee detect and requires some luck. 
5. Simpler code base due to implementing only the InlineVerifier gives us a better chance at reducing bugs as it is easier to understand, test, and formally model.

### How it works

How the InlineVerifier works in the context of the DataIterator as implemented in this PR is as follows:

1. While selecting the data in `DataIterator`, the `SELECT * FROM ...` gets replaced with `SELECT *, MD5(...) FROM ...`.
2. The fingerprint is stored in the `RowBatch` struct.
3. When the `BatchWriter` tries to write the `RowBatch`, instead of inserting it directly with a single statement, it:
    1. Opens a transaction.
    2. Inserts the data as done previously
    3. `SELECT pk, MD5(....) FROM ...`
    4. Checks the MD5 against the fingerprint stored on `RowBatch`.

As one can note, the number of round trips per batch written has been increased from 1 to 4. I suspect this _should_ be okay, as inserting 200 rows should take the majority of the time. Furthermore, since we are eventually going to remove the iterative verifier in favour of using this, the overall clock time of a Ghostferry run should decrease.

Another complication is the presence of compressed columns that has already been copied to the target. If a compressed column is specified, step 3.3 will be modified to `SELECT pk, MD5, compressedCol1, compressedCol2....`. The MD5 will exclude the compressed columns. Additionally, the decompressed columns are compared in Golang after step 3.4.