### PR TITLE
Test copying escaped data

### DIFF
--- a/test/integration/types_test.rb
+++ b/test/integration/types_test.rb
@@ -40,4 +40,34 @@ class TypesTest < GhostferryTestCase
       assert_equal expected_row, row
     end
   end
+
+  def test_escaped_data
+    [source_db, target_db].each do |db|
+      db.query("CREATE DATABASE IF NOT EXISTS #{DEFAULT_DB}")
+      db.query("CREATE TABLE IF NOT EXISTS #{DEFAULT_FULL_TABLE_NAME} (id bigint(20) not null auto_increment, data1 TEXT, data2 VARCHAR(255), data3 BLOB, primary key(id))")
+    end
+
+    source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} (id, data1, data2, data3) VALUES (1, '''', '''', _binary'''')")
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+
+    ghostferry.on_status(Ghostferry::Status::BINLOG_STREAMING_STARTED) do
+      source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} (id, data1, data2, data3) VALUES (2, '''', '''', _binary'''')")
+      source_db.query("UPDATE #{DEFAULT_FULL_TABLE_NAME} SET data1 = 'test', data2 = 'test', data3 = _binary'test' WHERE id = 1")
+      source_db.query("UPDATE #{DEFAULT_FULL_TABLE_NAME} SET data1 = '''', data2 = '''', data3 = _binary'''' WHERE id = 1")
+      source_db.query("DELETE FROM #{DEFAULT_FULL_TABLE_NAME} WHERE id = 2")
+    end
+
+    ghostferry.run
+
+    assert_test_table_is_identical
+    res = target_db.query("SELECT * FROM #{DEFAULT_FULL_TABLE_NAME}")
+    assert_equal 1, res.count
+    res.each do |row|
+      assert_equal 1, row["id"]
+      assert_equal "'", row["data1"]
+      assert_equal "'", row["data2"]
+      assert_equal "'", row["data3"]
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -85,11 +85,13 @@ class GhostferryTestCase < Minitest::Test
     assert_equal(
       source[DEFAULT_FULL_TABLE_NAME][:row_count],
       target[DEFAULT_FULL_TABLE_NAME][:row_count],
+      "source and target row count don't match",
     )
 
     assert_equal(
       source[DEFAULT_FULL_TABLE_NAME][:checksum],
       target[DEFAULT_FULL_TABLE_NAME][:checksum],
+      "source and target checksum don't match",
     )
   end
 


### PR DESCRIPTION
We never explicitly tested moving escaped data, which is only ' with NO_BACKSLASH_ESCAPE.

This adds an integration test specifically for this.