### PR TITLE
InlineVerifier Binlog Reverifier

### DIFF
--- a/config.go
+++ b/config.go
@@ -144,15 +144,13 @@ func (c *DatabaseConfig) assertParamSet(param, value string) error {
 
 type InlineVerifierConfig struct {
 	// The maximum expected downtime during cutover, in the format of
-	// time.ParseDuration.
+	// time.ParseDuration. If nothing is specified, the InlineVerifier will not
+	// try to estimate the downtime and will always allow cutover.
 	MaxExpectedDowntime string
 
 	// The interval at which the periodic binlog reverification occurs, in the
-	// format of time.ParseDuration.
+	// format of time.ParseDuration. Default: 1s.
 	VerifyBinlogEventsInterval string
-
-	// The maximum number of iterations to perform reverify in VerifyBeforeCutover
-	FinalReverifyMaxIterations int
 
 	verifyBinlogEventsInterval time.Duration
 	maxExpectedDowntime        time.Duration
@@ -165,6 +163,8 @@ func (c *InlineVerifierConfig) Validate() error {
 		if err != nil {
 			return err
 		}
+	} else {
+		c.maxExpectedDowntime = time.Duration(0)
 	}
 
 	if c.VerifyBinlogEventsInterval == "" {
@@ -174,10 +174,6 @@ func (c *InlineVerifierConfig) Validate() error {
 	c.verifyBinlogEventsInterval, err = time.ParseDuration(c.VerifyBinlogEventsInterval)
 	if err != nil {
 		return err
-	}
-
-	if c.FinalReverifyMaxIterations == 0 {
-		c.FinalReverifyMaxIterations = 30
 	}
 
 	return nil

--- a/inline_verifier.go
+++ b/inline_verifier.go
@@ -3,31 +3,158 @@ package ghostferry
 import (
 	"bytes"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/golang/snappy"
 	"github.com/sirupsen/logrus"
 )
 
+// This struct is very similar to ReverifyStore, but it is more optimized
+// for serialization into JSON.
+//
+// TODO: remove IterativeVerifier and remove this comment.
+type BinlogVerifyStore struct {
+	EmitLogPerRowsAdded uint64
+
+	mutex *sync.Mutex
+	store map[string]map[string]map[uint64]struct{} // db => table => (pk set)
+
+	// The total number of rows added to the reverify store, ever.  Does not
+	// include the rows added in the interrupted run if the present run is a
+	// resuming one. This is only used for emitting metrics.
+	totalRowCount   uint64
+	currentRowCount uint64 // The number of rows in store currently.
+}
+
+type BinlogVerifySerializedStore struct {
+	Store    map[string]map[string]map[uint64]struct{}
+	RowCount uint64
+}
+
+type BinlogVerifyBatch struct {
+	SchemaName string
+	TableName  string
+	Pks        []uint64
+}
+
+func NewBinlogVerifyStore() *BinlogVerifyStore {
+	return &BinlogVerifyStore{
+		EmitLogPerRowsAdded: uint64(10000), // TODO: make this configurable
+		mutex:               &sync.Mutex{},
+		store:               make(map[string]map[string]map[uint64]struct{}),
+		totalRowCount:       uint64(0),
+		currentRowCount:     uint64(0),
+	}
+}
+
+func (s *BinlogVerifyStore) Add(table *TableSchema, pk uint64) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	_, exists := s.store[table.Schema]
+	if !exists {
+		s.store[table.Schema] = make(map[string]map[uint64]struct{})
+	}
+
+	_, exists = s.store[table.Schema][table.Name]
+	if !exists {
+		s.store[table.Schema][table.Name] = make(map[uint64]struct{})
+	}
+
+	_, exists = s.store[table.Schema][table.Name][pk]
+	if !exists {
+		s.store[table.Schema][table.Name][pk] = struct{}{}
+		s.totalRowCount++
+		s.currentRowCount++
+
+		if s.totalRowCount%s.EmitLogPerRowsAdded == 0 {
+			metrics.Gauge("inline_verifier_current_rows", float64(s.currentRowCount), []MetricTag{}, 1.0)
+			metrics.Gauge("inline_verifier_total_rows", float64(s.totalRowCount), []MetricTag{}, 1.0)
+			logrus.WithFields(logrus.Fields{
+				"tag":         "binlog_verify_store",
+				"currentRows": s.currentRowCount,
+				"totalRows":   s.totalRowCount,
+			}).Debug("current rows in BinlogVerifyStore")
+		}
+	}
+}
+
+func (s *BinlogVerifyStore) FlushAndBatchByTable(batchsize int) []BinlogVerifyBatch {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	batches := make([]BinlogVerifyBatch, 0)
+	for schemaName, _ := range s.store {
+		for tableName, pkSet := range s.store[schemaName] {
+			pkBatch := make([]uint64, 0, batchsize)
+
+			for pk, _ := range pkSet {
+				pkBatch = append(pkBatch, pk)
+				if len(pkBatch) >= batchsize {
+					batches = append(batches, BinlogVerifyBatch{
+						SchemaName: schemaName,
+						TableName:  tableName,
+						Pks:        pkBatch,
+					})
+					pkBatch = make([]uint64, 0, batchsize)
+				}
+			}
+
+			if len(pkBatch) > 0 {
+				batches = append(batches, BinlogVerifyBatch{
+					SchemaName: schemaName,
+					TableName:  tableName,
+					Pks:        pkBatch,
+				})
+			}
+		}
+	}
+
+	s.flushWithoutLock()
+	return batches
+}
+
+func (s *BinlogVerifyStore) Serialize() BinlogVerifySerializedStore {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	return BinlogVerifySerializedStore{
+		Store:    s.store,
+		RowCount: s.currentRowCount,
+	}
+}
+
+func (s *BinlogVerifyStore) flushWithoutLock() {
+	s.store = make(map[string]map[string]map[uint64]struct{})
+	s.currentRowCount = 0
+}
+
 type InlineVerifier struct {
-	SourceDB *sql.DB
-	TargetDB *sql.DB
+	SourceDB                   *sql.DB
+	TargetDB                   *sql.DB
+	DatabaseRewrites           map[string]string
+	TableRewrites              map[string]string
+	TableSchemaCache           TableSchemaCache
+	Concurrency                int
+	BatchSize                  int
+	VerifyBinlogEventsInterval time.Duration
+	FinalReverifyMaxIterations int
+	MaxExpectedDowntime        time.Duration
+
+	ErrorHandler ErrorHandler
+
+	reverifyStore              *BinlogVerifyStore
+	periodicVerifyStopped      bool
+	verifyDuringCutoverStarted AtomicBoolean
 
 	sourceStmtCache *StmtCache
 	targetStmtCache *StmtCache
 	logger          *logrus.Entry
-}
-
-func (v *InlineVerifier) VerifyBeforeCutover() error {
-	// TODO: Iterate until the reverify queue is small enough
-	return nil
-}
-
-func (v *InlineVerifier) VerifyDuringCutover() (VerificationResult, error) {
-	// TODO: verify everything within the reverify queue.
-	return VerificationResult{}, nil
 }
 
 func (v *InlineVerifier) StartInBackground() error {
@@ -44,16 +171,10 @@ func (v *InlineVerifier) Result() (VerificationResultAndStatus, error) {
 	return VerificationResultAndStatus{}, nil
 }
 
-func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetDb, targetTable string, sourceBatch *RowBatch) ([]uint64, error) {
+func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetSchema, targetTable string, sourceBatch *RowBatch) ([]uint64, error) {
 	table := sourceBatch.TableSchema()
 
-	fingerprintQuery := table.FingerprintQuery(targetDb, targetTable, sourceBatch.Size())
-	fingerprintStmt, err := v.targetStmtCache.StmtFor(v.TargetDB, fingerprintQuery)
-	if err != nil {
-		return nil, err
-	}
-
-	pks := make([]interface{}, len(sourceBatch.Values()))
+	pks := make([]uint64, len(sourceBatch.Values()))
 	for i, row := range sourceBatch.Values() {
 		pk, err := row.GetUint64(sourceBatch.PkIndex())
 		if err != nil {
@@ -63,43 +184,10 @@ func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetDb, targetTabl
 		pks[i] = pk
 	}
 
-	rows, err := tx.Stmt(fingerprintStmt).Query(pks...)
-	if err != nil {
-		return nil, err
-	}
-
-	columns, err := rows.Columns()
-	if err != nil {
-		return nil, err
-	}
-
 	// Fetch target data
-	targetFingerprints := make(map[uint64][]byte)                // pk -> fingerprint
-	targetDecompressedData := make(map[uint64]map[string][]byte) // pk -> columnName -> compressedData
-
-	for rows.Next() {
-		rowData, err := ScanByteRow(rows, len(columns))
-		if err != nil {
-			return nil, err
-		}
-
-		pk, err := strconv.ParseUint(string(rowData[0]), 10, 64)
-		if err != nil {
-			return nil, err
-		}
-
-		targetFingerprints[pk] = rowData[1]
-		targetDecompressedData[pk] = make(map[string][]byte)
-
-		// Note that the FingerprintQuery returns the columns: pk, fingerprint,
-		// compressedData1, compressedData2, ...
-		// If there are no compressed data, only 2 columns are returned.
-		for i := 2; i < len(columns); i++ {
-			targetDecompressedData[pk][columns[i]], err = v.DecompressData(table, columns[i], rowData[i])
-			if err != nil {
-				return nil, err
-			}
-		}
+	targetFingerprints, targetDecompressedData, err := v.getFingerprintDataFromDb("target", targetSchema, targetTable, tx, table, pks)
+	if err != nil {
+		return nil, err
 	}
 
 	// Fetch source data
@@ -125,20 +213,181 @@ func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetDb, targetTabl
 				return nil, fmt.Errorf("cannot convert column %v to []byte", col.Name)
 			}
 
-			sourceDecompressedData[pk][col.Name], err = v.DecompressData(table, col.Name, compressedData)
+			sourceDecompressedData[pk][col.Name], err = v.decompressData(table, col.Name, compressedData)
 		}
 	}
 
-	mismatches := v.CompareHashes(sourceFingerprints, targetFingerprints)
-	if len(mismatches) > 0 {
-		return mismatches, nil
-	}
-
-	mismatches = v.CompareDecompressedData(sourceDecompressedData, targetDecompressedData)
-	return mismatches, nil
+	return v.compareHashesAndData(sourceFingerprints, targetFingerprints, sourceDecompressedData, targetDecompressedData), nil
 }
 
-func (v *InlineVerifier) DecompressData(table *TableSchema, column string, compressed []byte) ([]byte, error) {
+func (v *InlineVerifier) PeriodicallyVerifyBinlogEvents() {
+	v.logger.Info("starting periodic reverifier")
+
+	for !v.periodicVerifyStopped || v.reverifyStore.currentRowCount > 0 {
+		time.Sleep(v.VerifyBinlogEventsInterval)
+		_, mismatches, err := v.verifyAllEventsInStore()
+		if err != nil {
+			v.ErrorHandler.Fatal("inline_verifier", err)
+		}
+
+		v.readdMismatchedPKsToBeVerifiedAgain(mismatches)
+
+		v.logger.WithFields(logrus.Fields{
+			"remainingRowCount": v.reverifyStore.currentRowCount,
+		}).Debug("reverified")
+	}
+
+	v.logger.Info("shutdown periodic reverifier")
+}
+
+func (v *InlineVerifier) StopPeriodicallyVerifyBinlogEvents() {
+	v.periodicVerifyStopped = true
+	v.logger.Info("request shutdown of periodic reverifier")
+}
+
+func (v *InlineVerifier) VerifyBeforeCutover() error {
+	var timeToVerify time.Duration
+	// Iterate until the reverify queue is small enough
+	for i := 0; i < v.FinalReverifyMaxIterations; i++ {
+		before := v.reverifyStore.currentRowCount
+		start := time.Now()
+
+		_, mismatches, err := v.verifyAllEventsInStore()
+		if err != nil {
+			return err
+		}
+
+		v.readdMismatchedPKsToBeVerifiedAgain(mismatches)
+		after := v.reverifyStore.currentRowCount
+		timeToVerify = time.Now().Sub(start)
+
+		v.logger.WithFields(logrus.Fields{
+			"store_size_before": before,
+			"store_size_after":  after,
+			"iteration":         i,
+		}).Infof("completed re-verification iteration %d", i)
+
+		if after <= 1000 || after >= before {
+			break
+		}
+	}
+
+	if v.MaxExpectedDowntime != 0 && timeToVerify > v.MaxExpectedDowntime {
+		return fmt.Errorf("cutover stage verification will not complete within max downtime duration (took %s)", timeToVerify)
+	}
+
+	return nil
+}
+
+func (v *InlineVerifier) VerifyDuringCutover() (VerificationResult, error) {
+	mismatchFound, mismatches, err := v.verifyAllEventsInStore()
+	if err != nil {
+		v.logger.WithError(err).Error("failed to VerifyDuringCutover")
+		return VerificationResult{}, err
+	}
+
+	if !mismatchFound {
+		return VerificationResult{
+			DataCorrect: true,
+		}, nil
+	}
+
+	var messageBuf bytes.Buffer
+	messageBuf.WriteString("cutover verification failed for: ")
+	incorrectTables := make([]string, 0)
+	for schemaName, _ := range mismatches {
+		for tableName, pks := range mismatches[schemaName] {
+			tableName = fmt.Sprintf("%s.%s", schemaName, tableName)
+			incorrectTables = append(incorrectTables, tableName)
+
+			messageBuf.WriteString(tableName)
+			messageBuf.WriteString(" [pks: ")
+			for _, pk := range pks {
+				messageBuf.WriteString(strconv.FormatUint(pk, 10))
+				messageBuf.WriteString(" ")
+			}
+			messageBuf.WriteString("] ")
+		}
+	}
+
+	message := messageBuf.String()
+	v.logger.WithField("incorrect_tables", incorrectTables).Error(message)
+
+	return VerificationResult{
+		DataCorrect:     false,
+		Message:         messageBuf.String(),
+		IncorrectTables: incorrectTables,
+	}, nil
+}
+
+func (v *InlineVerifier) getFingerprintDataFromDb(whichDB, schemaName, tableName string, tx *sql.Tx, table *TableSchema, pks []uint64) (map[uint64][]byte, map[uint64]map[string][]byte, error) {
+	var db *sql.DB
+	var stmtCache *StmtCache
+	if whichDB == "source" {
+		db = v.SourceDB
+		stmtCache = v.sourceStmtCache
+	} else if whichDB == "target" {
+		db = v.TargetDB
+		stmtCache = v.targetStmtCache
+	} else {
+		return nil, nil, errors.New("programming error: whichDB must be either source or target")
+	}
+
+	fingerprintQuery := table.FingerprintQuery(schemaName, tableName, len(pks))
+	fingerprintStmt, err := stmtCache.StmtFor(db, fingerprintQuery)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if tx != nil {
+		fingerprintStmt = tx.Stmt(fingerprintStmt)
+	}
+
+	args := make([]interface{}, len(pks))
+	for i, pk := range pks {
+		args[i] = pk
+	}
+
+	rows, err := fingerprintStmt.Query(args...)
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	fingerprints := make(map[uint64][]byte)                // pk -> fingerprint
+	decompressedData := make(map[uint64]map[string][]byte) // pk -> columnName -> decompressedData
+
+	for rows.Next() {
+		rowData, err := ScanByteRow(rows, len(columns))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		pk, err := strconv.ParseUint(string(rowData[0]), 10, 64)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		fingerprints[pk] = rowData[1]
+		decompressedData[pk] = make(map[string][]byte)
+
+		// Note that the FingerprintQuery returns the columns: pk, fingerprint,
+		// compressedData1, compressedData2, ...
+		// If there are no compressed data, only 2 columns are returned and this
+		// loop will be skipped.
+		for i := 2; i < len(columns); i++ {
+			decompressedData[pk][columns[i]], err = v.decompressData(table, columns[i], rowData[i])
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+
+	return fingerprints, decompressedData, nil
+}
+
+func (v *InlineVerifier) decompressData(table *TableSchema, column string, compressed []byte) ([]byte, error) {
 	var decompressed []byte
 	algorithm, isCompressed := table.CompressedColumns[column]
 	if !isCompressed {
@@ -157,7 +406,7 @@ func (v *InlineVerifier) DecompressData(table *TableSchema, column string, compr
 	}
 }
 
-func (v *InlineVerifier) CompareHashes(source, target map[uint64][]byte) []uint64 {
+func (v *InlineVerifier) compareHashes(source, target map[uint64][]byte) map[uint64]struct{} {
 	mismatchSet := map[uint64]struct{}{}
 
 	for pk, targetHash := range target {
@@ -174,15 +423,10 @@ func (v *InlineVerifier) CompareHashes(source, target map[uint64][]byte) []uint6
 		}
 	}
 
-	mismatches := make([]uint64, 0, len(mismatchSet))
-	for mismatch, _ := range mismatchSet {
-		mismatches = append(mismatches, mismatch)
-	}
-
-	return mismatches
+	return mismatchSet
 }
 
-func (v *InlineVerifier) CompareDecompressedData(source, target map[uint64]map[string][]byte) []uint64 {
+func (v *InlineVerifier) compareDecompressedData(source, target map[uint64]map[string][]byte) map[uint64]struct{} {
 	mismatchSet := map[uint64]struct{}{}
 
 	for pk, targetDecompressedColumns := range target {
@@ -217,10 +461,150 @@ func (v *InlineVerifier) CompareDecompressedData(source, target map[uint64]map[s
 		}
 	}
 
-	mismatches := make([]uint64, 0, len(mismatchSet))
-	for mismatch, _ := range mismatchSet {
-		mismatches = append(mismatches, mismatch)
+	return mismatchSet
+}
+
+func (v *InlineVerifier) compareHashesAndData(sourceHashes, targetHashes map[uint64][]byte, sourceData, targetData map[uint64]map[string][]byte) []uint64 {
+	mismatches := v.compareHashes(sourceHashes, targetHashes)
+	compressedMismatch := v.compareDecompressedData(sourceData, targetData)
+	for pk, _ := range compressedMismatch {
+		mismatches[pk] = struct{}{}
 	}
 
-	return mismatches
+	mismatchList := make([]uint64, 0, len(mismatches))
+
+	for pk, _ := range mismatches {
+		mismatchList = append(mismatchList, pk)
+	}
+
+	return mismatchList
+}
+
+func (v *InlineVerifier) binlogEventListener(evs []DMLEvent) error {
+	if v.verifyDuringCutoverStarted.Get() {
+		return fmt.Errorf("cutover has started but received binlog event!")
+	}
+
+	for _, ev := range evs {
+		pk, err := ev.PK()
+		if err != nil {
+			return err
+		}
+
+		v.reverifyStore.Add(ev.TableSchema(), pk)
+	}
+
+	return nil
+}
+
+func (v *InlineVerifier) readdMismatchedPKsToBeVerifiedAgain(mismatches map[string]map[string][]uint64) {
+	for schemaName, _ := range mismatches {
+		for tableName, pks := range mismatches[schemaName] {
+			table := v.TableSchemaCache.Get(schemaName, tableName)
+			for _, pk := range pks {
+				v.reverifyStore.Add(table, pk)
+			}
+		}
+	}
+}
+
+// Returns mismatches in the form of db -> table -> pks
+func (v *InlineVerifier) verifyAllEventsInStore() (bool, map[string]map[string][]uint64, error) {
+	mismatchFound := false
+	mismatches := make(map[string]map[string][]uint64)
+	allBatches := v.reverifyStore.FlushAndBatchByTable(v.BatchSize)
+
+	if len(allBatches) == 0 {
+		return mismatchFound, mismatches, nil
+	}
+
+	v.logger.WithField("batches", len(allBatches)).Debug("reverifying")
+
+	for _, batch := range allBatches {
+		if _, exists := mismatches[batch.SchemaName]; !exists {
+			mismatches[batch.SchemaName] = make(map[string][]uint64)
+		}
+
+		if _, exists := mismatches[batch.SchemaName][batch.TableName]; !exists {
+			mismatches[batch.SchemaName][batch.TableName] = make([]uint64, 0)
+		}
+
+		batchMismatches, err := v.verifyBinlogBatch(batch)
+		if err != nil {
+			return false, nil, err
+		}
+
+		if len(batchMismatches) > 0 {
+			mismatchFound = true
+			mismatches[batch.SchemaName][batch.TableName] = append(mismatches[batch.SchemaName][batch.TableName], batchMismatches...)
+		}
+	}
+
+	return mismatchFound, mismatches, nil
+}
+
+// Returns a list of mismatched PKs.
+// Since the mismatches gets re-added to the reverify store, this must return
+// a union of mismatches of fingerprints and mismatches due to decompressed
+// data.
+func (v *InlineVerifier) verifyBinlogBatch(batch BinlogVerifyBatch) ([]uint64, error) {
+	targetSchema := batch.SchemaName
+	if targetSchemaName, exists := v.DatabaseRewrites[targetSchema]; exists {
+		targetSchema = targetSchemaName
+	}
+
+	targetTable := batch.TableName
+	if targetTableName, exists := v.TableRewrites[targetTable]; exists {
+		targetTable = targetTableName
+	}
+
+	sourceTableSchema := v.TableSchemaCache.Get(batch.SchemaName, batch.TableName)
+	if sourceTableSchema == nil {
+		return []uint64{}, fmt.Errorf("programming error? %s.%s is not found in TableSchemaCache but is being reverified", batch.SchemaName, batch.TableName)
+	}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+
+	var sourceFingerprints map[uint64][]byte
+	var sourceDecompressedData map[uint64]map[string][]byte
+	var sourceErr error
+	go func() {
+		defer wg.Done()
+		sourceErr = WithRetries(5, 0, v.logger, "get fingerprints from source db", func() (err error) {
+			sourceFingerprints, sourceDecompressedData, err = v.getFingerprintDataFromDb(
+				"source", batch.SchemaName, batch.TableName,
+				nil, // No transaction
+				sourceTableSchema,
+				batch.Pks,
+			)
+			return
+		})
+	}()
+
+	var targetFingerprints map[uint64][]byte
+	var targetDecompressedData map[uint64]map[string][]byte
+	var targetErr error
+	go func() {
+		defer wg.Done()
+		targetErr = WithRetries(5, 0, v.logger, "get fingerprints from target db", func() (err error) {
+			targetFingerprints, targetDecompressedData, err = v.getFingerprintDataFromDb(
+				"target", targetSchema, targetTable,
+				nil, // No transaction
+				sourceTableSchema,
+				batch.Pks,
+			)
+			return
+		})
+	}()
+
+	wg.Wait()
+	if sourceErr != nil {
+		return nil, sourceErr
+	}
+	if targetErr != nil {
+		return nil, targetErr
+	}
+
+	return v.compareHashesAndData(sourceFingerprints, targetFingerprints, sourceDecompressedData, targetDecompressedData), nil
 }

--- a/inline_verifier.go
+++ b/inline_verifier.go
@@ -140,7 +140,6 @@ type InlineVerifier struct {
 	DatabaseRewrites           map[string]string
 	TableRewrites              map[string]string
 	TableSchemaCache           TableSchemaCache
-	Concurrency                int
 	BatchSize                  int
 	VerifyBinlogEventsInterval time.Duration
 	FinalReverifyMaxIterations int
@@ -223,7 +222,7 @@ func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetSchema, target
 func (v *InlineVerifier) PeriodicallyVerifyBinlogEvents() {
 	v.logger.Info("starting periodic reverifier")
 
-	for !v.periodicVerifyStopped || v.reverifyStore.currentRowCount > 0 {
+	for !v.periodicVerifyStopped {
 		time.Sleep(v.VerifyBinlogEventsInterval)
 		_, mismatches, err := v.verifyAllEventsInStore()
 		if err != nil {

--- a/test/go/table_schema_cache_test.go
+++ b/test/go/table_schema_cache_test.go
@@ -138,26 +138,33 @@ func (this *TableSchemaCacheTestSuite) TestAsSliceEmpty() {
 }
 
 func (this *TableSchemaCacheTestSuite) TestFingerprintQuery() {
-	tables, err := ghostferry.LoadTables(this.Ferry.SourceDB, this.tableFilter, nil)
+	tableSchemaCache, err := ghostferry.LoadTables(this.Ferry.SourceDB, this.tableFilter, nil)
 	this.Require().Nil(err)
 
-	table := tables.AsSlice()[0]
+	tables := tableSchemaCache.AsSlice()
+	table := tables[0]
 	query := table.FingerprintQuery("s", "t", 10)
 	this.Require().Equal("SELECT `id`,MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')),MD5(COALESCE(`data`, 'NULL')))) AS __ghostferry_row_md5 FROM `s`.`t` WHERE `id` IN (?,?,?,?,?,?,?,?,?,?)", query)
 
-	table = tables.AsSlice()[1]
+	table = tables[1]
 	table.CompressedColumns = map[string]string{"data": "SNAPPY"}
 	query = table.FingerprintQuery("s", "t", 10)
 	this.Require().Equal("SELECT `id`,MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')))) AS __ghostferry_row_md5,`data` FROM `s`.`t` WHERE `id` IN (?,?,?,?,?,?,?,?,?,?)", query)
 }
 
 func (this *TableSchemaCacheTestSuite) TestTableRowMd5Query() {
-	tables, err := ghostferry.LoadTables(this.Ferry.SourceDB, this.tableFilter, nil)
+	tableSchemaCache, err := ghostferry.LoadTables(this.Ferry.SourceDB, this.tableFilter, nil)
 	this.Require().Nil(err)
 
-	table := tables.AsSlice()[0]
+	tables := tableSchemaCache.AsSlice()
+	table := tables[0]
 	query := table.RowMd5Query()
 	this.Require().Equal("MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')),MD5(COALESCE(`data`, 'NULL')))) AS __ghostferry_row_md5", query)
+
+	table = tables[1]
+	table.CompressedColumns = map[string]string{"data": "SNAPPY"}
+	query = table.RowMd5Query()
+	this.Require().Equal("MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')))) AS __ghostferry_row_md5", query)
 }
 
 func (this *TableSchemaCacheTestSuite) TestQuotedTableName() {

--- a/test/integration/inline_verifier_test.rb
+++ b/test/integration/inline_verifier_test.rb
@@ -83,8 +83,7 @@ class InlineVerifierTest < GhostferryTestCase
     verification_ran = false
     ghostferry.on_status(Ghostferry::Status::VERIFIED) do |*incorrect_tables|
       verification_ran = true
-      assert_equal 1, incorrect_tables.length
-      assert_equal "gftest.test_table_1", incorrect_tables.first
+      assert_equal ["gftest.test_table_1"], incorrect_tables
     end
 
     ghostferry.run

--- a/test/integration/inline_verifier_test.rb
+++ b/test/integration/inline_verifier_test.rb
@@ -66,6 +66,31 @@ class InlineVerifierTest < GhostferryTestCase
     assert_nil ghostferry.error
   end
 
+  def test_catches_binlog_streamer_corruption
+    seed_random_data(source_db, number_of_rows: 1)
+    seed_random_data(target_db, number_of_rows: 0)
+
+    result = source_db.query("SELECT id FROM #{DEFAULT_FULL_TABLE_NAME} LIMIT 1")
+    corrupting_id = result.first["id"] + 1
+    enable_corrupting_insert_trigger(corrupting_id)
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline" })
+
+    ghostferry.on_status(Ghostferry::Status::ROW_COPY_COMPLETED) do
+      source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} (id, data) VALUES (#{corrupting_id}, 'data')")
+    end
+
+    verification_ran = false
+    ghostferry.on_status(Ghostferry::Status::VERIFIED) do |*incorrect_tables|
+      verification_ran = true
+      assert_equal 1, incorrect_tables.length
+      assert_equal "gftest.test_table_1", incorrect_tables.first
+    end
+
+    ghostferry.run
+    assert verification_ran
+  end
+
   private
 
   def enable_corrupting_insert_trigger(corrupting_id)

--- a/test/lib/go/integrationferry.go
+++ b/test/lib/go/integrationferry.go
@@ -224,6 +224,16 @@ func NewStandardConfig() (*ghostferry.Config, error) {
 		}
 	}
 
+	verifierType := os.Getenv("GHOSTFERRY_VERIFIER_TYPE")
+	if verifierType == ghostferry.VerifierTypeIterative {
+		config.VerifierType = ghostferry.VerifierTypeIterative
+		config.IterativeVerifierConfig = ghostferry.IterativeVerifierConfig{
+			Concurrency: 2,
+		}
+	} else if verifierType != "" {
+		config.VerifierType = verifierType
+	}
+
 	return config, config.ValidateConfig()
 }
 
@@ -234,16 +244,6 @@ func main() {
 	config, err := NewStandardConfig()
 	if err != nil {
 		panic(err)
-	}
-
-	verifierType := os.Getenv("GHOSTFERRY_VERIFIER_TYPE")
-	if verifierType == ghostferry.VerifierTypeIterative {
-		config.VerifierType = ghostferry.VerifierTypeIterative
-		config.IterativeVerifierConfig = ghostferry.IterativeVerifierConfig{
-			Concurrency: 2,
-		}
-	} else if verifierType != "" {
-		config.VerifierType = verifierType
 	}
 
 	// This is currently a hack to customize the Ghostferry configuration.


### PR DESCRIPTION
The InlineVerifier doesn't verify the Binlog copied. This PR adds a reverifier component to the InlineVerifier. It periodically attempts to verify the BinlogEvents copied prior to cutover (within `PeriodicallyVerifyBinlogEvents`). If a row doesn't match, it will be added back to the queue to be verified again in the future. This process will be stopped after the DataIterator finishes copying all rows. After it is stopped, `VerifyBeforeCutover` starts. Within this phase, the verifier attempts to iterate over the verification queue until it is small enough (< 1000 binlog events by default). A maximum of 30 iterations (by default). After this is done, VerifyDuringCutover should be called by the application. During this, the verifier will return the mismatches if they are found. 

The code shares a fair amount of similarities to the IterativeVerifier, except it is running as DataIterator is copying, while the original IterativeVerifier code runs after DataIterator is done. Note that this verifier is not resumable yet. I'll make it resumable in a follow up PR (should be relatively easily as I just need to dump the ReverifyStore with the state dump).

Downstream consumer changes required

- Metric tag changed from `iterative_verifier_store_rows` to `inline_verifier_current_rows`