### PR TITLE
Removed StateTracker complexity

### DIFF
--- a/batch_writer.go
+++ b/batch_writer.go
@@ -10,7 +10,7 @@ import (
 type BatchWriter struct {
 	DB             *sql.DB
 	InlineVerifier *InlineVerifier
-	StateTracker   *CopyStateTracker
+	StateTracker   *StateTracker
 
 	DatabaseRewrites map[string]string
 	TableRewrites    map[string]string

--- a/binlog_writer.go
+++ b/binlog_writer.go
@@ -17,7 +17,7 @@ type BinlogWriter struct {
 	WriteRetries int
 
 	ErrorHandler ErrorHandler
-	StateTracker *CopyStateTracker
+	StateTracker *StateTracker
 
 	binlogEventBuffer chan DMLEvent
 	logger            *logrus.Entry
@@ -110,7 +110,7 @@ func (b *BinlogWriter) writeEvents(events []DMLEvent) error {
 	}
 
 	if b.StateTracker != nil {
-		b.StateTracker.UpdateLastProcessedBinlogPosition(events[len(events)-1].BinlogPosition())
+		b.StateTracker.UpdateLastWrittenBinlogPosition(events[len(events)-1].BinlogPosition())
 	}
 
 	return nil

--- a/data_iterator.go
+++ b/data_iterator.go
@@ -16,7 +16,7 @@ type DataIterator struct {
 
 	ErrorHandler ErrorHandler
 	CursorConfig *CursorConfig
-	StateTracker *CopyStateTracker
+	StateTracker *StateTracker
 
 	targetPKs      *sync.Map
 	batchListeners []func(*RowBatch) error
@@ -32,7 +32,7 @@ func (d *DataIterator) Run(tables []*TableSchema) {
 	// tracking state. However, some methods are still useful so we initialize
 	// a minimal local instance.
 	if d.StateTracker == nil {
-		d.StateTracker = NewCopyStateTracker(0)
+		d.StateTracker = NewStateTracker(0)
 	}
 
 	d.logger.WithField("tablesCount", len(tables)).Info("starting data iterator run")

--- a/ferry.go
+++ b/ferry.go
@@ -481,7 +481,6 @@ func (f *Ferry) Start() error {
 	// is terminated with some rows copied but no binlog events are written.
 	// This guarentees that we are able to restart from a valid location.
 	f.StateTracker.UpdateLastWrittenBinlogPosition(pos)
-	f.StateTracker.UpdateLastStoredBinlogPositionForInlineVerifier(pos)
 
 	return nil
 }

--- a/ferry.go
+++ b/ferry.go
@@ -102,7 +102,7 @@ func (f *Ferry) NewDataIterator() *DataIterator {
 			BatchSize:   f.Config.DataIterationBatchSize,
 			ReadRetries: f.Config.DBReadRetries,
 		},
-		StateTracker: f.StateTracker.CopyStage,
+		StateTracker: f.StateTracker,
 	}
 
 	if f.CopyFilter != nil {
@@ -144,7 +144,7 @@ func (f *Ferry) NewBinlogWriter() *BinlogWriter {
 		WriteRetries: f.Config.DBWriteRetries,
 
 		ErrorHandler: f.ErrorHandler,
-		StateTracker: f.StateTracker.CopyStage,
+		StateTracker: f.StateTracker,
 	}
 }
 
@@ -159,7 +159,7 @@ func (f *Ferry) NewBatchWriter() *BatchWriter {
 
 	batchWriter := &BatchWriter{
 		DB:           f.TargetDB,
-		StateTracker: f.StateTracker.CopyStage,
+		StateTracker: f.StateTracker,
 
 		DatabaseRewrites: f.Config.DatabaseRewrites,
 		TableRewrites:    f.Config.TableRewrites,
@@ -480,7 +480,8 @@ func (f *Ferry) Start() error {
 	// If we don't set this now, there is a race condition where Ghostferry
 	// is terminated with some rows copied but no binlog events are written.
 	// This guarentees that we are able to restart from a valid location.
-	f.StateTracker.CopyStage.UpdateLastProcessedBinlogPosition(pos)
+	f.StateTracker.UpdateLastWrittenBinlogPosition(pos)
+	f.StateTracker.UpdateLastStoredBinlogPositionForInlineVerifier(pos)
 
 	return nil
 }
@@ -698,7 +699,7 @@ func (f *Ferry) Progress() *Progress {
 	s.FinalBinlogPos = f.BinlogStreamer.targetBinlogPosition
 
 	// Table Progress
-	serializedState := f.StateTracker.CopyStage.Serialize()
+	serializedState := f.StateTracker.Serialize(nil)
 	s.Tables = make(map[string]TableProgress)
 	targetPKs := make(map[string]uint64)
 	f.DataIterator.targetPKs.Range(func(k, v interface{}) bool {
@@ -731,7 +732,7 @@ func (f *Ferry) Progress() *Progress {
 	// ETA
 	var totalPKsToCopy uint64 = 0
 	var completedPKs uint64 = 0
-	estimatedPKsPerSecond := f.StateTracker.CopyStage.EstimatedPKsPerSecond()
+	estimatedPKsPerSecond := f.StateTracker.EstimatedPKsPerSecond()
 	for _, targetPK := range targetPKs {
 		totalPKsToCopy += targetPK
 	}

--- a/sharding/test/callbacks_test.go
+++ b/sharding/test/callbacks_test.go
@@ -134,7 +134,7 @@ func (t *CallbacksTestSuite) TestFailsRunOnPanicError() {
 		stateDump := &ghostferry.SerializableState{}
 		jsonErr = json.Unmarshal([]byte(errorData["StateDump"]), stateDump)
 		t.Require().Nil(jsonErr)
-		t.Require().NotNil(stateDump.CopyStage)
+		t.Require().NotNil(stateDump)
 		t.Require().True(len(stateDump.LastKnownTableSchemaCache) > 0)
 
 		w.WriteHeader(http.StatusInternalServerError)

--- a/status_deprecated.go
+++ b/status_deprecated.go
@@ -85,8 +85,8 @@ func FetchStatusDeprecated(f *Ferry, v Verifier) *StatusDeprecated {
 
 	serializedState := f.StateTracker.Serialize(nil)
 
-	lastSuccessfulPKs := serializedState.CopyStage.LastSuccessfulPrimaryKeys
-	completedTables := serializedState.CopyStage.CompletedTables
+	lastSuccessfulPKs := serializedState.LastSuccessfulPrimaryKeys
+	completedTables := serializedState.CompletedTables
 
 	targetPKs := make(map[string]uint64)
 	f.DataIterator.targetPKs.Range(func(k, v interface{}) bool {
@@ -181,7 +181,7 @@ func FetchStatusDeprecated(f *Ferry, v Verifier) *StatusDeprecated {
 	// ASAP. It's not supposed to be that accurate anyway.
 	var totalPKsToCopy uint64 = 0
 	var completedPKs uint64 = 0
-	estimatedPKsPerSecond := f.StateTracker.CopyStage.EstimatedPKsPerSecond()
+	estimatedPKsPerSecond := f.StateTracker.EstimatedPKsPerSecond()
 	for _, targetPK := range targetPKs {
 		totalPKsToCopy += targetPK
 	}

--- a/test/go/data_iterator_test.go
+++ b/test/go/data_iterator_test.go
@@ -54,7 +54,7 @@ func (this *DataIteratorTestSuite) SetupTest() {
 			BatchSize:   config.DataIterationBatchSize,
 			ReadRetries: config.DBReadRetries,
 		},
-		StateTracker: ghostferry.NewCopyStateTracker(config.DataIterationConcurrency * 10),
+		StateTracker: ghostferry.NewStateTracker(config.DataIterationConcurrency * 10),
 	}
 
 	this.receivedRows = make(map[string][]ghostferry.RowData, 0)
@@ -161,7 +161,7 @@ func (this *DataIteratorTestSuite) TestDoneListenerGetsNotifiedWhenDone() {
 }
 
 func (this *DataIteratorTestSuite) completedTables() map[string]bool {
-	return this.di.StateTracker.Serialize().CompletedTables
+	return this.di.StateTracker.Serialize(nil).CompletedTables
 }
 
 func TestDataIterator(t *testing.T) {

--- a/test/integration/interrupt_resume_test.rb
+++ b/test/integration/interrupt_resume_test.rb
@@ -25,7 +25,7 @@ class InterruptResumeTest < GhostferryTestCase
     result = target_db.query("SELECT MAX(id) AS max_id FROM #{DEFAULT_FULL_TABLE_NAME}")
     last_successful_id = result.first["max_id"]
     assert last_successful_id > 0
-    assert_equal last_successful_id, dumped_state["CopyStage"]["LastSuccessfulPrimaryKeys"]["#{DEFAULT_DB}.#{DEFAULT_TABLE}"]
+    assert_equal last_successful_id, dumped_state["LastSuccessfulPrimaryKeys"]["#{DEFAULT_DB}.#{DEFAULT_TABLE}"]
   end
 
   def test_interrupt_and_resume_without_last_known_schema_cache

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -112,6 +112,5 @@ class GhostferryTestCase < Minitest::Test
     refute dumped_state["LastSuccessfulPrimaryKeys"].nil?
     refute dumped_state["CompletedTables"].nil?
     refute dumped_state["LastWrittenBinlogPosition"].nil?
-    refute dumped_state["LastStoredBinlogPositionForInlineVerifier"].nil?
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -109,8 +109,9 @@ class GhostferryTestCase < Minitest::Test
     refute dumped_state.nil?
     refute dumped_state["GhostferryVersion"].nil?
     refute dumped_state["LastKnownTableSchemaCache"].nil?
-    refute dumped_state["CopyStage"]["LastSuccessfulPrimaryKeys"].nil?
-    refute dumped_state["CopyStage"]["CompletedTables"].nil?
-    refute dumped_state["CopyStage"]["LastProcessedBinlogPosition"].nil?
+    refute dumped_state["LastSuccessfulPrimaryKeys"].nil?
+    refute dumped_state["CompletedTables"].nil?
+    refute dumped_state["LastWrittenBinlogPosition"].nil?
+    refute dumped_state["LastStoredBinlogPositionForInlineVerifier"].nil?
   end
 end


### PR DESCRIPTION
The `StateTracker` code was complex as it was split between the `CopyStateTracker` and the `VerifierStateTracker`. Since we are moving towards the `InlineVerifier`, which requires very little state, we don't need this complexity anymore. 

This PR removes the extra complexity and only retains a single `StateTracker` and `SerializableState`.