### PR TITLE
Made InlineVerifier resumable

### DIFF
--- a/batch_writer.go
+++ b/batch_writer.go
@@ -83,7 +83,7 @@ func (w *BatchWriter) WriteRowBatch(batch *RowBatch) error {
 
 			if len(mismatches) > 0 {
 				tx.Rollback()
-				return fmt.Errorf("row fingerprints for pks %v do not match", mismatches)
+				return fmt.Errorf("row fingerprints for pks %v on %v do not match", mismatches, batch.TableSchema().String())
 			}
 		}
 

--- a/ferry.go
+++ b/ferry.go
@@ -726,11 +726,12 @@ func (f *Ferry) SerializeStateToJSON() (string, error) {
 		err := errors.New("no valid StateTracker")
 		return "", err
 	}
-	serializedState := f.StateTracker.Serialize(f.Tables)
-
+	var binlogVerifyStore *BinlogVerifyStore = nil
 	if f.inlineVerifier != nil {
-		serializedState.BinlogVerifyStore = f.inlineVerifier.reverifyStore.Serialize()
+		binlogVerifyStore = f.inlineVerifier.reverifyStore
 	}
+
+	serializedState := f.StateTracker.Serialize(f.Tables, binlogVerifyStore)
 
 	stateBytes, err := json.MarshalIndent(serializedState, "", " ")
 	return string(stateBytes), err
@@ -751,7 +752,7 @@ func (f *Ferry) Progress() *Progress {
 	s.FinalBinlogPos = f.BinlogStreamer.targetBinlogPosition
 
 	// Table Progress
-	serializedState := f.StateTracker.Serialize(nil)
+	serializedState := f.StateTracker.Serialize(nil, nil)
 	s.Tables = make(map[string]TableProgress)
 	targetPKs := make(map[string]uint64)
 	f.DataIterator.targetPKs.Range(func(k, v interface{}) bool {

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -197,21 +197,6 @@ func (r *ShardingFerry) deltaCopyJoinedTables() error {
 		return err
 	}
 
-	verifier, err := r.Ferry.NewIterativeVerifier()
-	if err != nil {
-		return err
-	}
-
-	verifier.Tables = tables
-
-	verificationResult, err := verifier.VerifyOnce()
-	if err != nil {
-		return err
-	}
-	if !verificationResult.DataCorrect {
-		return fmt.Errorf("joined tables verifier detected data discrepancy: %s", verificationResult.Message)
-	}
-
 	return nil
 }
 
@@ -250,21 +235,6 @@ func (r *ShardingFerry) copyPrimaryKeyTables() error {
 	err = r.Ferry.RunStandaloneDataCopy(tables)
 	if err != nil {
 		return err
-	}
-
-	verifier, err := r.Ferry.NewIterativeVerifier()
-	if err != nil {
-		return err
-	}
-
-	verifier.TableSchemaCache = sourceDbTables
-	verifier.Tables = tables
-
-	verificationResult, err := verifier.VerifyOnce()
-	if err != nil {
-		return err
-	} else if !verificationResult.DataCorrect {
-		return fmt.Errorf("primary key tables verifier detected data discrepancy: %s", verificationResult.Message)
 	}
 
 	return nil

--- a/sharding/test/primary_key_table_test.go
+++ b/sharding/test/primary_key_table_test.go
@@ -90,7 +90,7 @@ func (t *PrimaryKeyTableTestSuite) TestPrimaryKeyTableVerificationFailure() {
 	t.Ferry.Run()
 
 	t.Require().NotNil(errHandler.LastError)
-	t.Require().Equal("primary key tables verifier detected data discrepancy: verification failed on table: gftest1.tenants_table for pk: 2", errHandler.LastError.Error())
+	t.Require().Equal("row fingerprints for pks [2] on gftest1.tenants_table do not match", errHandler.LastError.Error())
 }
 
 func TestPrimaryKeyTableTestSuite(t *testing.T) {

--- a/state_tracker.go
+++ b/state_tracker.go
@@ -209,7 +209,7 @@ func (s *StateTracker) updateSpeedLog(deltaPK uint64) {
 	}
 }
 
-func (s *StateTracker) Serialize(lastKnownTableSchemaCache TableSchemaCache) *SerializableState {
+func (s *StateTracker) Serialize(lastKnownTableSchemaCache TableSchemaCache, binlogVerifyStore *BinlogVerifyStore) *SerializableState {
 	s.BinlogRWMutex.RLock()
 	defer s.BinlogRWMutex.RUnlock()
 
@@ -223,6 +223,10 @@ func (s *StateTracker) Serialize(lastKnownTableSchemaCache TableSchemaCache) *Se
 		CompletedTables:                           make(map[string]bool),
 		LastWrittenBinlogPosition:                 s.lastWrittenBinlogPosition,
 		LastStoredBinlogPositionForInlineVerifier: s.lastStoredBinlogPositionForInlineVerifier,
+	}
+
+	if binlogVerifyStore != nil {
+		state.BinlogVerifyStore = binlogVerifyStore.Serialize()
 	}
 
 	// Need a copy because lastSuccessfulPrimaryKeys may change after Serialize

--- a/state_tracker.go
+++ b/state_tracker.go
@@ -38,6 +38,7 @@ type SerializableState struct {
 	CompletedTables                           map[string]bool
 	LastWrittenBinlogPosition                 mysql.Position
 	LastStoredBinlogPositionForInlineVerifier mysql.Position
+	BinlogVerifyStore                         BinlogVerifySerializedStore
 }
 
 func (s *SerializableState) MinBinlogPosition() mysql.Position {
@@ -222,7 +223,6 @@ func (s *StateTracker) Serialize(lastKnownTableSchemaCache TableSchemaCache) *Se
 		CompletedTables:                           make(map[string]bool),
 		LastWrittenBinlogPosition:                 s.lastWrittenBinlogPosition,
 		LastStoredBinlogPositionForInlineVerifier: s.lastStoredBinlogPositionForInlineVerifier,
-		// TODO: BinlogVerifySerializedStore
 	}
 
 	// Need a copy because lastSuccessfulPrimaryKeys may change after Serialize

--- a/status_deprecated.go
+++ b/status_deprecated.go
@@ -83,7 +83,7 @@ func FetchStatusDeprecated(f *Ferry, v Verifier) *StatusDeprecated {
 	// Getting all table statuses
 	status.TableStatuses = make([]*TableStatusDeprecated, 0, len(f.Tables))
 
-	serializedState := f.StateTracker.Serialize(nil)
+	serializedState := f.StateTracker.Serialize(nil, nil)
 
 	lastSuccessfulPKs := serializedState.LastSuccessfulPrimaryKeys
 	completedTables := serializedState.CompletedTables

--- a/test/go/data_iterator_test.go
+++ b/test/go/data_iterator_test.go
@@ -161,7 +161,7 @@ func (this *DataIteratorTestSuite) TestDoneListenerGetsNotifiedWhenDone() {
 }
 
 func (this *DataIteratorTestSuite) completedTables() map[string]bool {
-	return this.di.StateTracker.Serialize(nil).CompletedTables
+	return this.di.StateTracker.Serialize(nil, nil).CompletedTables
 }
 
 func TestDataIterator(t *testing.T) {

--- a/test/go/inline_verifier_test.go
+++ b/test/go/inline_verifier_test.go
@@ -1,0 +1,46 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/Shopify/ghostferry"
+	"github.com/stretchr/testify/require"
+)
+
+func newMockBinlogVerifySerializedStore() ghostferry.BinlogVerifySerializedStore {
+	s := make(ghostferry.BinlogVerifySerializedStore)
+	s["db"] = map[string]map[uint64]int{
+		"table1": map[uint64]int{
+			3:  1,
+			10: 2,
+			30: 3,
+		},
+	}
+	s["db2"] = map[string]map[uint64]int{
+		"table2": map[uint64]int{
+			4:  1,
+			20: 2,
+			40: 1,
+		},
+	}
+	return s
+}
+
+func TestBinlogVerifySerializedStoreRowCount(t *testing.T) {
+	r := require.New(t)
+
+	s := newMockBinlogVerifySerializedStore()
+
+	r.Equal(uint64(10), s.RowCount())
+}
+
+func TestBinlogVerifySerializedStoreCopy(t *testing.T) {
+	r := require.New(t)
+
+	s := newMockBinlogVerifySerializedStore()
+	s2 := s.Copy()
+	s2["db"]["table1"][3] += 1
+
+	r.Equal(uint64(10), s.RowCount())
+	r.Equal(uint64(11), s2.RowCount())
+}

--- a/test/helpers/ghostferry_helper.rb
+++ b/test/helpers/ghostferry_helper.rb
@@ -252,7 +252,7 @@ module GhostferryHelper
                 @logger.debug("stdout: #{line}")
               elsif reader == stderr
                 @stderr << line
-                if line.start_with?("{")
+                if json_log_line?(line)
                   logline = JSON.parse(line)
                   tag = logline["tag"]
                   tag = "_none" if tag.nil?
@@ -340,6 +340,12 @@ module GhostferryHelper
       rescue GhostferryExitFailure
         # ignore
       end
+    end
+
+    private
+
+    def json_log_line?(line)
+      line.start_with?("{")
     end
   end
 end

--- a/test/helpers/ghostferry_helper.rb
+++ b/test/helpers/ghostferry_helper.rb
@@ -47,7 +47,7 @@ module GhostferryHelper
       AFTER_BINLOG_APPLY = "AFTER_BINLOG_APPLY"
     end
 
-    attr_reader :stdout, :stderr, :exit_status, :pid, :error
+    attr_reader :stdout, :stderr, :logrus_lines, :exit_status, :pid, :error, :error_lines
 
     def initialize(main_path, config: {}, logger: nil, message_timeout: 30, port: 39393)
       @logger = logger
@@ -76,6 +76,8 @@ module GhostferryHelper
       @exit_status = nil
       @stdout = []
       @stderr = []
+      @logrus_lines = {} # tag => [line1, line2]
+      @error_lines = [] # lines with level == error
       @error = nil
 
       # Setup the directory to the compiled binary under the system temporary
@@ -250,6 +252,17 @@ module GhostferryHelper
                 @logger.debug("stdout: #{line}")
               elsif reader == stderr
                 @stderr << line
+                if line.start_with?("{")
+                  logline = JSON.parse(line)
+                  tag = logline["tag"]
+                  tag = "_none" if tag.nil?
+                  @logrus_lines[tag] ||= []
+                  @logrus_lines[tag] << logline
+
+                  if logline["level"] == "error"
+                    @error_lines << logline
+                  end
+                end
                 @logger.debug("stderr: #{line}")
               end
             end
@@ -306,6 +319,11 @@ module GhostferryHelper
 
     def send_signal(signal)
       Process.kill(signal, @pid) if @pid != 0
+    end
+
+    def term_and_wait_for_exit
+      send_signal("TERM")
+      @subprocess_thread.join
     end
 
     def kill

--- a/test/integration/inline_verifier_test.rb
+++ b/test/integration/inline_verifier_test.rb
@@ -21,7 +21,7 @@ class InlineVerifierTest < GhostferryTestCase
 
     refute_nil ghostferry.error
     err_msg = ghostferry.error["ErrMessage"]
-    assert err_msg.include?("row fingerprints for pks [#{corrupting_id}] do not match"), message: err_msg
+    assert err_msg.include?("row fingerprints for pks [#{corrupting_id}] on #{DEFAULT_DB}.#{DEFAULT_TABLE} do not match"), message: err_msg
 
     # Make sure it is not inserted into the target
     results = target_db.query("SELECT * FROM #{DEFAULT_FULL_TABLE_NAME} WHERE id = #{corrupting_id}")
@@ -45,7 +45,7 @@ class InlineVerifierTest < GhostferryTestCase
 
     refute_nil ghostferry.error
     err_msg = ghostferry.error["ErrMessage"]
-    assert err_msg.include?("row fingerprints for pks [1] do not match"), message: err_msg
+    assert err_msg.include?("row fingerprints for pks [1] on #{DEFAULT_DB}.#{DEFAULT_TABLE} do not match"), message: err_msg
   end
 
   def test_same_decompressed_data_different_compressed_test_passes_inline_verification

--- a/test/integration/inline_verifier_test.rb
+++ b/test/integration/inline_verifier_test.rb
@@ -88,6 +88,7 @@ class InlineVerifierTest < GhostferryTestCase
 
     ghostferry.run
     assert verification_ran
+    assert_equal "cutover verification failed for: gftest.test_table_1 [pks: #{corrupting_id} ] ", ghostferry.error_lines.last["msg"]
   end
 
   private

--- a/test/integration/interrupt_resume_test.rb
+++ b/test/integration/interrupt_resume_test.rb
@@ -104,4 +104,172 @@ class InterruptResumeTest < GhostferryTestCase
 
     assert_test_table_is_identical
   end
+
+  def test_interrupt_resume_inline_verifier_with_datawriter
+    datawriter = new_source_datawriter
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline" })
+
+    start_datawriter_with_ghostferry(datawriter, ghostferry)
+
+    batches_written = 0
+    ghostferry.on_status(Ghostferry::Status::AFTER_ROW_COPY) do
+      batches_written += 1
+      if batches_written >= 2
+        ghostferry.term_and_wait_for_exit
+      end
+    end
+
+    dumped_state = ghostferry.run_expecting_interrupt
+    assert_basic_fields_exist_in_dumped_state(dumped_state)
+    refute_nil dumped_state["BinlogVerifyStore"]
+    refute_nil dumped_state["BinlogVerifyStore"]["gftest"]
+    refute_nil dumped_state["BinlogVerifyStore"]["gftest"]["test_table_1"]
+
+    # Resume Ghostferry with dumped state
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline" })
+
+    verification_ran = false
+    incorrect_tables = []
+    ghostferry.on_status(Ghostferry::Status::VERIFIED) do |*tables|
+      verification_ran = true
+      incorrect_tables = tables
+    end
+
+    # The datawriter is still writing to the database since earlier, so we need
+    # to stop it during cutover.
+    stop_datawriter_during_cutover(datawriter, ghostferry)
+
+    ghostferry.run(dumped_state)
+
+    assert verification_ran
+    assert_equal 0, incorrect_tables.length
+    assert_test_table_is_identical
+  end
+
+  def test_interrupt_inline_verifier_will_emit_binlog_verify_store
+    result = source_db.query("SELECT MAX(id) FROM #{DEFAULT_FULL_TABLE_NAME}")
+    chosen_id = result.first["MAX(id)"] + 1
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline" })
+
+    i = 0
+    ghostferry.on_status(Ghostferry::Status::AFTER_ROW_COPY) do
+      sleep if i >= 1 # block the DataIterator so it doesn't race with the term_and_wait_for_exit below.
+      source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} (id, data) VALUES (#{chosen_id}, 'data')")
+      i += 1
+    end
+
+    ghostferry.on_status(Ghostferry::Status::AFTER_BINLOG_APPLY) do
+      ghostferry.term_and_wait_for_exit
+    end
+
+    dumped_state = ghostferry.run_expecting_interrupt
+    assert_basic_fields_exist_in_dumped_state(dumped_state)
+    refute_nil dumped_state["BinlogVerifyStore"]
+    refute_nil dumped_state["BinlogVerifyStore"]["gftest"]
+    refute_nil dumped_state["BinlogVerifyStore"]["gftest"]["test_table_1"]
+
+    # FLAKY: AFTER_BINLOG_APPLY is emitted after the BinlogStreamer
+    #        finishes processing all of the event listeners. The block below
+    #        blocks the BinlogStreamer from processing additional rows but it
+    #        does not block InlineVerifier.PeriodicallyVerifyBinlogEvents. This
+    #        means the binlog event created in the code above may be verified
+    #        before the TERM signal is processed. Thus, the state dump may not
+    #        contain this row.
+    #
+    #        Fixing this is somewhat non-trivial and likely require a more
+    #        extensive signal emitting system within Ghostferry.
+    assert_equal 1, dumped_state["BinlogVerifyStore"]["gftest"]["test_table_1"]["#{chosen_id}"]
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline" })
+    ghostferry.run(dumped_state)
+    assert_test_table_is_identical
+  end
+
+  def test_interrupt_resume_inline_verifier_will_verify_entries_in_reverify_store
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline" })
+
+    # This row would have been copied as we terminate ghostferry after 1 batch
+    # is copied.
+    result = source_db.query("SELECT MIN(id) FROM #{DEFAULT_FULL_TABLE_NAME}")
+    chosen_id = result.first["MIN(id)"] + 1
+
+    i = 0
+    ghostferry.on_status(Ghostferry::Status::AFTER_ROW_COPY) do
+      if i == 1
+        # We need to delete it the second batch because trying to delete the
+        # minimum id row while in the first batch will result in a lock as the
+        # DataIterator holds a FOR UPDATE lock for the minimum id row.
+        source_db.query("DELETE FROM #{DEFAULT_FULL_TABLE_NAME} WHERE id = #{chosen_id}")
+      end
+      sleep if i > 1 # block the DataIterator so it doesn't race with the term_and_wait_for_exit below.
+      i += 1
+    end
+
+    ghostferry.on_status(Ghostferry::Status::AFTER_BINLOG_APPLY) do
+      ghostferry.term_and_wait_for_exit
+    end
+
+    dumped_state = ghostferry.run_expecting_interrupt
+    assert_basic_fields_exist_in_dumped_state(dumped_state)
+    refute_nil dumped_state["BinlogVerifyStore"]
+    refute_nil dumped_state["BinlogVerifyStore"]["gftest"]
+    refute_nil dumped_state["BinlogVerifyStore"]["gftest"]["test_table_1"]
+
+    # FLAKY: See explanation in test_interrupt_inline_verifier_will_emit_binlog_verify_store
+    assert_equal 1, dumped_state["BinlogVerifyStore"]["gftest"]["test_table_1"]["#{chosen_id}"]
+
+    # Corrupt the row before resuming
+    target_db.query("REPLACE INTO #{DEFAULT_FULL_TABLE_NAME} (id, data) VALUES (#{chosen_id}, 'corrupted')")
+
+    verification_ran = false
+    incorrect_tables = nil
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline" })
+    ghostferry.on_status(Ghostferry::Status::VERIFIED) do |*tables|
+      verification_ran = true
+      incorrect_tables = tables
+    end
+
+    ghostferry.run(dumped_state)
+    assert verification_ran
+    assert_equal 1, incorrect_tables.length
+    assert_equal "gftest.test_table_1", incorrect_tables.first
+
+    error_line = ghostferry.error_lines.last
+    assert_equal "cutover verification failed for: gftest.test_table_1 [pks: #{chosen_id} ] ", error_line["msg"]
+  end
+
+  def test_interrupt_resume_inline_verifier_will_verify_additional_rows_changed_on_source_during_interrupt
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline" })
+
+    ghostferry.on_status(Ghostferry::Status::AFTER_ROW_COPY) do
+      ghostferry.term_and_wait_for_exit
+    end
+
+    dumped_state = ghostferry.run_expecting_interrupt
+    assert_basic_fields_exist_in_dumped_state(dumped_state)
+    refute_nil dumped_state["BinlogVerifyStore"]
+
+    result = source_db.query("SELECT MIN(id) FROM #{DEFAULT_FULL_TABLE_NAME}")
+    chosen_id = result.first["MIN(id)"]
+
+    source_db.query("UPDATE #{DEFAULT_FULL_TABLE_NAME} SET data = 'data2' WHERE id = #{chosen_id}")
+    target_db.query("UPDATE #{DEFAULT_FULL_TABLE_NAME} SET data = 'corrupted' WHERE id = #{chosen_id}")
+
+    verification_ran = false
+    incorrect_tables = nil
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline" })
+    ghostferry.on_status(Ghostferry::Status::VERIFIED) do |*tables|
+      verification_ran = true
+      incorrect_tables = tables
+    end
+
+    ghostferry.run(dumped_state)
+    assert verification_ran
+    assert_equal 1, incorrect_tables.length
+    assert_equal "gftest.test_table_1", incorrect_tables.first
+
+    error_line = ghostferry.error_lines.last
+    assert_equal "cutover verification failed for: gftest.test_table_1 [pks: #{chosen_id} ] ", error_line["msg"]
+  end
 end


### PR DESCRIPTION
This PR makes all of Ghostferry interrupt/resumable when running with the InlineVerifier. Most of the code are the ruby integration tests.

Also note: Previously, `RunStandaloneCopy` was recording improper LastSuccessfulPK position as the BatchWriter from Ferry is reused in it. This is fixed. Furthermore, the IterativeVerifier is removed from `deltaCopyJoinedTables` and `copyPrimaryKeyTables`. Instead, RunStandaloneCopy now automatically verifies the data via the InlineVerifier.
