### PR TITLE
Explicitly link tutorial and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ Run tests:
 Test copydb:
 
 - `make copydb && ghostferry-copydb -verbose examples/copydb/conf.json`
-- For a more detailed tutorial, see the
-  [documentation](https://shopify.github.io/ghostferry).
+- For a more detailed [tutorial](https://shopify.github.io/ghostferry/master/tutorialcopydb.html), see the
+  [documentation](https://shopify.github.io/ghostferry/master/index.html).


### PR DESCRIPTION
When clicking on the "documentation" link one lands on page prompting to select a branch, which seems unintended. This MR links documentation directly to its master version. It also explicitly links "tutorial" to its page in the docs.