### PR TITLE
Rename sharding.Config.SourceDB => SourceSchema

### DIFF
--- a/sharding/cmd/main.go
+++ b/sharding/cmd/main.go
@@ -117,12 +117,12 @@ func parseConfig() *sharding.Config {
 		errorAndExit("missing ShardingValue config")
 	}
 
-	if config.SourceDB == "" {
-		errorAndExit("missing SourceDB config")
+	if config.SourceSchema == "" {
+		errorAndExit("missing SourceSchema config")
 	}
 
-	if config.TargetDB == "" {
-		errorAndExit("missing TargetDB config")
+	if config.TargetSchema == "" {
+		errorAndExit("missing TargetSchema config")
 	}
 
 	if config.StatsDAddress == "" {

--- a/sharding/config.go
+++ b/sharding/config.go
@@ -9,8 +9,8 @@ type Config struct {
 
 	ShardingKey   string
 	ShardingValue int64
-	SourceDB      string
-	TargetDB      string
+	SourceSchema  string
+	TargetSchema  string
 
 	SourceReplicationMaster       *ghostferry.DatabaseConfig
 	ReplicatedMasterPositionQuery string

--- a/sharding/metrics.go
+++ b/sharding/metrics.go
@@ -26,8 +26,8 @@ func InitializeMetrics(prefix string, config *Config) error {
 	SetGlobalMetrics(prefix, metricsChan)
 
 	metrics.DefaultTags = []ghostferry.MetricTag{
-		{Name: "SourceDB", Value: config.SourceDB},
-		{Name: "TargetDB", Value: config.TargetDB},
+		{Name: "SourceDB", Value: config.SourceSchema},
+		{Name: "TargetDB", Value: config.TargetSchema},
 	}
 
 	metrics.AddConsumer()

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -20,7 +20,7 @@ type ShardingFerry struct {
 func NewFerry(config *Config) (*ShardingFerry, error) {
 	var err error
 
-	config.DatabaseRewrites = map[string]string{config.SourceDB: config.TargetDB}
+	config.DatabaseRewrites = map[string]string{config.SourceSchema: config.TargetSchema}
 
 	config.CopyFilter = &ShardedCopyFilter{
 		ShardingKey:   config.ShardingKey,
@@ -37,7 +37,7 @@ func NewFerry(config *Config) (*ShardingFerry, error) {
 
 	config.TableFilter = &ShardedTableFilter{
 		ShardingKey:   config.ShardingKey,
-		SourceShard:   config.SourceDB,
+		SourceShard:   config.SourceSchema,
 		JoinedTables:  config.JoinedTables,
 		IgnoredTables: ignored,
 	}

--- a/sharding/testhelpers/unit_test_suite.go
+++ b/sharding/testhelpers/unit_test_suite.go
@@ -14,15 +14,15 @@ import (
 )
 
 const (
-	sourceDbName    = "gftest1"
-	targetDbName    = "gftest2"
-	testTable       = "table1"
-	primaryKeyTable = "tenants_table"
-	joinedTableName = "joined_table"
-	joinTableName   = "join_table"
-	joiningKey      = "join_id"
-	shardingKey     = "tenant_id"
-	shardingValue   = 2
+	sourceSchemaName = "gftest1"
+	targetSchemaName = "gftest2"
+	testTable        = "table1"
+	primaryKeyTable  = "tenants_table"
+	joinedTableName  = "joined_table"
+	joinTableName    = "join_table"
+	joiningKey       = "join_id"
+	shardingKey      = "tenant_id"
+	shardingValue    = 2
 )
 
 type ShardingUnitTestSuite struct {
@@ -81,35 +81,35 @@ func (t *ShardingUnitTestSuite) SetupTest() {
 	t.dropTestDbs()
 	testhelpers.SetupTest()
 
-	testhelpers.SeedInitialData(t.SourceDB, sourceDbName, testTable, 1000)
-	testhelpers.SeedInitialData(t.TargetDB, targetDbName, testTable, 0)
+	testhelpers.SeedInitialData(t.SourceDB, sourceSchemaName, testTable, 1000)
+	testhelpers.SeedInitialData(t.TargetDB, targetSchemaName, testTable, 0)
 
-	testhelpers.SeedInitialData(t.SourceDB, sourceDbName, joinedTableName, 100)
-	testhelpers.SeedInitialData(t.TargetDB, targetDbName, joinedTableName, 0)
+	testhelpers.SeedInitialData(t.SourceDB, sourceSchemaName, joinedTableName, 100)
+	testhelpers.SeedInitialData(t.TargetDB, targetSchemaName, joinedTableName, 0)
 
-	testhelpers.SeedInitialData(t.SourceDB, sourceDbName, joinTableName, 100)
-	testhelpers.SeedInitialData(t.TargetDB, targetDbName, joinTableName, 0)
+	testhelpers.SeedInitialData(t.SourceDB, sourceSchemaName, joinTableName, 100)
+	testhelpers.SeedInitialData(t.TargetDB, targetSchemaName, joinTableName, 0)
 
-	testhelpers.AddTenantID(t.SourceDB, sourceDbName, testTable, 3)
-	testhelpers.AddTenantID(t.TargetDB, targetDbName, testTable, 3)
+	testhelpers.AddTenantID(t.SourceDB, sourceSchemaName, testTable, 3)
+	testhelpers.AddTenantID(t.TargetDB, targetSchemaName, testTable, 3)
 
-	testhelpers.AddTenantID(t.SourceDB, sourceDbName, joinTableName, 3)
-	testhelpers.AddTenantID(t.TargetDB, targetDbName, joinTableName, 3)
+	testhelpers.AddTenantID(t.SourceDB, sourceSchemaName, joinTableName, 3)
+	testhelpers.AddTenantID(t.TargetDB, targetSchemaName, joinTableName, 3)
 
-	addJoinID(t.SourceDB, sourceDbName, joinTableName)
-	addJoinID(t.TargetDB, targetDbName, joinTableName)
+	addJoinID(t.SourceDB, sourceSchemaName, joinTableName)
+	addJoinID(t.TargetDB, targetSchemaName, joinTableName)
 
-	testhelpers.SeedInitialData(t.SourceDB, sourceDbName, primaryKeyTable, 3)
-	testhelpers.SeedInitialData(t.TargetDB, targetDbName, primaryKeyTable, 0)
+	testhelpers.SeedInitialData(t.SourceDB, sourceSchemaName, primaryKeyTable, 3)
+	testhelpers.SeedInitialData(t.TargetDB, targetSchemaName, primaryKeyTable, 0)
 
-	testhelpers.SeedInitialData(t.SourceDB, sourceDbName, testhelpers.TestCompressedTable1Name, 0)
-	testhelpers.SeedInitialData(t.TargetDB, targetDbName, testhelpers.TestCompressedTable1Name, 0)
+	testhelpers.SeedInitialData(t.SourceDB, sourceSchemaName, testhelpers.TestCompressedTable1Name, 0)
+	testhelpers.SeedInitialData(t.TargetDB, targetSchemaName, testhelpers.TestCompressedTable1Name, 0)
 
-	setColumnType(t.SourceDB, sourceDbName, testhelpers.TestCompressedTable1Name, testhelpers.TestCompressedColumn1Name, "MEDIUMBLOB")
-	setColumnType(t.TargetDB, targetDbName, testhelpers.TestCompressedTable1Name, testhelpers.TestCompressedColumn1Name, "MEDIUMBLOB")
+	setColumnType(t.SourceDB, sourceSchemaName, testhelpers.TestCompressedTable1Name, testhelpers.TestCompressedColumn1Name, "MEDIUMBLOB")
+	setColumnType(t.TargetDB, targetSchemaName, testhelpers.TestCompressedTable1Name, testhelpers.TestCompressedColumn1Name, "MEDIUMBLOB")
 
-	testhelpers.AddTenantID(t.SourceDB, sourceDbName, testhelpers.TestCompressedTable1Name, 3)
-	testhelpers.AddTenantID(t.TargetDB, targetDbName, testhelpers.TestCompressedTable1Name, 3)
+	testhelpers.AddTenantID(t.SourceDB, sourceSchemaName, testhelpers.TestCompressedTable1Name, 3)
+	testhelpers.AddTenantID(t.TargetDB, targetSchemaName, testhelpers.TestCompressedTable1Name, 3)
 
 	t.setupShardingFerry()
 }
@@ -125,8 +125,8 @@ func (t *ShardingUnitTestSuite) AssertTenantCopied() {
 	testhelpers.AssertTwoQueriesHaveEqualResult(
 		t.T(),
 		t.Ferry.Ferry,
-		fmt.Sprintf("SELECT * FROM %s.%s WHERE %s = %d", sourceDbName, testTable, shardingKey, shardingValue),
-		fmt.Sprintf("SELECT * FROM %s.%s", targetDbName, testTable),
+		fmt.Sprintf("SELECT * FROM %s.%s WHERE %s = %d", sourceSchemaName, testTable, shardingKey, shardingValue),
+		fmt.Sprintf("SELECT * FROM %s.%s", targetSchemaName, testTable),
 	)
 }
 
@@ -139,8 +139,8 @@ func (t *ShardingUnitTestSuite) setupShardingFerry() {
 		ShardingKey:   shardingKey,
 		ShardingValue: shardingValue,
 
-		SourceDB: sourceDbName,
-		TargetDB: targetDbName,
+		SourceSchema: sourceSchemaName,
+		TargetSchema: targetSchemaName,
 
 		JoinedTables: map[string][]sharding.JoinTable{
 			joinedTableName: []sharding.JoinTable{
@@ -174,10 +174,10 @@ func (t *ShardingUnitTestSuite) setupShardingFerry() {
 }
 
 func (t *ShardingUnitTestSuite) dropTestDbs() {
-	_, err := t.SourceDB.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s", sourceDbName))
+	_, err := t.SourceDB.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s", sourceSchemaName))
 	t.Require().Nil(err)
 
-	_, err = t.TargetDB.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s", targetDbName))
+	_, err = t.TargetDB.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s", targetSchemaName))
 	t.Require().Nil(err)
 }
 


### PR DESCRIPTION
`SourceDB` and `TargetDB` on `sharding.Config` refers to the schema name of a database. `SourceDB` is also used on `ghostferry.Ferry` to point to a `*sql.DB`. Since the `Ferry` struct also embeds a `Config` struct (a questionable choice to begin with), this naming caused me significant confusion.

I'm not sure if this adds to more confusion, but I want to quickly raise this issue as this is not the first time I got confused by variable names using words such as: "schema", "db"/"database", "table", and "table schema".