### PR TITLE
Ignore LDFLAGS from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ COMMIT          := $(addsuffix $(DIRTY_TREE),$(shell git rev-parse --short HEAD)
 VERSION_STR     := $(VERSION)+$(DATETIME)+$(COMMIT)
 
 # Flags
-LDFLAGS         += -X github.com/Shopify/ghostferry.VersionString=$(VERSION_STR)
+LDFLAGS         := -X github.com/Shopify/ghostferry.VersionString=$(VERSION_STR)
 
 # Paths
 GOBIN           := $(GOPATH)/bin


### PR DESCRIPTION
This was causing issues for our developers running `make sharding`.

Let's ignore the LDFLAGS that are already set in the environment for a more deterministic build