### PR TITLE
Additional info logs in DataIterator

### DIFF
--- a/data_iterator.go
+++ b/data_iterator.go
@@ -138,8 +138,15 @@ func (d *DataIterator) Run(tables []*TableSchema) {
 				})
 
 				if err != nil {
-					logger.WithError(err).Error("failed to iterate table")
-					d.ErrorHandler.Fatal("data_iterator", err)
+					switch e := err.(type) {
+					case BatchWriterVerificationFailed:
+						logger.WithField("incorrect_tables", e.table).Error(e.Error())
+						d.ErrorHandler.Fatal("inline_verifier", err)
+					default:
+						logger.WithError(err).Error("failed to iterate table")
+						d.ErrorHandler.Fatal("data_iterator", err)
+					}
+
 				}
 
 				logger.Debug("table iteration completed")

--- a/data_iterator.go
+++ b/data_iterator.go
@@ -152,8 +152,18 @@ func (d *DataIterator) Run(tables []*TableSchema) {
 		}()
 	}
 
+	i := 0
+	loggingIncrement := len(tablesWithData) / 50
+	if loggingIncrement == 0 {
+		loggingIncrement = 1
+	}
+
 	for table, _ := range tablesWithData {
 		tablesQueue <- table
+		i++
+		if i%loggingIncrement == 0 {
+			d.logger.WithField("table", table.String()).Infof("queued table for processing (%d/%d)", i, len(tablesWithData))
+		}
 	}
 
 	d.logger.Info("done queueing tables to be iterated, closing table channel")


### PR DESCRIPTION
Note: I need this for some downstream tests so I can more reliably interrupt Ghostferry based on logging outputs. That said, this is probably nice in case someone wants to run Ghostferry without `-verbose`.

If debug level logs are turned off (as in ghostferry-sharding), there are no visibility of the DataIterator's progress in the logs. This PR adds at most 50 lines of logs while the DataIterator runs.

The log lines are emitted after a table is queued. Since the queue is an unbuffered channel and consumed by the tableIterators, logging here will reliably report the approximate number of tables copied by Ghostferry.

