### PR TITLE
Ignore certain columns during InlineVerification

### DIFF
--- a/copydb/test/copydb_test.go
+++ b/copydb/test/copydb_test.go
@@ -67,7 +67,7 @@ func (t *CopydbTestSuite) TearDownTest() {
 
 func (t *CopydbTestSuite) TestCreateDatabaseAndTableWithRewrites() {
 	var err error
-	t.copydbFerry.Ferry.Tables, err = ghostferry.LoadTables(t.ferry.SourceDB, t.copydbFerry.Ferry.TableFilter, nil)
+	t.copydbFerry.Ferry.Tables, err = ghostferry.LoadTables(t.ferry.SourceDB, t.copydbFerry.Ferry.TableFilter, nil, nil)
 	t.Require().Nil(err)
 
 	err = t.copydbFerry.CreateDatabasesAndTables()

--- a/copydb/test/filter_test.go
+++ b/copydb/test/filter_test.go
@@ -38,6 +38,7 @@ func (this *FilterTestSuite) TestLoadTablesWithWhitelist() {
 			},
 		),
 		nil,
+		nil,
 	)
 
 	this.Require().Nil(err)
@@ -61,6 +62,7 @@ func (this *FilterTestSuite) TestLoadTablesWithBlacklist() {
 				Blacklist: []string{"test_table_2"},
 			},
 		),
+		nil,
 		nil,
 	)
 

--- a/ferry.go
+++ b/ferry.go
@@ -422,7 +422,7 @@ func (f *Ferry) Initialize() (err error) {
 	// changed.
 	if f.StateToResumeFrom == nil || f.StateToResumeFrom.LastKnownTableSchemaCache == nil {
 		metrics.Measure("LoadTables", nil, 1.0, func() {
-			f.Tables, err = LoadTables(f.SourceDB, f.TableFilter, f.ColumnCompressionConfig)
+			f.Tables, err = LoadTables(f.SourceDB, f.TableFilter, f.CompressedColumnsForVerification, f.IgnoredColumnsForVerification)
 		})
 		if err != nil {
 			return err

--- a/inline_verifier.go
+++ b/inline_verifier.go
@@ -277,7 +277,7 @@ func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetSchema, target
 		for idx, col := range table.Columns {
 			var compressedData []byte
 			var ok bool
-			if _, ok = table.CompressedColumns[col.Name]; !ok {
+			if _, ok = table.CompressedColumnsForVerification[col.Name]; !ok {
 				continue
 			}
 
@@ -462,7 +462,7 @@ func (v *InlineVerifier) getFingerprintDataFromDb(db *sql.DB, stmtCache *StmtCac
 
 func (v *InlineVerifier) decompressData(table *TableSchema, column string, compressed []byte) ([]byte, error) {
 	var decompressed []byte
-	algorithm, isCompressed := table.CompressedColumns[column]
+	algorithm, isCompressed := table.CompressedColumnsForVerification[column]
 	if !isCompressed {
 		return nil, fmt.Errorf("%v is not a compressed column", column)
 	}

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -213,7 +213,7 @@ func (r *ShardingFerry) copyPrimaryKeyTables() error {
 	r.config.TableFilter.(*ShardedTableFilter).PrimaryKeyTables = pkTables
 	r.config.CopyFilter.(*ShardedCopyFilter).PrimaryKeyTables = pkTables
 
-	sourceDbTables, err := ghostferry.LoadTables(r.Ferry.SourceDB, r.config.TableFilter, r.config.ColumnCompressionConfig)
+	sourceDbTables, err := ghostferry.LoadTables(r.Ferry.SourceDB, r.config.TableFilter, r.config.CompressedColumnsForVerification, r.config.IgnoredColumnsForVerification)
 	if err != nil {
 		return err
 	}

--- a/test/go/binlog_streamer_test.go
+++ b/test/go/binlog_streamer_test.go
@@ -42,6 +42,7 @@ func (this *BinlogStreamerTestSuite) SetupTest() {
 			TablesFunc: nil,
 		},
 		nil,
+		nil,
 	)
 	this.Require().Nil(err)
 

--- a/test/go/data_iterator_test.go
+++ b/test/go/data_iterator_test.go
@@ -34,7 +34,7 @@ func (this *DataIteratorTestSuite) SetupTest() {
 		TablesFunc: nil,
 	}
 
-	tables, err := ghostferry.LoadTables(sourceDb, tableFilter, nil)
+	tables, err := ghostferry.LoadTables(sourceDb, tableFilter, nil, nil)
 	this.Require().Nil(err)
 
 	this.tables = tables.AsSlice()

--- a/test/go/iterative_verifier_test.go
+++ b/test/go/iterative_verifier_test.go
@@ -369,7 +369,7 @@ func (t *IterativeVerifierTestSuite) reloadTables() {
 		TablesFunc: nil,
 	}
 
-	tables, err := ghostferry.LoadTables(t.db, tableFilter, nil)
+	tables, err := ghostferry.LoadTables(t.db, tableFilter, nil, nil)
 	t.Require().Nil(err)
 
 	t.Ferry.Tables = tables

--- a/test/helpers/ghostferry_helper.rb
+++ b/test/helpers/ghostferry_helper.rb
@@ -227,6 +227,10 @@ module GhostferryHelper
           environment["GHOSTFERRY_DATA_COLUMN_SNAPPY"] = "1"
         end
 
+        if @config[:ignored_column]
+          environment["GHOSTFERRY_IGNORED_COLUMN"] = @config[:ignored_column]
+        end
+
         @logger.info("starting ghostferry test binary #{@compiled_binary_path}")
         Open3.popen3(environment, @compiled_binary_path) do |stdin, stdout, stderr, wait_thr|
           stdin.puts(resuming_state) unless resuming_state.nil?

--- a/test/lib/go/integrationferry.go
+++ b/test/lib/go/integrationferry.go
@@ -250,10 +250,21 @@ func main() {
 	// TODO: allow Ghostferry config to be specified by the ruby test directly.
 	compressedDataColumn := os.Getenv("GHOSTFERRY_DATA_COLUMN_SNAPPY")
 	if compressedDataColumn != "" {
-		config.ColumnCompressionConfig = map[string]map[string]map[string]string{
+		config.CompressedColumnsForVerification = map[string]map[string]map[string]string{
 			"gftest": map[string]map[string]string{
 				"test_table_1": map[string]string{
 					"data": "SNAPPY",
+				},
+			},
+		}
+	}
+
+	ignoredColumn := os.Getenv("GHOSTFERRY_IGNORED_COLUMN")
+	if ignoredColumn != "" {
+		config.IgnoredColumnsForVerification = map[string]map[string]map[string]struct{}{
+			"gftest": map[string]map[string]struct{}{
+				"test_table_1": map[string]struct{}{
+					ignoredColumn: struct{}{},
 				},
 			},
 		}


### PR DESCRIPTION
This code is used in the same special case that handles the CompressedColumns: if data on the source and target already agrees with each other except for a non-critical field (say the a last_updated timestamp that does not affect the actual data integrity), the InlineVerifier should be able to be skip that particular column during verification to avoid a failed run. This option previously existed within the IterativeVerifier but I neglected to bring it over to the InlineVerifier. 

I must admit, I don't quite like how the code is structured (w.r.t. adding yet another parameter to `TableSchema` and another argument to `LoadTables()`). However, I can't see any other simple ways to get this to work. If there's some sort of cleanup/refactor we can do here, I'm all ears.