### PR TITLE
Less noisy logs from the MD5 transform

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -3,6 +3,7 @@ package ghostferry
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/siddontang/go-mysql/schema"
@@ -166,8 +167,15 @@ func (c *Cursor) Fetch(db SqlPreparer) (batch *RowBatch, pkpos uint64, err error
 		return
 	}
 
+	// With the inline verifier, the columns to be selected may be very large as
+	// the query generated will be very large. The code here simply hides the
+	// columns from the logger to not spam the logs.
+
+	splitQuery := strings.Split(query, "FROM")
+	loggedQuery := fmt.Sprintf("SELECT [omitted] FROM %s", splitQuery[1])
+
 	logger := c.logger.WithFields(logrus.Fields{
-		"sql":  query,
+		"sql":  loggedQuery,
 		"args": args,
 	})
 

--- a/test/integration/trivial_test.rb
+++ b/test/integration/trivial_test.rb
@@ -22,4 +22,19 @@ class TrivialIntegrationTests < GhostferryTestCase
     ghostferry.run
     assert_test_table_is_identical
   end
+
+  def test_logged_query_omits_columns
+    seed_simple_database_with_single_table
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+    ghostferry.run
+
+    assert ghostferry.logrus_lines["cursor"].length > 0
+
+    ghostferry.logrus_lines["cursor"].each do |line|
+      if line["msg"].start_with?("found ")
+        assert line["sql"].start_with?("SELECT [omitted] FROM")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Cursor emitted logs that includes the entire query. With the InlineVerifier, this query could be huge and thus clutters up the log. This change omits the columns selected, which reduces this clutter.

Example log line before this change:

```
{
    "args":[923],
    "level":"debug",
    "msg":"found 178 rows",
    "sql":"SELECT *, MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')),MD5(COALESCE(`data`, 'NULL')))) AS __ghostferry_row_md5 FROM `gftest`.`test_table_1` WHERE `id` \u003e ? ORDER BY `id` LIMIT 200 FOR UPDATE",
    "table":"gftest.test_table_1",
    "tag":"cursor",
    "time":"2019-09-25T14:11:35-04:00"
}
```

Example after:
```
{
    "args":[911],
    "level":"debug",
    "msg":"found 187 rows",
    "sql":"SELECT [omitted] FROM  `gftest`.`test_table_1` WHERE `id` \u003e ? ORDER BY `id` LIMIT 200 FOR UPDATE",
    "table":"gftest.test_table_1",
    "tag":"cursor",
    "time":"2019-09-25T14:08:35-04:00"
}
```
