### PR TITLE
Further tests for the InlineVerifier

### DIFF
--- a/table_schema_cache.go
+++ b/table_schema_cache.go
@@ -81,10 +81,10 @@ func (t *TableSchema) RowMd5Query() string {
 
 	hashStrs := make([]string, len(columns))
 	for i, column := range columns {
-		hashStrs[i] = fmt.Sprintf("MD5(COALESCE(%s, 'NULL'))", normalizeAndQuoteColumn(column))
+		hashStrs[i] = fmt.Sprintf("MD5(%s)", normalizeAndQuoteColumn(column))
 	}
 
-	t.rowMd5Query = fmt.Sprintf("MD5(CONCAT(%s)) AS __ghostferry_row_md5", strings.Join(hashStrs, ","))
+	t.rowMd5Query = fmt.Sprintf("MD5(CONCAT_WS('',%s)) AS __ghostferry_row_md5", strings.Join(hashStrs, ","))
 	return t.rowMd5Query
 }
 

--- a/table_schema_cache.go
+++ b/table_schema_cache.go
@@ -81,10 +81,10 @@ func (t *TableSchema) RowMd5Query() string {
 
 	hashStrs := make([]string, len(columns))
 	for i, column := range columns {
-		hashStrs[i] = fmt.Sprintf("MD5(%s)", normalizeAndQuoteColumn(column))
+		hashStrs[i] = fmt.Sprintf("MD5(COALESCE(%s, 'NULL'))", normalizeAndQuoteColumn(column))
 	}
 
-	t.rowMd5Query = fmt.Sprintf("MD5(CONCAT_WS('',%s)) AS __ghostferry_row_md5", strings.Join(hashStrs, ","))
+	t.rowMd5Query = fmt.Sprintf("MD5(CONCAT(%s)) AS __ghostferry_row_md5", strings.Join(hashStrs, ","))
 	return t.rowMd5Query
 }
 

--- a/table_schema_cache.go
+++ b/table_schema_cache.go
@@ -81,7 +81,9 @@ func (t *TableSchema) RowMd5Query() string {
 
 	hashStrs := make([]string, len(columns))
 	for i, column := range columns {
-		hashStrs[i] = fmt.Sprintf("MD5(COALESCE(%s, 'NULL'))", normalizeAndQuoteColumn(column))
+		// Magic string that's unlikely to be a real record. For a history of this
+		// issue, refer to https://github.com/Shopify/ghostferry/pull/137
+		hashStrs[i] = fmt.Sprintf("MD5(COALESCE(%s, 'NULL_PBj}b]74P@JTo$5G_null'))", normalizeAndQuoteColumn(column))
 	}
 
 	t.rowMd5Query = fmt.Sprintf("MD5(CONCAT(%s)) AS __ghostferry_row_md5", strings.Join(hashStrs, ","))

--- a/test/go/table_schema_cache_test.go
+++ b/test/go/table_schema_cache_test.go
@@ -144,12 +144,12 @@ func (this *TableSchemaCacheTestSuite) TestFingerprintQuery() {
 	tables := tableSchemaCache.AsSlice()
 	table := tables[0]
 	query := table.FingerprintQuery("s", "t", 10)
-	this.Require().Equal("SELECT `id`,MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')),MD5(COALESCE(`data`, 'NULL')))) AS __ghostferry_row_md5 FROM `s`.`t` WHERE `id` IN (?,?,?,?,?,?,?,?,?,?)", query)
+	this.Require().Equal("SELECT `id`,MD5(CONCAT(MD5(COALESCE(`id`, 'NULL_PBj}b]74P@JTo$5G_null')),MD5(COALESCE(`data`, 'NULL_PBj}b]74P@JTo$5G_null')))) AS __ghostferry_row_md5 FROM `s`.`t` WHERE `id` IN (?,?,?,?,?,?,?,?,?,?)", query)
 
 	table = tables[1]
 	table.CompressedColumns = map[string]string{"data": "SNAPPY"}
 	query = table.FingerprintQuery("s", "t", 10)
-	this.Require().Equal("SELECT `id`,MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')))) AS __ghostferry_row_md5,`data` FROM `s`.`t` WHERE `id` IN (?,?,?,?,?,?,?,?,?,?)", query)
+	this.Require().Equal("SELECT `id`,MD5(CONCAT(MD5(COALESCE(`id`, 'NULL_PBj}b]74P@JTo$5G_null')))) AS __ghostferry_row_md5,`data` FROM `s`.`t` WHERE `id` IN (?,?,?,?,?,?,?,?,?,?)", query)
 }
 
 func (this *TableSchemaCacheTestSuite) TestTableRowMd5Query() {
@@ -159,12 +159,12 @@ func (this *TableSchemaCacheTestSuite) TestTableRowMd5Query() {
 	tables := tableSchemaCache.AsSlice()
 	table := tables[0]
 	query := table.RowMd5Query()
-	this.Require().Equal("MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')),MD5(COALESCE(`data`, 'NULL')))) AS __ghostferry_row_md5", query)
+	this.Require().Equal("MD5(CONCAT(MD5(COALESCE(`id`, 'NULL_PBj}b]74P@JTo$5G_null')),MD5(COALESCE(`data`, 'NULL_PBj}b]74P@JTo$5G_null')))) AS __ghostferry_row_md5", query)
 
 	table = tables[1]
 	table.CompressedColumns = map[string]string{"data": "SNAPPY"}
 	query = table.RowMd5Query()
-	this.Require().Equal("MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')))) AS __ghostferry_row_md5", query)
+	this.Require().Equal("MD5(CONCAT(MD5(COALESCE(`id`, 'NULL_PBj}b]74P@JTo$5G_null')))) AS __ghostferry_row_md5", query)
 }
 
 func (this *TableSchemaCacheTestSuite) TestQuotedTableName() {

--- a/test/go/table_schema_cache_test.go
+++ b/test/go/table_schema_cache_test.go
@@ -144,12 +144,12 @@ func (this *TableSchemaCacheTestSuite) TestFingerprintQuery() {
 	tables := tableSchemaCache.AsSlice()
 	table := tables[0]
 	query := table.FingerprintQuery("s", "t", 10)
-	this.Require().Equal("SELECT `id`,MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')),MD5(COALESCE(`data`, 'NULL')))) AS __ghostferry_row_md5 FROM `s`.`t` WHERE `id` IN (?,?,?,?,?,?,?,?,?,?)", query)
+	this.Require().Equal("SELECT `id`,MD5(CONCAT_WS('',MD5(`id`),MD5(`data`))) AS __ghostferry_row_md5 FROM `s`.`t` WHERE `id` IN (?,?,?,?,?,?,?,?,?,?)", query)
 
 	table = tables[1]
 	table.CompressedColumns = map[string]string{"data": "SNAPPY"}
 	query = table.FingerprintQuery("s", "t", 10)
-	this.Require().Equal("SELECT `id`,MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')))) AS __ghostferry_row_md5,`data` FROM `s`.`t` WHERE `id` IN (?,?,?,?,?,?,?,?,?,?)", query)
+	this.Require().Equal("SELECT `id`,MD5(CONCAT_WS('',MD5(`id`))) AS __ghostferry_row_md5,`data` FROM `s`.`t` WHERE `id` IN (?,?,?,?,?,?,?,?,?,?)", query)
 }
 
 func (this *TableSchemaCacheTestSuite) TestTableRowMd5Query() {
@@ -159,12 +159,12 @@ func (this *TableSchemaCacheTestSuite) TestTableRowMd5Query() {
 	tables := tableSchemaCache.AsSlice()
 	table := tables[0]
 	query := table.RowMd5Query()
-	this.Require().Equal("MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')),MD5(COALESCE(`data`, 'NULL')))) AS __ghostferry_row_md5", query)
+	this.Require().Equal("MD5(CONCAT_WS('',MD5(`id`),MD5(`data`))) AS __ghostferry_row_md5", query)
 
 	table = tables[1]
 	table.CompressedColumns = map[string]string{"data": "SNAPPY"}
 	query = table.RowMd5Query()
-	this.Require().Equal("MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')))) AS __ghostferry_row_md5", query)
+	this.Require().Equal("MD5(CONCAT_WS('',MD5(`id`))) AS __ghostferry_row_md5", query)
 }
 
 func (this *TableSchemaCacheTestSuite) TestQuotedTableName() {

--- a/test/go/table_schema_cache_test.go
+++ b/test/go/table_schema_cache_test.go
@@ -144,12 +144,12 @@ func (this *TableSchemaCacheTestSuite) TestFingerprintQuery() {
 	tables := tableSchemaCache.AsSlice()
 	table := tables[0]
 	query := table.FingerprintQuery("s", "t", 10)
-	this.Require().Equal("SELECT `id`,MD5(CONCAT_WS('',MD5(`id`),MD5(`data`))) AS __ghostferry_row_md5 FROM `s`.`t` WHERE `id` IN (?,?,?,?,?,?,?,?,?,?)", query)
+	this.Require().Equal("SELECT `id`,MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')),MD5(COALESCE(`data`, 'NULL')))) AS __ghostferry_row_md5 FROM `s`.`t` WHERE `id` IN (?,?,?,?,?,?,?,?,?,?)", query)
 
 	table = tables[1]
 	table.CompressedColumns = map[string]string{"data": "SNAPPY"}
 	query = table.FingerprintQuery("s", "t", 10)
-	this.Require().Equal("SELECT `id`,MD5(CONCAT_WS('',MD5(`id`))) AS __ghostferry_row_md5,`data` FROM `s`.`t` WHERE `id` IN (?,?,?,?,?,?,?,?,?,?)", query)
+	this.Require().Equal("SELECT `id`,MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')))) AS __ghostferry_row_md5,`data` FROM `s`.`t` WHERE `id` IN (?,?,?,?,?,?,?,?,?,?)", query)
 }
 
 func (this *TableSchemaCacheTestSuite) TestTableRowMd5Query() {
@@ -159,12 +159,12 @@ func (this *TableSchemaCacheTestSuite) TestTableRowMd5Query() {
 	tables := tableSchemaCache.AsSlice()
 	table := tables[0]
 	query := table.RowMd5Query()
-	this.Require().Equal("MD5(CONCAT_WS('',MD5(`id`),MD5(`data`))) AS __ghostferry_row_md5", query)
+	this.Require().Equal("MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')),MD5(COALESCE(`data`, 'NULL')))) AS __ghostferry_row_md5", query)
 
 	table = tables[1]
 	table.CompressedColumns = map[string]string{"data": "SNAPPY"}
 	query = table.RowMd5Query()
-	this.Require().Equal("MD5(CONCAT_WS('',MD5(`id`))) AS __ghostferry_row_md5", query)
+	this.Require().Equal("MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')))) AS __ghostferry_row_md5", query)
 }
 
 func (this *TableSchemaCacheTestSuite) TestQuotedTableName() {

--- a/test/integration/inline_verifier_test.rb
+++ b/test/integration/inline_verifier_test.rb
@@ -2,10 +2,21 @@ require "test_helper"
 
 class InlineVerifierTest < GhostferryTestCase
   INSERT_TRIGGER_NAME = "corrupting_insert_trigger"
+  ASCIIDATA = "foobar"
+  UTF8MB3DATA = "これは普通なストリングです"
+  UTF8MB4DATA = "𠜎𠜱𠝹𠱓𠱸𠲖𠳏𠳕𠴕𠵼𠵿𠸎𠸏𠹷"
+  CHARSET_TO_COLLATION = {
+    "utf8mb4" => "utf8mb4_unicode_ci",
+    "utf8mb3" => "utf8_unicode_ci",
+  }
 
   def teardown
     drop_triggers
   end
+
+  #############################
+  # General Integration Tests #
+  #############################
 
   def test_corrupted_insert_is_detected_inline_with_batch_writer
     seed_random_data(source_db, number_of_rows: 3)
@@ -91,7 +102,79 @@ class InlineVerifierTest < GhostferryTestCase
     assert_equal "cutover verification failed for: gftest.test_table_1 [pks: #{corrupting_id} ] ", ghostferry.error_lines.last["msg"]
   end
 
+  ###################
+  # Collation Tests #
+  ###################
+
+  def test_ascii_data_from_utfmb3_to_utfmb4
+    run_collation_test(ASCIIDATA, "utf8mb3", "utf8mb4", identical: true)
+  end
+
+  def test_ascii_data_from_utfmb4_to_utfmb3
+    run_collation_test(ASCIIDATA, "utf8mb4", "utf8mb3", identical: true)
+  end
+
+  def test_utfmb3_data_from_utfmb3_to_utfmb4
+    run_collation_test(UTF8MB3DATA, "utf8mb3", "utf8mb4", identical: true)
+  end
+
+  def test_utfmb3_data_from_utfmb4_to_utfmb3
+    run_collation_test(UTF8MB3DATA, "utf8mb4", "utf8mb3", identical: true)
+  end
+
+  def test_utfmb4_data_from_utfmb4_to_utfmb3
+    run_collation_test(UTF8MB4DATA, "utf8mb4", "utf8mb3", identical: false)
+  end
+
   private
+
+  def run_collation_test(data, source_charset, target_charset, identical:)
+    seed_random_data(source_db, number_of_rows: 0)
+    seed_random_data(target_db, number_of_rows: 0)
+
+    unsafe_source_db_config = source_db_config
+    unsafe_source_db_config[:init_command] = "SET @@SESSION.sql_mode = ''"
+    unsafe_source_db = Mysql2::Client.new(unsafe_source_db_config)
+
+    unsafe_target_db_config = target_db_config
+    unsafe_target_db_config[:init_command] = "SET @@SESSION.sql_mode = ''"
+    unsafe_target_db = Mysql2::Client.new(unsafe_target_db_config)
+
+    set_data_column_collation(unsafe_source_db, source_charset)
+    set_data_column_collation(unsafe_target_db, target_charset)
+
+    unsafe_source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} (id, data) VALUES (1, '#{data}')")
+
+    verify_during_cutover_ran = false
+    incorrect_tables = nil
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline" })
+    ghostferry.on_status(Ghostferry::Status::VERIFIED) do |*t|
+      verify_during_cutover_ran = true
+      incorrect_tables = t
+    end
+
+    if identical
+      ghostferry.run
+      assert verify_during_cutover_ran
+      assert_equal [], incorrect_tables
+
+      rows = unsafe_target_db.query("SELECT * FROM #{DEFAULT_FULL_TABLE_NAME} WHERE id = 1")
+      assert_equal 1, rows.count
+      rows.each do |row|
+        assert_equal data, row["data"]
+      end
+    else
+      ghostferry.run_expecting_interrupt
+
+      refute_nil ghostferry.error
+      err_msg = ghostferry.error["ErrMessage"]
+      assert err_msg.include?("row fingerprints for pks [1] on #{DEFAULT_DB}.#{DEFAULT_TABLE} do not match"), message: err_msg
+    end
+  end
+
+  def set_data_column_collation(db, charset)
+    db.query("ALTER TABLE #{DEFAULT_FULL_TABLE_NAME} MODIFY data VARCHAR(255) CHARACTER SET #{charset} COLLATE #{CHARSET_TO_COLLATION[charset]}")
+  end
 
   def enable_corrupting_insert_trigger(corrupting_id)
     query = [


### PR DESCRIPTION
Is a decently straightforward PR, although I do fix an issue with `NULL` vs `'NULL'`.

- Tested that InlineVerifier works across multiple charsets and collations.
- Tested positive and negative zero floating point values.
- Tested NULL values.

### Appendix: Technical analysis of the `NULL` vs `'NULL'` problem

One thing I uncovered is that `NULL` is being treated the same as `'NULL'` by the InlineVerifier. Thus, we're prone to [false](https://www.wired.com/2015/11/null/) [negatives](https://www.wired.com/story/null-license-plate-landed-one-hacker-ticket-hell/) involving NULL. The cause of the issue is as folllows:

- To generate a checksum, for each row, we compute the MD5 of each column and concatenate the result. Then we generate yet another MD5 for this concatenated string.
- MD5 checksum is computed on the mysql server, using the `MD5` function. However, `MD5(NULL) -> NULL`, and `CONCAT(NULL, 'data') -> NULL`. This means every row that has a NULL column will have a NULL checksum, which is unacceptable.
- To get around this, we use the `COALESCE` function, which returns the first non null entry. Specifically, we used `MD5(COALASCE(column, 'NULL'))`. If the column is NULL, we would thus compute `MD5('NULL')`. This causes the collision with the string `'NULL'`.

The current workaround uses a magic string that's unlikely to be found in nature. Although it may be possible to use `CONCAT_WS` and `NULLIF` to accomplish this without the magic string. There are some reverted commits for reference. The commit at the end also adds a test case that will be triggered if the naive `CONCAT_WS` method is implemented in the future.