### PR TITLE
Update semantics to reflect usage of Pagination Column vs PK column

### DIFF
--- a/config.go
+++ b/config.go
@@ -276,7 +276,7 @@ type CascadingPaginationColumnConfig struct {
 	PerTable map[string]map[string]string // SchemaName => TableName => ColumnName
 
 	// FallbackColumn is a global default to fallback to and is more specific than the default fallback,
-	// which would be the PK
+	// which would be the Primary Key
 	FallbackColumn string
 }
 
@@ -436,7 +436,7 @@ type Config struct {
 	//
 	// - If you are copying a table where the data is already partially on the
 	//   target through some other means.
-	//   - Specifically, the PK of this row on both the source and the target are
+	//   - Specifically, the PaginationKey of this row on both the source and the target are
 	//     the same. Thus, INSERT IGNORE will skip copying this row, leaving the
 	//     data on the target unchanged.
 	//   - If the data on the target is already identical to the source, then

--- a/data_iterator.go
+++ b/data_iterator.go
@@ -18,7 +18,7 @@ type DataIterator struct {
 	CursorConfig *CursorConfig
 	StateTracker *StateTracker
 
-	targetPKs      *sync.Map
+	targetPaginationKeys      *sync.Map
 	batchListeners []func(*RowBatch) error
 	doneListeners  []func() error
 	logger         *logrus.Entry
@@ -26,7 +26,7 @@ type DataIterator struct {
 
 func (d *DataIterator) Run(tables []*TableSchema) {
 	d.logger = logrus.WithField("tag", "data_iterator")
-	d.targetPKs = &sync.Map{}
+	d.targetPaginationKeys = &sync.Map{}
 
 	// If a state tracker is not provided, then the caller doesn't care about
 	// tracking state. However, some methods are still useful so we initialize
@@ -36,7 +36,7 @@ func (d *DataIterator) Run(tables []*TableSchema) {
 	}
 
 	d.logger.WithField("tablesCount", len(tables)).Info("starting data iterator run")
-	tablesWithData, emptyTables, err := MaxPrimaryKeys(d.DB, tables, d.logger)
+	tablesWithData, emptyTables, err := MaxPaginationKeys(d.DB, tables, d.logger)
 	if err != nil {
 		d.ErrorHandler.Fatal("data_iterator", err)
 	}
@@ -45,14 +45,14 @@ func (d *DataIterator) Run(tables []*TableSchema) {
 		d.StateTracker.MarkTableAsCompleted(table.String())
 	}
 
-	for table, maxPk := range tablesWithData {
+	for table, maxPaginationKey := range tablesWithData {
 		tableName := table.String()
 		if d.StateTracker.IsTableComplete(tableName) {
 			// In a previous run, the table may have been completed.
 			// We don't need to reiterate those tables as it has already been done.
 			delete(tablesWithData, table)
 		} else {
-			d.targetPKs.Store(table.String(), maxPk)
+			d.targetPaginationKeys.Store(table.String(), maxPaginationKey)
 		}
 	}
 
@@ -72,23 +72,23 @@ func (d *DataIterator) Run(tables []*TableSchema) {
 
 				logger := d.logger.WithField("table", table.String())
 
-				targetPKInterface, found := d.targetPKs.Load(table.String())
+				targetPaginationKeyInterface, found := d.targetPaginationKeys.Load(table.String())
 				if !found {
-					err := fmt.Errorf("%s not found in targetPKs, this is likely a programmer error", table.String())
+					err := fmt.Errorf("%s not found in targetPaginationKeys, this is likely a programmer error", table.String())
 					logger.WithError(err).Error("this is definitely a bug")
 					d.ErrorHandler.Fatal("data_iterator", err)
 					return
 				}
 
-				startPk := d.StateTracker.LastSuccessfulPK(table.String())
-				if startPk == math.MaxUint64 {
+				startPaginationKey := d.StateTracker.LastSuccessfulPaginationKey(table.String())
+				if startPaginationKey == math.MaxUint64 {
 					err := fmt.Errorf("%v has been marked as completed but a table iterator has been spawned, this is likely a programmer error which resulted in the inconsistent starting state", table.String())
 					logger.WithError(err).Error("this is definitely a bug")
 					d.ErrorHandler.Fatal("data_iterator", err)
 					return
 				}
 
-				cursor := d.CursorConfig.NewCursor(table, startPk, targetPKInterface.(uint64))
+				cursor := d.CursorConfig.NewCursor(table, startPaginationKey, targetPaginationKeyInterface.(uint64))
 				if d.SelectFingerprint {
 					if len(cursor.ColumnsToSelect) == 0 {
 						cursor.ColumnsToSelect = []string{"*"}
@@ -108,19 +108,19 @@ func (d *DataIterator) Run(tables []*TableSchema) {
 						rows := make([]RowData, batch.Size())
 
 						for i, rowData := range batch.Values() {
-							pk, err := rowData.GetUint64(batch.PkIndex())
+							paginationKey, err := rowData.GetUint64(batch.PaginationKeyIndex())
 							if err != nil {
-								logger.WithError(err).Error("failed to get pk data")
+								logger.WithError(err).Error("failed to get paginationKey data")
 								return err
 							}
 
-							fingerprints[pk] = rowData[len(rowData)-1].([]byte)
+							fingerprints[paginationKey] = rowData[len(rowData)-1].([]byte)
 							rows[i] = rowData[:len(rowData)-1]
 						}
 
 						batch = &RowBatch{
 							values:       rows,
-							pkIndex:      batch.PkIndex(),
+							paginationKeyIndex:      batch.PaginationKeyIndex(),
 							table:        table,
 							fingerprints: fingerprints,
 						}

--- a/docs/source/copydbinterruptresume.rst
+++ b/docs/source/copydbinterruptresume.rst
@@ -67,7 +67,7 @@ state will be dumped to stdout with JSON. An example of this can be seen below:
         "Name": "mysql-bin.000008",
         "Pos": 193989
       },
-      "LastSuccessfulPrimaryKeys": {
+      "LastSuccessfulPaginationKeys": {
         "abc.table1": 200
       },
       "CompletedTables": {}
@@ -115,4 +115,3 @@ Some other considerations/notes:
   in the future.
 * While we are confident that the algorithm to be correct, this is still a
   highly experimental feature. USE AT YOUR OWN RISK.
-

--- a/progress.go
+++ b/progress.go
@@ -11,8 +11,8 @@ const (
 )
 
 type TableProgress struct {
-	LastSuccessfulPK uint64
-	TargetPK         uint64
+	LastSuccessfulPaginationKey uint64
+	TargetPaginationKey         uint64
 	CurrentAction    string // Possible values are defined via the constants TableAction*
 }
 
@@ -40,8 +40,8 @@ type Progress struct {
 	FinalBinlogPos mysql.Position
 
 	// A best estimate on the speed at which the copying is taking place. If
-	// there are large gaps in the PK space, this probably will be inaccurate.
-	PKsPerSecond uint64
+	// there are large gaps in the PaginationKey space, this probably will be inaccurate.
+	PaginationKeysPerSecond uint64
 	ETA          float64 // seconds
 	TimeTaken    float64 // seconds
 }

--- a/row_batch.go
+++ b/row_batch.go
@@ -6,15 +6,15 @@ import (
 
 type RowBatch struct {
 	values       []RowData
-	pkIndex      int
+	paginationKeyIndex      int
 	table        *TableSchema
 	fingerprints map[uint64][]byte
 }
 
-func NewRowBatch(table *TableSchema, values []RowData, pkIndex int) *RowBatch {
+func NewRowBatch(table *TableSchema, values []RowData, paginationKeyIndex int) *RowBatch {
 	return &RowBatch{
 		values:  values,
-		pkIndex: pkIndex,
+		paginationKeyIndex: paginationKeyIndex,
 		table:   table,
 	}
 }
@@ -23,12 +23,12 @@ func (e *RowBatch) Values() []RowData {
 	return e.values
 }
 
-func (e *RowBatch) PkIndex() int {
-	return e.pkIndex
+func (e *RowBatch) PaginationKeyIndex() int {
+	return e.paginationKeyIndex
 }
 
-func (e *RowBatch) ValuesContainPk() bool {
-	return e.pkIndex >= 0
+func (e *RowBatch) ValuesContainPaginationKey() bool {
+	return e.paginationKeyIndex >= 0
 }
 
 func (e *RowBatch) Size() int {

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -205,13 +205,13 @@ func (r *ShardingFerry) copyPrimaryKeyTables() error {
 		return nil
 	}
 
-	pkTables := map[string]struct{}{}
+	primaryKeyTables := map[string]struct{}{}
 	for _, name := range r.config.PrimaryKeyTables {
-		pkTables[name] = struct{}{}
+		primaryKeyTables[name] = struct{}{}
 	}
 
-	r.config.TableFilter.(*ShardedTableFilter).PrimaryKeyTables = pkTables
-	r.config.CopyFilter.(*ShardedCopyFilter).PrimaryKeyTables = pkTables
+	r.config.TableFilter.(*ShardedTableFilter).PrimaryKeyTables = primaryKeyTables
+	r.config.CopyFilter.(*ShardedCopyFilter).PrimaryKeyTables = primaryKeyTables
 
 	sourceDbTables, err := ghostferry.LoadTables(r.Ferry.SourceDB, r.config.TableFilter, r.config.CompressedColumnsForVerification, r.config.IgnoredColumnsForVerification, r.config.CascadingPaginationColumnConfig)
 	if err != nil {
@@ -220,7 +220,7 @@ func (r *ShardingFerry) copyPrimaryKeyTables() error {
 
 	tables := []*ghostferry.TableSchema{}
 	for _, table := range sourceDbTables.AsSlice() {
-		if _, exists := pkTables[table.Name]; exists {
+		if _, exists := primaryKeyTables[table.Name]; exists {
 			if len(table.PKColumns) != 1 {
 				return fmt.Errorf("Multiple PK columns are not supported with the PrimaryKeyTables option")
 			}

--- a/sharding/test/primary_key_table_test.go
+++ b/sharding/test/primary_key_table_test.go
@@ -90,7 +90,7 @@ func (t *PrimaryKeyTableTestSuite) TestPrimaryKeyTableVerificationFailure() {
 	t.Ferry.Run()
 
 	t.Require().NotNil(errHandler.LastError)
-	t.Require().Equal("row fingerprints for pks [2] on gftest1.tenants_table do not match", errHandler.LastError.Error())
+	t.Require().Equal("row fingerprints for paginationKeys [2] on gftest1.tenants_table do not match", errHandler.LastError.Error())
 }
 
 func TestPrimaryKeyTableTestSuite(t *testing.T) {

--- a/test/go/iterative_verifier_integration_test.go
+++ b/test/go/iterative_verifier_integration_test.go
@@ -12,15 +12,15 @@ import (
 
 func TestHashesSql(t *testing.T) {
 	columns := []schema.TableColumn{schema.TableColumn{Name: "id"}, schema.TableColumn{Name: "data"}, schema.TableColumn{Name: "float_col", Type: schema.TYPE_FLOAT}}
-	pks := []uint64{1, 5, 42}
+	paginationKeys := []uint64{1, 5, 42}
 
-	sql, args, err := ghostferry.GetMd5HashesSql("gftest", "test_table", "id", columns, pks)
+	sql, args, err := ghostferry.GetMd5HashesSql("gftest", "test_table", "id", columns, paginationKeys)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "SELECT `id`, MD5(CONCAT(MD5(COALESCE(`id`, 'NULL')),MD5(COALESCE(`data`, 'NULL')),MD5(COALESCE((if (`float_col` = '-0', 0, `float_col`)), 'NULL')))) "+
 		"AS row_fingerprint FROM `gftest`.`test_table` WHERE `id` IN (?,?,?) ORDER BY `id`", sql)
 	for idx, arg := range args {
-		assert.Equal(t, pks[idx], arg.(uint64))
+		assert.Equal(t, paginationKeys[idx], arg.(uint64))
 	}
 }
 
@@ -49,7 +49,7 @@ func TestVerificationFailsDeletedRow(t *testing.T) {
 			result, err := iterativeVerifier.VerifyDuringCutover()
 			assert.Nil(t, err)
 			assert.False(t, result.DataCorrect)
-			assert.Regexp(t, "verification failed.*gftest.table1.*pks: (43)|(42)|(43,42)|(42,43)", result.Message)
+			assert.Regexp(t, "verification failed.*gftest.table1.*paginationKeys: (43)|(42)|(43,42)|(42,43)", result.Message)
 			ran = true
 		},
 		DataWriter: &testhelpers.MixedActionDataWriter{
@@ -92,7 +92,7 @@ func TestVerificationFailsUpdatedRow(t *testing.T) {
 			result, err := iterativeVerifier.VerifyDuringCutover()
 			assert.Nil(t, err)
 			assert.False(t, result.DataCorrect)
-			assert.Regexp(t, "verification failed.*gftest.table1.*pks: (42)|(43)|(43,42)|(42,43)", result.Message)
+			assert.Regexp(t, "verification failed.*gftest.table1.*paginationKeys: (42)|(43)|(43,42)|(42,43)", result.Message)
 			ran = true
 		},
 		DataWriter: &testhelpers.MixedActionDataWriter{

--- a/test/go/race_conditions_integration_test.go
+++ b/test/go/race_conditions_integration_test.go
@@ -125,7 +125,7 @@ func TestSelectCopyUpdateBinlog(t *testing.T) {
 	testcase.Run()
 }
 
-func TestOnlyDeleteRowWithMaxPrimaryKey(t *testing.T) {
+func TestOnlyDeleteRowWithMaxPaginationKey(t *testing.T) {
 	testcase := &testhelpers.IntegrationTestCase{
 		T: t,
 		SetupAction: func(f *testhelpers.TestFerry, sourceDB, targetDB *sql.DB) {

--- a/test/go/row_batch_test.go
+++ b/test/go/row_batch_test.go
@@ -94,18 +94,18 @@ func (this *RowBatchTestSuite) TestRowBatchMetadata() {
 
 	this.Require().Equal("test_schema", batch.TableSchema().Schema)
 	this.Require().Equal("test_table", batch.TableSchema().Name)
-	this.Require().Equal(true, batch.ValuesContainPk())
-	this.Require().Equal(0, batch.PkIndex())
-	this.Require().Equal(1000, batch.Values()[0][batch.PkIndex()])
+	this.Require().Equal(true, batch.ValuesContainPaginationKey())
+	this.Require().Equal(0, batch.PaginationKeyIndex())
+	this.Require().Equal(1000, batch.Values()[0][batch.PaginationKeyIndex()])
 }
 
-func (this *RowBatchTestSuite) TestRowBatchNoPkIndex() {
+func (this *RowBatchTestSuite) TestRowBatchNoPaginationKeyIndex() {
 	vals := []ghostferry.RowData{
 		ghostferry.RowData{"hello"},
 	}
 	batch := ghostferry.NewRowBatch(this.sourceTable, vals, -1)
 
-	this.Require().Equal(false, batch.ValuesContainPk())
+	this.Require().Equal(false, batch.ValuesContainPaginationKey())
 }
 
 func TestRowBatchTestSuite(t *testing.T) {

--- a/test/go/table_schema_cache_test.go
+++ b/test/go/table_schema_cache_test.go
@@ -166,7 +166,7 @@ func (this *TableSchemaCacheTestSuite) TestLoadTablesRejectTablesWhenCascadingPa
 	this.Require().EqualError(err, ghostferry.NonExistingPaginationKeyColumnError(testhelpers.TestSchemaName, table, paginationColumn).Error())
 }
 
-func (this *TableSchemaCacheTestSuite) TestLoadTablesWithPrimaryKeyColumnFallback() {
+func (this *TableSchemaCacheTestSuite) TestLoadTablesWithPaginationKeyColumnFallback() {
 	table := "pk_fallback_column_present"
 	query := fmt.Sprintf("CREATE TABLE %s.%s (identity bigint(20) not null, data TEXT, primary key(identity))", testhelpers.TestSchemaName, table)
 	_, err := this.Ferry.SourceDB.Exec(query)
@@ -186,7 +186,7 @@ func (this *TableSchemaCacheTestSuite) TestLoadTablesRejectTablesWithoutPKColumn
 	_, err = ghostferry.LoadTables(this.Ferry.SourceDB, this.tableFilter, nil, nil, nil)
 
 	this.Require().NotNil(err)
-	this.Require().EqualError(err, ghostferry.NonExistingPKError(testhelpers.TestSchemaName, table).Error())
+	this.Require().EqualError(err, ghostferry.NonExistingPaginationKeyError(testhelpers.TestSchemaName, table).Error())
 }
 
 func (this *TableSchemaCacheTestSuite) TestLoadTablesRejectTablesWithCompositePKButNoAlternateColumnToFallBackTo() {

--- a/test/go/trivial_integration_test.go
+++ b/test/go/trivial_integration_test.go
@@ -71,14 +71,14 @@ func TestCopyDataWithDeleteLoad(t *testing.T) {
 	testcase.Run()
 }
 
-func TestCopyDataWithLargePrimaryKeyValues(t *testing.T) {
+func TestCopyDataWithLargePaginationKeyValues(t *testing.T) {
 	ferry := testhelpers.NewTestFerry()
 
 	ferry.Config.DataIterationBatchSize = 10
 
 	testcase := &testhelpers.IntegrationTestCase{
 		T:           t,
-		SetupAction: setupSingleTableDatabaseWithHighBitUint64PKs,
+		SetupAction: setupSingleTableDatabaseWithHighBitUint64PaginationKeys,
 		Ferry:       ferry,
 	}
 
@@ -170,7 +170,7 @@ func TestCopyDataWithNullInColumn(t *testing.T) {
 // Helper methods below
 // ====================
 
-func useUnsignedPK(db *sql.DB) {
+func useUnsignedPaginationKey(db *sql.DB) {
 	_, err := db.Exec("ALTER TABLE gftest.table1 MODIFY id bigint(20) unsigned not null")
 	testhelpers.PanicIfError(err)
 }
@@ -188,14 +188,14 @@ func setupSingleTableDatabase(f *testhelpers.TestFerry, sourceDB, targetDB *sql.
 	testhelpers.SeedInitialData(targetDB, "gftest", "table1", 0)
 }
 
-func setupSingleTableDatabaseWithHighBitUint64PKs(f *testhelpers.TestFerry, sourceDB, targetDB *sql.DB) {
+func setupSingleTableDatabaseWithHighBitUint64PaginationKeys(f *testhelpers.TestFerry, sourceDB, targetDB *sql.DB) {
 	setupSingleTableDatabase(f, sourceDB, targetDB)
 
 	_, err := sourceDB.Exec("TRUNCATE gftest.table1")
 	testhelpers.PanicIfError(err)
 
-	useUnsignedPK(sourceDB)
-	useUnsignedPK(targetDB)
+	useUnsignedPaginationKey(sourceDB)
+	useUnsignedPaginationKey(targetDB)
 
 	stmt, err := sourceDB.Prepare("INSERT INTO gftest.table1 (id, data) VALUES (?, ?)")
 	testhelpers.PanicIfError(err)

--- a/test/integration/callbacks_test.rb
+++ b/test/integration/callbacks_test.rb
@@ -16,8 +16,8 @@ class CallbacksTest < GhostferryTestCase
 
     assert_equal "done", progress.last["CurrentState"]
 
-    assert_equal 1111, progress.last["Tables"]["gftest.test_table_1"]["LastSuccessfulPK"]
-    assert_equal 1111, progress.last["Tables"]["gftest.test_table_1"]["TargetPK"]
+    assert_equal 1111, progress.last["Tables"]["gftest.test_table_1"]["LastSuccessfulPaginationKey"]
+    assert_equal 1111, progress.last["Tables"]["gftest.test_table_1"]["TargetPaginationKey"]
     assert_equal "completed", progress.last["Tables"]["gftest.test_table_1"]["CurrentAction"]
 
     refute progress.last["LastSuccessfulBinlogPos"]["Name"].nil?
@@ -27,7 +27,7 @@ class CallbacksTest < GhostferryTestCase
 
     assert_equal false, progress.last["Throttled"]
 
-    refute progress.last["PKsPerSecond"].nil?
+    refute progress.last["PaginationKeysPerSecond"].nil?
     refute progress.last["ETA"].nil?
     assert progress.last["TimeTaken"] > 0
   end

--- a/test/integration/inline_verifier_test.rb
+++ b/test/integration/inline_verifier_test.rb
@@ -32,7 +32,7 @@ class InlineVerifierTest < GhostferryTestCase
 
     refute_nil ghostferry.error
     err_msg = ghostferry.error["ErrMessage"]
-    assert err_msg.include?("row fingerprints for pks [#{corrupting_id}] on #{DEFAULT_DB}.#{DEFAULT_TABLE} do not match"), message: err_msg
+    assert err_msg.include?("row fingerprints for paginationKeys [#{corrupting_id}] on #{DEFAULT_DB}.#{DEFAULT_TABLE} do not match"), message: err_msg
 
     # Make sure it is not inserted into the target
     results = target_db.query("SELECT * FROM #{DEFAULT_FULL_TABLE_NAME} WHERE id = #{corrupting_id}")
@@ -56,7 +56,7 @@ class InlineVerifierTest < GhostferryTestCase
 
     refute_nil ghostferry.error
     err_msg = ghostferry.error["ErrMessage"]
-    assert err_msg.include?("row fingerprints for pks [1] on #{DEFAULT_DB}.#{DEFAULT_TABLE} do not match"), message: err_msg
+    assert err_msg.include?("row fingerprints for paginationKeys [1] on #{DEFAULT_DB}.#{DEFAULT_TABLE} do not match"), message: err_msg
   end
 
   def test_same_decompressed_data_different_compressed_test_passes_inline_verification
@@ -134,7 +134,7 @@ class InlineVerifierTest < GhostferryTestCase
 
     ghostferry.run
     assert verification_ran
-    assert_equal "cutover verification failed for: gftest.test_table_1 [pks: #{corrupting_id} ] ", ghostferry.error_lines.last["msg"]
+    assert_equal "cutover verification failed for: gftest.test_table_1 [paginationKeys: #{corrupting_id} ] ", ghostferry.error_lines.last["msg"]
   end
 
   #######################
@@ -160,7 +160,7 @@ class InlineVerifierTest < GhostferryTestCase
     ghostferry.run_expecting_interrupt
     refute_nil ghostferry.error
     err_msg = ghostferry.error["ErrMessage"]
-    assert err_msg.include?("row fingerprints for pks [1] on #{DEFAULT_DB}.#{DEFAULT_TABLE} do not match"), message: err_msg
+    assert err_msg.include?("row fingerprints for paginationKeys [1] on #{DEFAULT_DB}.#{DEFAULT_TABLE} do not match"), message: err_msg
 
     # Now we run the real test case.
     target_db.query("UPDATE #{DEFAULT_FULL_TABLE_NAME} SET data = -0.0 WHERE id = 1")
@@ -205,7 +205,7 @@ class InlineVerifierTest < GhostferryTestCase
     ghostferry.run_expecting_interrupt
     refute_nil ghostferry.error
     err_msg = ghostferry.error["ErrMessage"]
-    assert err_msg.include?("row fingerprints for pks [1] on #{DEFAULT_DB}.#{DEFAULT_TABLE} do not match"), message: err_msg
+    assert err_msg.include?("row fingerprints for paginationKeys [1] on #{DEFAULT_DB}.#{DEFAULT_TABLE} do not match"), message: err_msg
   end
 
   def test_null_vs_null_string
@@ -219,7 +219,7 @@ class InlineVerifierTest < GhostferryTestCase
     ghostferry.run_expecting_interrupt
     refute_nil ghostferry.error
     err_msg = ghostferry.error["ErrMessage"]
-    assert err_msg.include?("row fingerprints for pks [1] on #{DEFAULT_DB}.#{DEFAULT_TABLE} do not match"), message: err_msg
+    assert err_msg.include?("row fingerprints for paginationKeys [1] on #{DEFAULT_DB}.#{DEFAULT_TABLE} do not match"), message: err_msg
   end
 
   def test_null_in_different_order
@@ -236,7 +236,7 @@ class InlineVerifierTest < GhostferryTestCase
     ghostferry.run_expecting_interrupt
     refute_nil ghostferry.error
     err_msg = ghostferry.error["ErrMessage"]
-    assert err_msg.include?("row fingerprints for pks [1] on #{DEFAULT_DB}.#{DEFAULT_TABLE} do not match"), message: err_msg
+    assert err_msg.include?("row fingerprints for paginationKeys [1] on #{DEFAULT_DB}.#{DEFAULT_TABLE} do not match"), message: err_msg
   end
 
   ###################
@@ -305,7 +305,7 @@ class InlineVerifierTest < GhostferryTestCase
 
       refute_nil ghostferry.error
       err_msg = ghostferry.error["ErrMessage"]
-      assert err_msg.include?("row fingerprints for pks [1] on #{DEFAULT_DB}.#{DEFAULT_TABLE} do not match"), message: err_msg
+      assert err_msg.include?("row fingerprints for paginationKeys [1] on #{DEFAULT_DB}.#{DEFAULT_TABLE} do not match"), message: err_msg
     end
   end
 

--- a/test/integration/interrupt_resume_test.rb
+++ b/test/integration/interrupt_resume_test.rb
@@ -25,7 +25,7 @@ class InterruptResumeTest < GhostferryTestCase
     result = target_db.query("SELECT MAX(id) AS max_id FROM #{DEFAULT_FULL_TABLE_NAME}")
     last_successful_id = result.first["max_id"]
     assert last_successful_id > 0
-    assert_equal last_successful_id, dumped_state["LastSuccessfulPrimaryKeys"]["#{DEFAULT_DB}.#{DEFAULT_TABLE}"]
+    assert_equal last_successful_id, dumped_state["LastSuccessfulPaginationKeys"]["#{DEFAULT_DB}.#{DEFAULT_TABLE}"]
   end
 
   def test_interrupt_and_resume_without_last_known_schema_cache
@@ -237,7 +237,7 @@ class InterruptResumeTest < GhostferryTestCase
     assert_equal "gftest.test_table_1", incorrect_tables.first
 
     error_line = ghostferry.error_lines.last
-    assert_equal "cutover verification failed for: gftest.test_table_1 [pks: #{chosen_id} ] ", error_line["msg"]
+    assert_equal "cutover verification failed for: gftest.test_table_1 [paginationKeys: #{chosen_id} ] ", error_line["msg"]
   end
 
   def test_interrupt_resume_inline_verifier_will_verify_additional_rows_changed_on_source_during_interrupt
@@ -281,6 +281,6 @@ class InterruptResumeTest < GhostferryTestCase
     assert_equal "gftest.test_table_1", incorrect_tables.first
 
     error_line = ghostferry.error_lines.last
-    assert_equal "cutover verification failed for: gftest.test_table_1 [pks: #{chosen_id} ] ", error_line["msg"]
+    assert_equal "cutover verification failed for: gftest.test_table_1 [paginationKeys: #{chosen_id} ] ", error_line["msg"]
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -109,7 +109,7 @@ class GhostferryTestCase < Minitest::Test
     refute dumped_state.nil?
     refute dumped_state["GhostferryVersion"].nil?
     refute dumped_state["LastKnownTableSchemaCache"].nil?
-    refute dumped_state["LastSuccessfulPrimaryKeys"].nil?
+    refute dumped_state["LastSuccessfulPaginationKeys"].nil?
     refute dumped_state["CompletedTables"].nil?
     refute dumped_state["LastWrittenBinlogPosition"].nil?
     refute dumped_state["LastStoredBinlogPositionForInlineVerifier"].nil?

--- a/webui/index.html
+++ b/webui/index.html
@@ -65,7 +65,7 @@
             <tr>
               <th><abbr title="This number is just an estimate, it probably is not accurate.">ETA</abbr></th>
               <td>
-                {{.ETA}} (at {{.PKsPerSecond}} PKs/s)
+                {{.ETA}} (at {{.PaginationKeysPerSecond}} PaginationKeys/s)
               </td>
             </tr>
             <tr>
@@ -193,20 +193,20 @@
           <thead>
             <tr>
               <th>Table</th>
-              <th><abbr title="Primary Key Column">PK</abbr></th>
+              <th><abbr title="Pagination Column">PaginationKey</abbr></th>
               <th>Status</th>
-              <th>Last Successful PK</th>
-              <th>Target PK</th>
+              <th>Last Successful PaginationKey</th>
+              <th>Target PaginationKey</th>
             </tr>
           </thead>
           <tbody>
             {{range .TableStatuses}}
               <tr>
                 <td><code>{{.TableName}}</code></td>
-                <td><code>{{.PrimaryKeyName}}</code></td>
+                <td><code>{{.PaginationKeyName}}</code></td>
                 <td>{{.Status}}</td>
-                <td>{{.LastSuccessfulPK}}</td>
-                <td>{{.TargetPK}}</td>
+                <td>{{.LastSuccessfulPaginationKey}}</td>
+                <td>{{.TargetPaginationKey}}</td>
               </tr>
             {{end}}
           </tbody>


### PR DESCRIPTION
Implementation of https://github.com/Shopify/ghostferry/pull/138 was a quick hack to attain the required functionality. This PR serves the sole purpose of ensuring naming now reflects the usage of `Pagination Column` as the pivot for iteration during a `Ghostferry` migration. 

In order to sift the correct usage of PK as in Primary Key vs that of Pagination Key throughout the code base, I resorted to introducing changes incrementally, commit per commit that can assist in the case a systematic mistake was made in the conversion. 

First my primary focus was to get rid off the deceptive naming off: `GetPKColumn` and to remove the unneeded index:
* Change naming GetPKColumn -> GetPaginationColumn"
* Remove unneeded index

After that, my primary focus was to convert:
* PrimaryKey -> PaginationKey

for those cases where this was needed. For instance, `PrimaryKeyTables` is a concept that pertains to Primary Keys, so that is something that needs to be retained vs other cases where clearly it pertains to Pagination Key instead.

Next on the menu was to check for the sanity of capital 'PK' occurrences as capitalization is an emphasis and thus indicates prominence:
* quotedPK -> quotedPaginationKey
* PK -> PaginationKey
* targetPK -> targetPaginationKey
* TargetPK -> TargetPaginationKey
* LastSuccessfulPK -> LastSuccessfulPaginationKey
* lastSuccessfulPK -> lastSuccessfulPaginationKey
* completedPK -> completedPaginationKey
* PKs -> PaginationKeys
* PKPositionLog -> PaginationKeyPositionLog
* deltaPK -> deltaPaginationKey

After all those changes above, there were a few cases remaining of capital 'PK' that made it easier to go for a blind change all:
* modify various PK -> PaginationKey

Then the main focus was on 'Pk' occurrences which were rather few:
* Pk -> PaginationKey

Lastly was any other 'pk' variable remaining where:
* pkColumn -> paginationKeyColumn

was first tackled as an easy way to decrease an occurrence of 500 different variables remaining

Followed by what should be `primaryKeyTable`:
* pkTable -> primaryKeyTable

After which at last it was easier to justify a blind indulgence of all that is remaining:
* bulk update pk -> paginationKey