### PR TITLE
Use CascadingPaginationColumnConfig.FallbackColumn as fallback after Primary Key

### DIFF
--- a/config.go
+++ b/config.go
@@ -275,8 +275,8 @@ type CascadingPaginationColumnConfig struct {
 	// PerTable has greatest specificity and takes precedence over the other options
 	PerTable map[string]map[string]string // SchemaName => TableName => ColumnName
 
-	// FallbackColumn is a global default to fallback to and is more specific than the default fallback,
-	// which would be the Primary Key
+	// FallbackColumn is a global default to fallback to and is less specific than the
+	// default, which is the Primary Key
 	FallbackColumn string
 }
 
@@ -297,6 +297,15 @@ func (c *CascadingPaginationColumnConfig) PaginationColumnFor(schemaName, tableN
 	}
 
 	return column, true
+}
+
+// FallbackPaginationColumnName retreives the column name specified as a fallback when the Primary Key isn't suitable for pagination
+func (c *CascadingPaginationColumnConfig) FallbackPaginationColumnName() (string, bool) {
+	if c == nil || c.FallbackColumn == "" {
+		return "", false
+	}
+
+	return c.FallbackColumn, true
 }
 
 type Config struct {
@@ -467,8 +476,8 @@ type Config struct {
 
 	// Ghostferry requires a single numeric column to paginate over tables. Inferring that column is done in the following exact order:
 	// 1. Use the PerTable pagination column, if configured for a table. Fail if we cannot find this column in the table.
-	// 2. Use the FallbackColumn pagination column, if configured. Fail if we cannot find this column in the table.
-	// 3. Use the table's primary key column as the pagination column. Fail if the primary key is a composite key or is not numeric.
+	// 2. Use the table's primary key column as the pagination column. Fail if the primary key is not numeric or is a composite key without a FallbackColumn specified.
+	// 3. Use the FallbackColumn pagination column, if configured. Fail if we cannot find this column in the table.
 	CascadingPaginationColumnConfig *CascadingPaginationColumnConfig
 }
 


### PR DESCRIPTION
_It's been a long time since I've written Go, so feel free to point out any non-idiomatic things!_

### What does this PR do?

As a follow-up to https://github.com/Shopify/ghostferry/pull/138, we should use `CascadingPaginationColumnConfig.FallbackColumn` as a last resort before erroring. The current `master` will use the fallback column before attempting to use the primary key.

### How does it do it?

```ruby
# Example of absolute override + fallback config
CascadingPaginationColumnConfig: {
  PerTable: {
    'my_db_schema' => {
      products: 'id',
    },
  },
  FallbackColumn: 'id'
}
```

https://github.com/Shopify/ghostferry/blob/7d01d7044d4b8577462657a8bf625a52453be7e9/table_schema_cache.go#L241-L253

### Notes

We will still error if the PK or `FallbackColumn` is non-numeric. I'm not sure if we should use the `FallbackColumn` if the PK is non-numeric, but for now we only check numericality after all of the above (see [here](https://github.com/Shopify/ghostferry/blob/7d01d7044d4b8577462657a8bf625a52453be7e9/table_schema_cache.go#L255-L257)).

I also spotted @sroysen's [comment](https://github.com/Shopify/ghostferry/pull/138#issuecomment-544944216) about defaulting to the table's auto-increment column for pagination after writing this PR. That's something that can be added as a check before the fallback if we so wish, so that feature would be complementary to this one.