### PR TITLE
InlineVerifier is not validating some tables with composite PKs correctly

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -65,7 +65,7 @@ type Cursor struct {
 	MaxPaginationKey uint64
 	RowLock          bool
 
-	paginationKeyColumn                    *schema.TableColumn
+	paginationKeyColumn         *schema.TableColumn
 	lastSuccessfulPaginationKey uint64
 	logger                      *logrus.Entry
 }
@@ -245,9 +245,9 @@ func (c *Cursor) Fetch(db SqlPreparer) (batch *RowBatch, paginationKeypos uint64
 	}
 
 	batch = &RowBatch{
-		values:  batchData,
+		values:             batchData,
 		paginationKeyIndex: paginationKeyIndex,
-		table:   c.Table,
+		table:              c.Table,
 	}
 
 	logger.Debugf("found %d rows", batch.Size())

--- a/dml_events.go
+++ b/dml_events.go
@@ -445,6 +445,5 @@ func paginationKeyFromEventData(table *TableSchema, rowData RowData) (uint64, er
 		return 0, err
 	}
 
-	paginationKeyIndex := table.PKColumns[0]
-	return rowData.GetUint64(paginationKeyIndex)
+	return rowData.GetUint64(table.GetPaginationKeyIndex())
 }

--- a/inline_verifier.go
+++ b/inline_verifier.go
@@ -82,9 +82,9 @@ func (s BinlogVerifySerializedStore) Copy() BinlogVerifySerializedStore {
 }
 
 type BinlogVerifyBatch struct {
-	SchemaName string
-	TableName  string
-	PaginationKeys        []uint64
+	SchemaName     string
+	TableName      string
+	PaginationKeys []uint64
 }
 
 func NewBinlogVerifyStore() *BinlogVerifyStore {
@@ -182,9 +182,9 @@ func (s *BinlogVerifyStore) Batches(batchsize int) []BinlogVerifyBatch {
 				paginationKeyBatch = append(paginationKeyBatch, paginationKey)
 				if len(paginationKeyBatch) >= batchsize {
 					batches = append(batches, BinlogVerifyBatch{
-						SchemaName: schemaName,
-						TableName:  tableName,
-						PaginationKeys:        paginationKeyBatch,
+						SchemaName:     schemaName,
+						TableName:      tableName,
+						PaginationKeys: paginationKeyBatch,
 					})
 					paginationKeyBatch = make([]uint64, 0, batchsize)
 				}
@@ -192,9 +192,9 @@ func (s *BinlogVerifyStore) Batches(batchsize int) []BinlogVerifyBatch {
 
 			if len(paginationKeyBatch) > 0 {
 				batches = append(batches, BinlogVerifyBatch{
-					SchemaName: schemaName,
-					TableName:  tableName,
-					PaginationKeys:        paginationKeyBatch,
+					SchemaName:     schemaName,
+					TableName:      tableName,
+					PaginationKeys: paginationKeyBatch,
 				})
 			}
 		}


### PR DESCRIPTION
The current InlineVerifier code uses `.PKColumns[0]` to identify the pagination column in the binlog verification. This causes **false negatives** in the verification for tables with certain composite PK tables.

This PR fixes this issue and adds the appropriate tests.