### PR TITLE
Do not record InlineVerifier pos in state dump if not verifying

### DIFF
--- a/ferry.go
+++ b/ferry.go
@@ -508,7 +508,9 @@ func (f *Ferry) Start() error {
 	// is terminated with some rows copied but no binlog events are written.
 	// This guarentees that we are able to restart from a valid location.
 	f.StateTracker.UpdateLastWrittenBinlogPosition(pos)
-	f.StateTracker.UpdateLastStoredBinlogPositionForInlineVerifier(pos)
+	if f.inlineVerifier != nil {
+		f.StateTracker.UpdateLastStoredBinlogPositionForInlineVerifier(pos)
+	}
 
 	return nil
 }

--- a/test/go/state_tracker_test.go
+++ b/test/go/state_tracker_test.go
@@ -38,6 +38,32 @@ func (s *StateTrackerTestSuite) TestMinBinlogPosition() {
 		},
 	}
 	s.Require().Equal(serializedState.MinBinlogPosition(), mysql.Position{"mysql-bin.00002", 10})
+
+	serializedState = &ghostferry.SerializableState{
+		LastWrittenBinlogPosition: mysql.Position{
+			Name: "",
+			Pos:  0,
+		},
+
+		LastStoredBinlogPositionForInlineVerifier: mysql.Position{
+			Name: "mysql-bin.00002",
+			Pos:  10,
+		},
+	}
+	s.Require().Equal(serializedState.MinBinlogPosition(), mysql.Position{"mysql-bin.00002", 10})
+
+	serializedState = &ghostferry.SerializableState{
+		LastStoredBinlogPositionForInlineVerifier: mysql.Position{
+			Name: "",
+			Pos:  0,
+		},
+
+		LastWrittenBinlogPosition: mysql.Position{
+			Name: "mysql-bin.00002",
+			Pos:  10,
+		},
+	}
+	s.Require().Equal(serializedState.MinBinlogPosition(), mysql.Position{"mysql-bin.00002", 10})
 }
 
 func TestStateTrackerTestSuite(t *testing.T) {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -112,6 +112,5 @@ class GhostferryTestCase < Minitest::Test
     refute dumped_state["LastSuccessfulPaginationKeys"].nil?
     refute dumped_state["CompletedTables"].nil?
     refute dumped_state["LastWrittenBinlogPosition"].nil?
-    refute dumped_state["LastStoredBinlogPositionForInlineVerifier"].nil?
   end
 end


### PR DESCRIPTION
If the VerifierType is not Inline, there's no point in recording the InlineVerifier binlog position in the state dump. This is done right now because the code records the binlog position at the beginning of a run. This actually somewhat misleading as it makes people using Ghostferry without verification might think the InlineVerifier is running due to its presence in the state dump.