### PR TITLE
Fix possible data corruption due to UPDATE/DELETE not applied on tables with JSON columns

### DIFF
--- a/test/integration/types_test.rb
+++ b/test/integration/types_test.rb
@@ -1,23 +1,26 @@
 require "test_helper"
 
 class TypesTest < GhostferryTestCase
-  def test_json_data
+  JSON_OBJ = '{"data": {"quote": "\\\'", "value": [1]}}'
+  EMPTY_JSON = '{}'
+  JSON_ARRAY = '[\"test_data\", \"test_data_2\"]'
+
+  def test_json_data_insert
     [source_db, target_db].each do |db|
       db.query("CREATE DATABASE IF NOT EXISTS #{DEFAULT_DB}")
       db.query("CREATE TABLE IF NOT EXISTS #{DEFAULT_FULL_TABLE_NAME} (id bigint(20) not null auto_increment, data JSON, primary key(id))")
     end
 
-    json_obj = '{"data": {"quote": "\\\'", "value": [1]}}'
-    empty_json = '{}'
-    json_array = '[\"test_data\", \"test_data_2\"]'
-    source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (1, '#{json_obj}')")
-    source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (2, '#{json_array}')")
-    source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (3, '#{empty_json}')")
+    source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (1, '#{JSON_OBJ}')")
+    source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (2, '#{JSON_ARRAY}')")
+    source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (3, '#{EMPTY_JSON}')")
+    source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (4, NULL)")
 
     ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
 
     ghostferry.on_status(Ghostferry::Status::BINLOG_STREAMING_STARTED) do
-      source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (4, '#{json_obj}')")
+      source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (5, '#{JSON_OBJ}')")
+      source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (6, NULL)")
     end
 
     ghostferry.run
@@ -26,12 +29,118 @@ class TypesTest < GhostferryTestCase
     # with a JSON column is broken on 5.7.
     # See: https://bugs.mysql.com/bug.php?id=87847
     res = target_db.query("SELECT COUNT(*) AS cnt FROM #{DEFAULT_FULL_TABLE_NAME}")
-    assert_equal 4, res.first["cnt"]
+    assert_equal 6, res.first["cnt"]
 
     expected = [
       {"id"=>1, "data"=>"{\"data\": {\"quote\": \"'\", \"value\": [1]}}"},
       {"id"=>2, "data"=>"[\"test_data\", \"test_data_2\"]"},
       {"id"=>3, "data"=>"{}"},
+      {"id"=>4, "data"=>nil},
+      {"id"=>5, "data"=>"{\"data\": {\"quote\": \"'\", \"value\": [1]}}"},
+      {"id"=>6, "data"=>nil},
+    ]
+
+    res = target_db.query("SELECT * FROM #{DEFAULT_FULL_TABLE_NAME} ORDER BY id ASC")
+    res.zip(expected).each do |row, expected_row|
+      assert_equal expected_row, row
+    end
+  end
+
+  def test_json_data_delete
+    [source_db, target_db].each do |db|
+      db.query("CREATE DATABASE IF NOT EXISTS #{DEFAULT_DB}")
+      db.query("CREATE TABLE IF NOT EXISTS #{DEFAULT_FULL_TABLE_NAME} (id bigint(20) not null auto_increment, data JSON, primary key(id))")
+    end
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+
+    ghostferry.on_status(Ghostferry::Status::BINLOG_STREAMING_STARTED) do
+      source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (1, '#{JSON_OBJ}')")
+      source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (2, '#{EMPTY_JSON}')")
+      source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (3, '#{JSON_ARRAY}')")
+      source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (4, NULL)")
+    end
+
+    timedout = false
+    ghostferry.on_status(Ghostferry::Status::ROW_COPY_COMPLETED) do
+      # Need to make sure we don't flush binlogs until we affirmatively see the
+      # 3 rows on the target and issue the DELETE statements
+      start = Time.now
+
+      loop do
+        sleep 0.1
+        res = target_db.query("SELECT COUNT(*) AS cnt FROM #{DEFAULT_FULL_TABLE_NAME}")
+        if res.first["cnt"] == 4
+          source_db.query("DELETE FROM #{DEFAULT_FULL_TABLE_NAME} WHERE id = 1")
+          source_db.query("DELETE FROM #{DEFAULT_FULL_TABLE_NAME} WHERE id = 2")
+          source_db.query("DELETE FROM #{DEFAULT_FULL_TABLE_NAME} WHERE id = 3")
+          source_db.query("DELETE FROM #{DEFAULT_FULL_TABLE_NAME} WHERE id = 4")
+          break
+        end
+
+        if Time.now - start > 10
+          timedout = true
+          break
+        end
+      end
+    end
+
+    ghostferry.run
+    refute timedout
+
+    res = target_db.query("SELECT COUNT(*) AS cnt FROM #{DEFAULT_FULL_TABLE_NAME}")
+    assert_equal 0, res.first["cnt"]
+  end
+
+  def test_json_data_update
+    [source_db, target_db].each do |db|
+      db.query("CREATE DATABASE IF NOT EXISTS #{DEFAULT_DB}")
+      db.query("CREATE TABLE IF NOT EXISTS #{DEFAULT_FULL_TABLE_NAME} (id bigint(20) not null auto_increment, data JSON, primary key(id))")
+    end
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+
+    ghostferry.on_status(Ghostferry::Status::BINLOG_STREAMING_STARTED) do
+      source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (1, '#{JSON_OBJ}')")
+      source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (2, '#{EMPTY_JSON}')")
+      source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (3, '#{JSON_ARRAY}')")
+      source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} VALUES (4, NULL)")
+    end
+
+    timedout = false
+    ghostferry.on_status(Ghostferry::Status::ROW_COPY_COMPLETED) do
+      # Need to make sure we don't flush binlogs until we affirmatively see the
+      # 3 rows on the target and issue the DELETE statements
+      start = Time.now
+
+      loop do
+        sleep 0.1
+        res = target_db.query("SELECT COUNT(*) AS cnt FROM #{DEFAULT_FULL_TABLE_NAME}")
+        if res.first["cnt"] == 4
+          source_db.query("UPDATE #{DEFAULT_FULL_TABLE_NAME} SET data = '#{EMPTY_JSON}' WHERE id = 1")
+          source_db.query("UPDATE #{DEFAULT_FULL_TABLE_NAME} SET data = '#{JSON_ARRAY}' WHERE id = 2")
+          source_db.query("UPDATE #{DEFAULT_FULL_TABLE_NAME} SET data = NULL WHERE id = 3")
+          source_db.query("UPDATE #{DEFAULT_FULL_TABLE_NAME} SET data = '#{JSON_OBJ}' WHERE id = 4")
+          break
+        end
+
+        if Time.now - start > 10
+          timedout = true
+          break
+        end
+      end
+    end
+
+    ghostferry.run
+    refute timedout
+
+    res = target_db.query("SELECT COUNT(*) AS cnt FROM #{DEFAULT_FULL_TABLE_NAME}")
+    assert_equal 4, res.first["cnt"]
+
+    expected = [
+      {"id"=>1, "data"=>"{}"},
+      {"id"=>2, "data"=>"[\"test_data\", \"test_data_2\"]"},
+      {"id"=>3, "data"=>nil},
       {"id"=>4, "data"=>"{\"data\": {\"quote\": \"'\", \"value\": [1]}}"},
     ]
 


### PR DESCRIPTION
A DELETE or UPDATE statement issued by the BinlogWriter on a table with a JSON column could result in the row not being deleted or updated, which causes data corruption. The InlineVerifier and IterativeVerifier will catch this corruption during cutover(1).

Before this PR, the query generated by the BinlogWriter for JSON tables looks like:

```
INSERT IGNORE INTO `gftest`.`test_table_1` (`id`,`data`) 
VALUES (2,'{}');

UPDATE `gftest`.`test_table_1` 
SET `id`=2,`data`='["test_data","test_data_2"]'
WHERE `id`=2 AND `data`='{}';

DELETE FROM `gftest`.`test_table_1` 
WHERE `id`=3 AND `data`='["test_data","test_data_2"]';
```


After:

```
INSERT IGNORE INTO `gftest`.`test_table_1` (`id`,`data`) 
VALUES (2,CAST('{}' AS JSON));

UPDATE `gftest`.`test_table_1` 
SET `id`=2,`data`=CAST('["test_data","test_data_2"]' AS JSON) 
WHERE `id`=2 AND `data`=CAST('{}' AS JSON);

DELETE FROM `gftest`.`test_table_1` 
WHERE `id`=3 AND `data`=CAST('["test_data","test_data_2"]' AS JSON);
```

The reason for data corruption using the BEFORE queries is: when the JSON column is compared with a string in MySQL, it won't produce a match with anything. Thus UPDATEs and DELETEs fails as Ghostferry needs to match the entire row on the target with the entire row on the source to ensure data integrity. Using `CAST( AS JSON)` solves this issue.

(1): Note that if the InlineVerifier is used on a table that has a JSON column and a composite PK where the pagination key is not the left most column in the composite PK, data corruption could occur WITHOUT the InlineVerifier notifying. See #145.