### PR TITLE
Makes discrepency error less noisy

### DIFF
--- a/inline_verifier.go
+++ b/inline_verifier.go
@@ -599,14 +599,6 @@ func (v *InlineVerifier) verifyAllEventsInStore() (bool, map[string]map[string][
 	v.logger.WithField("batches", len(allBatches)).Debug("verifyAllEventsInStore")
 
 	for _, batch := range allBatches {
-		if _, exists := mismatches[batch.SchemaName]; !exists {
-			mismatches[batch.SchemaName] = make(map[string][]uint64)
-		}
-
-		if _, exists := mismatches[batch.SchemaName][batch.TableName]; !exists {
-			mismatches[batch.SchemaName][batch.TableName] = make([]uint64, 0)
-		}
-
 		batchMismatches, err := v.verifyBinlogBatch(batch)
 		if err != nil {
 			return false, nil, err
@@ -615,6 +607,15 @@ func (v *InlineVerifier) verifyAllEventsInStore() (bool, map[string]map[string][
 
 		if len(batchMismatches) > 0 {
 			mismatchFound = true
+
+			if _, exists := mismatches[batch.SchemaName]; !exists {
+				mismatches[batch.SchemaName] = make(map[string][]uint64)
+			}
+
+			if _, exists := mismatches[batch.SchemaName][batch.TableName]; !exists {
+				mismatches[batch.SchemaName][batch.TableName] = make([]uint64, 0)
+			}
+
 			mismatches[batch.SchemaName][batch.TableName] = append(mismatches[batch.SchemaName][batch.TableName], batchMismatches...)
 		}
 	}


### PR DESCRIPTION
Right now, any table/schemas that are checked are emitted in the mismatches hash, even if there are not mismatches. Thus, you get mismatch messages that looks like:

```
cutover verification failed for:
database.table1 [pks: 1 2 3 ]
database.table2 [pks: ]
```

In this example, only database.table1 have mismatches, but table2 is emitted. This commit fixes it such that only database.table1 is emitted.