### PR TITLE
Add maintenance comment to all sql change queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 build/
 .bundle/
 .vscode/
+.idea

--- a/config.go
+++ b/config.go
@@ -49,12 +49,15 @@ func (this *TLSConfig) BuildConfig() (*tls.Config, error) {
 }
 
 type DatabaseConfig struct {
-	Host      string
-	Port      uint16
-	User      string
-	Pass      string
-	Collation string
-	Params    map[string]string
+	Host       string
+	Port       uint16
+	User       string
+	Pass       string
+	Collation  string
+	Params     map[string]string
+	// SQL query comments to differentiate Ghostferry's binlog events
+	// Optional: defaults to empty string (no comments)
+	Marginalia string
 
 	TLS *TLSConfig
 }
@@ -126,7 +129,7 @@ func (c *DatabaseConfig) SqlDB(logger *logrus.Entry) (*sql.DB, error) {
 		logger.WithField("dsn", MaskedDSN(dbCfg)).Info("connecting to database")
 	}
 
-	return sql.Open("mysql", dbCfg.FormatDSN())
+	return sql.Open("mysql", dbCfg.FormatDSN(), c.Marginalia)
 }
 
 func (c *DatabaseConfig) assertParamSet(param, value string) error {

--- a/sqlwrapper/ghostferry_db.go
+++ b/sqlwrapper/ghostferry_db.go
@@ -7,23 +7,25 @@ import (
 
 type DB struct {
 	*sqlorig.DB
+	marginalia string
 }
 
 type Tx struct {
 	*sqlorig.Tx
+	marginalia string
 }
 
-func Open(driverName, dataSourceName string) (*DB, error) {
+func Open(driverName, dataSourceName, marginalia string) (*DB, error) {
 	sqlDB, err := sqlorig.Open(driverName, dataSourceName)
-	return &DB{sqlDB}, err
+	return &DB{sqlDB, marginalia}, err
 }
 
 func (db DB) PrepareContext(ctx context.Context, query string) (*sqlorig.Stmt, error) {
-	return db.DB.PrepareContext(ctx, query)
+	return db.DB.PrepareContext(ctx, Annotate(query, db.marginalia))
 }
 
 func (db DB) ExecContext(ctx context.Context, query string, args ...interface{}) (sqlorig.Result, error) {
-	return db.DB.ExecContext(ctx, query, args...)
+	return db.DB.ExecContext(ctx, Annotate(query, db.marginalia), args...)
 }
 
 func (db DB) QueryContext(ctx context.Context, query string, args ...interface{}) (*sqlorig.Rows, error) {
@@ -31,11 +33,11 @@ func (db DB) QueryContext(ctx context.Context, query string, args ...interface{}
 }
 
 func (db DB) Exec(query string, args ...interface{}) (sqlorig.Result, error) {
-	return db.DB.Exec(query, args...)
+	return db.DB.Exec(Annotate(query, db.marginalia), args...)
 }
 
 func (db DB) Prepare(query string) (*sqlorig.Stmt, error) {
-	return db.DB.Prepare(query)
+	return db.DB.Prepare(Annotate(query, db.marginalia))
 }
 
 func (db DB) Query(query string, args ...interface{}) (*sqlorig.Rows, error) {
@@ -52,23 +54,23 @@ func (db DB) QueryRowContext(ctx context.Context, query string, args ...interfac
 
 func (db DB) Begin() (*Tx, error) {
 	tx, err := db.DB.Begin()
-	return &Tx{tx}, err
+	return &Tx{tx, db.marginalia}, err
 }
 
 func (tx Tx) ExecContext(ctx context.Context, query string, args ...interface{}) (sqlorig.Result, error) {
-	return tx.Tx.ExecContext(ctx, query, args...)
+	return tx.Tx.ExecContext(ctx, Annotate(query, tx.marginalia), args...)
 }
 
 func (tx Tx) Exec(query string, args ...interface{}) (sqlorig.Result, error) {
-	return tx.Tx.Exec(query, args...)
+	return tx.Tx.Exec(Annotate(query, tx.marginalia), args...)
 }
 
 func (tx Tx) Prepare(query string) (*sqlorig.Stmt, error) {
-	return tx.Tx.Prepare(query)
+	return tx.Tx.Prepare(Annotate(query, tx.marginalia))
 }
 
 func (tx Tx) PrepareContext(ctx context.Context, query string) (*sqlorig.Stmt, error) {
-	return tx.Tx.PrepareContext(ctx, query)
+	return tx.Tx.PrepareContext(ctx, Annotate(query, tx.marginalia))
 }
 
 func (tx Tx) QueryContext(ctx context.Context, query string, args ...interface{}) (*sqlorig.Rows, error) {
@@ -85,4 +87,8 @@ func (tx Tx) QueryRowContext(ctx context.Context, query string, args ...interfac
 
 func (tx Tx) QueryRow(query string, args ...interface{}) *sqlorig.Row {
 	return tx.Tx.QueryRow(query, args...)
+}
+
+func Annotate(query, marginalia string) string {
+	return marginalia + query
 }

--- a/test/go/binlog_streamer_test.go
+++ b/test/go/binlog_streamer_test.go
@@ -29,7 +29,7 @@ func (this *BinlogStreamerTestSuite) SetupTest() {
 	this.Require().Nil(err)
 
 	sourceDSN := sourceConfig.FormatDSN()
-	this.sourceDb, err = sql.Open("mysql", sourceDSN)
+	this.sourceDb, err = sql.Open("mysql", sourceDSN, testFerry.Source.Marginalia)
 	if err != nil {
 		this.Fail("failed to connect to source database")
 	}

--- a/test/go/iterative_verifier_collation_test.go
+++ b/test/go/iterative_verifier_collation_test.go
@@ -30,7 +30,7 @@ func (t *IterativeVerifierCollationTestSuite) SetupTest() {
 
 	unsafeDSN := unsafeConfig.FormatDSN()
 
-	t.unsafeDb, err = sql.Open("mysql", unsafeDSN)
+	t.unsafeDb, err = sql.Open("mysql", unsafeDSN, unsafeDbConfig.Marginalia)
 	t.Require().Nil(err)
 
 	t.asciiData = "foobar"

--- a/test/go/race_conditions_integration_test.go
+++ b/test/go/race_conditions_integration_test.go
@@ -16,6 +16,14 @@ func setupSingleEntryTable(f *testhelpers.TestFerry, sourceDB, targetDB *sql.DB)
 	testhelpers.SeedInitialData(targetDB, "gftest", "table1", 0)
 }
 
+func annotate(queries []string, marginalia string) []string {
+	annotatedQueries := make([]string, len(queries))
+	for i, q := range queries {
+		annotatedQueries[i] = sql.Annotate(q, marginalia)
+	}
+	return annotatedQueries
+}
+
 func TestSelectUpdateBinlogCopy(t *testing.T) {
 	testcase := testhelpers.IntegrationTestCase{
 		T:           t,
@@ -36,6 +44,8 @@ func TestSelectUpdateBinlogCopy(t *testing.T) {
 				}
 			}(queries[i])
 		}
+
+		queries = annotate(queries, testcase.Ferry.Source.Marginalia)
 
 		// Waiting for sure until we can see the queries as they will be
 		// locked due to the SELECT FOR UPDATE that is being performed.

--- a/testhelpers/test_ferry.go
+++ b/testhelpers/test_ferry.go
@@ -37,6 +37,7 @@ func NewTestConfig() *ghostferry.Config {
 			Params: map[string]string{
 				"charset": "utf8mb4",
 			},
+			Marginalia: "/*maintenance:ghostferry*/ ",
 		},
 
 		Target: &ghostferry.DatabaseConfig{


### PR DESCRIPTION
# The Problem
Need to differentiate Technical Ghostferry's binlog events from Core's Business binlog events

# The Solution
Add `/*maintenance:ghostferry*/` comment to all change queries that are executed by Ghostferry. 