### PR TITLE
Unit-test for binary-column data corruption (#157)

### DIFF
--- a/test/go/trivial_integration_test.go
+++ b/test/go/trivial_integration_test.go
@@ -6,6 +6,7 @@ import (
 	sql "github.com/Shopify/ghostferry/sqlwrapper"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/Shopify/ghostferry/testhelpers"
 )
@@ -103,38 +104,10 @@ func TestCopyDataWhileRenamingDatabaseAndTable(t *testing.T) {
 	}
 
 	testcase.CustomVerifyAction = func(f *testhelpers.TestFerry, sourceDB, targetDB *sql.DB) {
-		sourceQuery := fmt.Sprintf("CHECKSUM TABLE `%s`.`%s` EXTENDED", sourceDatabaseName, sourceTableName)
-		targetQuery := fmt.Sprintf("CHECKSUM TABLE `%s`.`%s` EXTENDED", targetDatabaseName, targetTableName)
-
-		var tablename string
-		var sourceChecksum sqlorig.NullInt64
-		var targetChecksum sqlorig.NullInt64
-
-		sourceRow := f.SourceDB.QueryRow(sourceQuery)
-		err := sourceRow.Scan(&tablename, &sourceChecksum)
-		if err != nil {
-			testcase.T.Errorf("failed to get source checksum: %v", err)
-			return
-		}
-		if !sourceChecksum.Valid {
-			testcase.T.Errorf("source table doesn't exist")
-			return
-		}
-
-		targetRow := f.TargetDB.QueryRow(targetQuery)
-		err = targetRow.Scan(&tablename, &targetChecksum)
-		if err != nil {
-			testcase.T.Errorf("failed to get source checksum: %v", err)
-			return
-		}
-
-		if !targetChecksum.Valid {
-			testcase.T.Errorf("target table doesn't exist")
-			return
-		}
-
-		if sourceChecksum.Int64 != targetChecksum.Int64 {
-			testcase.T.Fatalf("source and target checksum does not match: %v, %v", sourceChecksum.Int64, targetChecksum.Int64)
+		sourceChecksum := checksumTable(t, sourceDB, sourceDatabaseName, sourceTableName, "source")
+		targetChecksum := checksumTable(t, targetDB, targetDatabaseName, targetTableName, "target")
+		if sourceChecksum != targetChecksum {
+			testcase.T.Fatalf("source and target checksum does not match: %v, %v", sourceChecksum, targetChecksum)
 		}
 	}
 
@@ -162,6 +135,92 @@ func TestCopyDataWithNullInColumn(t *testing.T) {
 			NumberOfWriters:     2,
 			Tables:              []string{"gftest.table1"},
 		},
+	}
+
+	testcase.Run()
+}
+
+func TestCopyDataInFixedSizeBinaryColumn(t *testing.T) {
+	databaseName := testhelpers.ApplicableTestDbs[0]
+	tableName := "table1"
+
+	// we need a way to wait for replication to catch up. There really isn't a good way to do this
+	// without a timeout without adding a notification from the binlog writer about updates (but how
+	// would it know that "updates are complete"?)
+	maxWaitForUpdates := 5 * time.Second
+
+	// XXX: If one changes the below line to be
+	//
+	// insertedData := "ABC\x00"
+	//
+	// the update stops working. This is a bug in how we process fixed-length binary columns
+	insertedData := "ABCD"
+	updatedData := "DEFG"
+
+	testcase := &testhelpers.IntegrationTestCase{
+		T:                       t,
+		Ferry:                   testhelpers.NewTestFerry(),
+		DisableChecksumVerifier: true,
+		AfterRowCopyIsComplete: func(ferry *testhelpers.TestFerry, sourceDB, targetDB *sql.DB) {
+			update := fmt.Sprintf("UPDATE `%s`.`%s` SET data = '%s' WHERE id = 1 LIMIT 1", databaseName, tableName, updatedData)
+			_, err := sourceDB.Exec(update)
+			if err != nil {
+				t.Errorf("updating source DB failed")
+				return
+			}
+		},
+		BeforeStoppingBinlogStreaming: func(ferry *testhelpers.TestFerry, sourceDB, targetDB *sql.DB) {
+			query := fmt.Sprintf("SELECT data FROM `%s`.`%s` WHERE id = 1", databaseName, tableName)
+			sourceRow := sourceDB.QueryRow(query)
+			var data string
+			err := sourceRow.Scan(&data)
+			if err != nil {
+				t.Errorf("selecting from source DB failed")
+				return
+			}
+			if data != updatedData {
+				t.Errorf("source table was not updated: '%s'", data)
+				return
+			}
+
+			// wait for replication to catch up. Not ideal, see comment above.
+			totalSleep := 0 * time.Millisecond
+			for {
+				targetRow := targetDB.QueryRow(query)
+				err = targetRow.Scan(&data)
+				if err != nil {
+					t.Errorf("selecting from target DB failed")
+					return
+				}
+				if data == updatedData {
+					break
+				}
+
+				sleep := 100 * time.Millisecond
+				time.Sleep(sleep)
+				totalSleep += sleep
+				if totalSleep > maxWaitForUpdates {
+					t.Errorf("target table was not updated after timeout: '%s'", data)
+					return
+				}
+			}
+		},
+		SetupAction: func(f *testhelpers.TestFerry, sourceDB, targetDB *sql.DB) {
+			setupSingleTableDatabaseWithBinaryColumn(sourceDB, databaseName, tableName)
+			setupSingleTableDatabaseWithBinaryColumn(targetDB, databaseName, tableName)
+
+			query := fmt.Sprintf("INSERT INTO `%s`.`%s` (id, data) VALUES (?, ?)", databaseName, tableName)
+			_, err := sourceDB.Exec(query, 1, insertedData)
+			testhelpers.PanicIfError(err)
+		},
+	}
+
+	testcase.CustomVerifyAction = func(f *testhelpers.TestFerry, sourceDB, targetDB *sql.DB) {
+		sourceChecksum := checksumTable(t, sourceDB, databaseName, tableName, "source")
+		targetChecksum := checksumTable(t, targetDB, databaseName, tableName, "target")
+		if sourceChecksum != targetChecksum {
+			testcase.T.Fatalf("source and target checksum does not match: %v, %v", sourceChecksum, targetChecksum)
+		}
 	}
 
 	testcase.Run()
@@ -215,4 +274,34 @@ func setupSingleTableDatabaseWithExtraNullColumn(f *testhelpers.TestFerry, sourc
 
 	_, err := sourceDB.Exec("UPDATE gftest.table1 SET tenant_id = NULL")
 	testhelpers.PanicIfError(err)
+}
+
+func setupSingleTableDatabaseWithBinaryColumn(db *sql.DB, dbname, tablename string) {
+	createDBQuery := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", dbname)
+	_, err := db.Exec(createDBQuery)
+	testhelpers.PanicIfError(err)
+
+	createTableQuery := fmt.Sprintf("CREATE TABLE `%s`.`%s` (id bigint(20) not null auto_increment, data BINARY(4), primary key(id))", dbname, tablename)
+	_, err = db.Exec(createTableQuery)
+	testhelpers.PanicIfError(err)
+}
+
+func checksumTable(t *testing.T, db *sql.DB, databaseName, tableName, logicalName string) int64 {
+	sourceQuery := fmt.Sprintf("CHECKSUM TABLE `%s`.`%s` EXTENDED", databaseName, tableName)
+
+	var rowTablename string
+	var checksum sqlorig.NullInt64
+
+	sourceRow := db.QueryRow(sourceQuery)
+	err := sourceRow.Scan(&rowTablename, &checksum)
+	if err != nil {
+		t.Errorf("failed to get %s checksum: %v", logicalName, err)
+		return 0
+	}
+	if !checksum.Valid {
+		t.Errorf("%s table doesn't exist", logicalName)
+		return 0
+	}
+
+	return checksum.Int64
 }

--- a/test/go/trivial_integration_test.go
+++ b/test/go/trivial_integration_test.go
@@ -149,12 +149,11 @@ func TestCopyDataInFixedSizeBinaryColumn(t *testing.T) {
 	// would it know that "updates are complete"?)
 	maxWaitForUpdates := 5 * time.Second
 
-	// XXX: If one changes the below line to be
-	//
-	// insertedData := "ABC\x00"
-	//
-	// the update stops working. This is a bug in how we process fixed-length binary columns
-	insertedData := "ABCD"
+	// NOTE: We explicitly test with trailing 0s, because the MySQL replication master will strip
+	// such trailing 0s when streaming events to us. As a result, the binlog writer must explicitly
+	// add then when building update/delete statements, as the WHERE clause would not match existing
+	// rows in the target DB
+	insertedData := "ABC\x00"
 	updatedData := "DEFG"
 
 	testcase := &testhelpers.IntegrationTestCase{


### PR DESCRIPTION
There seems to be a bug in the propagation of data from the binlog
streamer to the binlog writer when using fixed-length BINARY columns.

This commit adds an integration test that currently works only under
very specific conditions, and prepares the code for the fix to the data
propagation logic.