### PR TITLE
Allow specifying table creation order #161

### DIFF
--- a/copydb/config.go
+++ b/copydb/config.go
@@ -44,6 +44,14 @@ type Config struct {
 	// Filter configuration for tables to copy
 	Tables FilterAndRewriteConfigs
 
+	// Specifies the order in which to create database tables as <db>.<table> .
+	// Names refer to original databases and tables (that is, before renaming
+	// occurs).
+	// If a table is to be created on start and appears in this list, it is
+	// created before any other table, and is created in the order listed here.
+	// All tables not specified in this list are created in arbitrary order.
+	TablesToBeCreatedFirst []string
+
 	// If you're running Ghostferry from a read only replica, turn this option
 	// on and specify SourceReplicationMaster and ReplicatedMasterPositionQuery.
 	RunFerryFromReplica bool

--- a/copydb/copydb.go
+++ b/copydb/copydb.go
@@ -60,7 +60,7 @@ func (this *CopydbFerry) CreateDatabasesAndTables() error {
 	// We need to create the same table/schemas on the target database
 	// as the ones we are copying.
 	logrus.Info("creating databases and tables on target")
-	for tableName := range this.Ferry.Tables {
+	for _, tableName := range this.Ferry.Tables.GetTableListWithPriority(this.config.TablesToBeCreatedFirst) {
 		t := strings.Split(tableName, ".")
 
 		err := this.createDatabaseIfExistsOnTarget(t[0])

--- a/copydb/test/copydb_test.go
+++ b/copydb/test/copydb_test.go
@@ -85,6 +85,13 @@ func (t *CopydbTestSuite) TestCreateDatabaseAndTableWithRewrites() {
 	t.Require().Equal(renamedTableName, value)
 }
 
+func (t *CopydbTestSuite) TestCreateDatabaseAndTableWithOrdering() {
+	// NOTE: Here we just ensure passing a table does not cause issues in the
+	// invocation. A more thorough test is done in the table-schema tests
+	t.copydbConfig.TablesToBeCreatedFirst = []string{testSchemaName + "." + testTableName}
+	t.TestCreateDatabaseAndTableWithRewrites()
+}
+
 func TestCopydb(t *testing.T) {
 	testhelpers.SetupTest()
 	suite.Run(t, &CopydbTestSuite{})

--- a/table_schema_cache.go
+++ b/table_schema_cache.go
@@ -293,6 +293,31 @@ func (c TableSchemaCache) Get(database, table string) *TableSchema {
 	return c[fullTableName(database, table)]
 }
 
+// Helper to sort a given map of tables with a second list giving a priority.
+// If an element is present in the input and the priority lists, the item will
+// appear first (in the order of the priority list), all other items appear in
+// the order given in the input
+func (c TableSchemaCache) GetTableListWithPriority(priorityList []string) (prioritzedTableNames []string) {
+	// just a fast lookup if the list contains items already
+	contains := map[string]struct{}{}
+	if len(priorityList) >= 0 {
+		for _, tableName := range priorityList {
+			// ignore tables given in the priority list that we don't know
+			if _, found := c[tableName]; found {
+				contains[tableName] = struct{}{}
+				prioritzedTableNames = append(prioritzedTableNames, tableName)
+			}
+		}
+	}
+	for tableName, _ := range c {
+		if _, found := contains[tableName]; !found {
+			prioritzedTableNames = append(prioritzedTableNames, tableName)
+		}
+	}
+
+	return
+}
+
 func showDatabases(c *sql.DB) ([]string, error) {
 	rows, err := c.Query("show databases")
 	if err != nil {

--- a/table_schema_cache.go
+++ b/table_schema_cache.go
@@ -297,7 +297,7 @@ func (c TableSchemaCache) Get(database, table string) *TableSchema {
 // If an element is present in the input and the priority lists, the item will
 // appear first (in the order of the priority list), all other items appear in
 // the order given in the input
-func (c TableSchemaCache) GetTableListWithPriority(priorityList []string) (prioritzedTableNames []string) {
+func (c TableSchemaCache) GetTableListWithPriority(priorityList []string) (prioritizedTableNames []string) {
 	// just a fast lookup if the list contains items already
 	contains := map[string]struct{}{}
 	if len(priorityList) >= 0 {
@@ -305,13 +305,13 @@ func (c TableSchemaCache) GetTableListWithPriority(priorityList []string) (prior
 			// ignore tables given in the priority list that we don't know
 			if _, found := c[tableName]; found {
 				contains[tableName] = struct{}{}
-				prioritzedTableNames = append(prioritzedTableNames, tableName)
+				prioritizedTableNames = append(prioritizedTableNames, tableName)
 			}
 		}
 	}
 	for tableName, _ := range c {
 		if _, found := contains[tableName]; !found {
-			prioritzedTableNames = append(prioritzedTableNames, tableName)
+			prioritizedTableNames = append(prioritizedTableNames, tableName)
 		}
 	}
 


### PR DESCRIPTION
This commit introduces the ability for ghostferry-copydb to create
tables in a specific order. This can be useful if tables to be created
contain foreign-key constraints (FKCs).

NOTE: This does not mean that ghostferry supports FKCs! However, with
this feature and by disabling FKCs in the target DB, it is
theoretically possible to migrate DBs with FKCs - this is experimental
and not recommended for production usage. Use with care!

To disable the FKCs, one must add the following config to the target DB
configuration:

    "Params": {
        "foreign_key_checks": "0"
    }