### PR TITLE
Fix resumable binlog position after interrupt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
   - docker
 
 env:
-  - DOCKER_COMPOSE_VERSION=1.21.2 RELEASE_BRANCH=master
+  - DOCKER_COMPOSE_VERSION=1.21.2 RELEASE_BRANCH=master CI=true
 
 install:
   # Installing Docker Compose
@@ -21,6 +21,9 @@ install:
 
   # Installing and Starting MySQL
   - .travisci/start-mysql.sh
+
+before_script:
+  - ulimit -n 16384
 
 script:
   - make test

--- a/binlog_streamer.go
+++ b/binlog_streamer.go
@@ -187,8 +187,10 @@ func (s *BinlogStreamer) Run() {
 			// with empty GenericEvent structs.
 			// so there's no way to handle this for us.
 			continue
-		default:
+		case *replication.XIDEvent, *replication.GTIDEvent:
 			s.lastResumableBinlogPosition.Pos = uint32(ev.Header.LogPos)
+			s.updateLastStreamedPosAndTime(ev)
+		default:
 			s.updateLastStreamedPosAndTime(ev)
 		}
 	}

--- a/binlog_writer.go
+++ b/binlog_writer.go
@@ -111,7 +111,7 @@ func (b *BinlogWriter) writeEvents(events []DMLEvent) error {
 	}
 
 	if b.StateTracker != nil {
-		b.StateTracker.UpdateLastWrittenBinlogPosition(events[len(events)-1].ResumableBinlogPosition())
+		b.StateTracker.UpdateLastResumableBinlogPosition(events[len(events)-1].ResumableBinlogPosition())
 	}
 
 	return nil

--- a/binlog_writer.go
+++ b/binlog_writer.go
@@ -2,6 +2,7 @@ package ghostferry
 
 import (
 	"fmt"
+
 	sql "github.com/Shopify/ghostferry/sqlwrapper"
 
 	"github.com/sirupsen/logrus"
@@ -110,7 +111,7 @@ func (b *BinlogWriter) writeEvents(events []DMLEvent) error {
 	}
 
 	if b.StateTracker != nil {
-		b.StateTracker.UpdateLastWrittenBinlogPosition(events[len(events)-1].BinlogPosition())
+		b.StateTracker.UpdateLastWrittenBinlogPosition(events[len(events)-1].ResumableBinlogPosition())
 	}
 
 	return nil

--- a/ferry.go
+++ b/ferry.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	sql "github.com/Shopify/ghostferry/sqlwrapper"
 	"math"
 	"net/http"
 	"os"
@@ -14,6 +13,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	sql "github.com/Shopify/ghostferry/sqlwrapper"
 
 	"github.com/go-sql-driver/mysql"
 	siddontanglog "github.com/siddontang/go-log/log"
@@ -507,9 +508,9 @@ func (f *Ferry) Start() error {
 	// If we don't set this now, there is a race condition where Ghostferry
 	// is terminated with some rows copied but no binlog events are written.
 	// This guarentees that we are able to restart from a valid location.
-	f.StateTracker.UpdateLastWrittenBinlogPosition(pos)
+	f.StateTracker.UpdateLastResumableBinlogPosition(pos)
 	if f.inlineVerifier != nil {
-		f.StateTracker.UpdateLastStoredBinlogPositionForInlineVerifier(pos)
+		f.StateTracker.UpdateLastResumableBinlogPositionForInlineVerifier(pos)
 	}
 
 	return nil

--- a/inline_verifier.go
+++ b/inline_verifier.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	sql "github.com/Shopify/ghostferry/sqlwrapper"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	sql "github.com/Shopify/ghostferry/sqlwrapper"
 
 	"github.com/golang/snappy"
 	"github.com/sirupsen/logrus"
@@ -569,7 +570,7 @@ func (v *InlineVerifier) binlogEventListener(evs []DMLEvent) error {
 
 	if v.StateTracker != nil {
 		ev := evs[len(evs)-1]
-		v.StateTracker.UpdateLastStoredBinlogPositionForInlineVerifier(ev.BinlogPosition())
+		v.StateTracker.UpdateLastStoredBinlogPositionForInlineVerifier(ev.ResumableBinlogPosition())
 	}
 
 	return nil

--- a/inline_verifier.go
+++ b/inline_verifier.go
@@ -570,7 +570,7 @@ func (v *InlineVerifier) binlogEventListener(evs []DMLEvent) error {
 
 	if v.StateTracker != nil {
 		ev := evs[len(evs)-1]
-		v.StateTracker.UpdateLastStoredBinlogPositionForInlineVerifier(ev.ResumableBinlogPosition())
+		v.StateTracker.UpdateLastResumableBinlogPositionForInlineVerifier(ev.ResumableBinlogPosition())
 	}
 
 	return nil

--- a/sharding/test/copy_filter_test.go
+++ b/sharding/test/copy_filter_test.go
@@ -142,7 +142,7 @@ func (t *CopyFilterTestSuite) TestShardingValueTypes() {
 	}
 
 	for _, tenantId := range tenantIds {
-		dmlEvents, _ := ghostferry.NewBinlogInsertEvents(t.normalTable, t.newRowsEvent([]interface{}{1001, tenantId, "data"}), mysql.Position{})
+		dmlEvents, _ := ghostferry.NewBinlogInsertEvents(t.normalTable, t.newRowsEvent([]interface{}{1001, tenantId, "data"}), mysql.Position{}, mysql.Position{})
 		applicable, err := t.filter.ApplicableEvent(dmlEvents[0])
 		t.Require().Nil(err)
 		t.Require().True(applicable, fmt.Sprintf("value %t wasn't applicable", tenantId))
@@ -150,7 +150,7 @@ func (t *CopyFilterTestSuite) TestShardingValueTypes() {
 }
 
 func (t *CopyFilterTestSuite) TestInvalidShardingValueTypesErrors() {
-	dmlEvents, err := ghostferry.NewBinlogInsertEvents(t.normalTable, t.newRowsEvent([]interface{}{1001, string("1"), "data"}), mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogInsertEvents(t.normalTable, t.newRowsEvent([]interface{}{1001, string("1"), "data"}), mysql.Position{}, mysql.Position{})
 	_, err = t.filter.ApplicableEvent(dmlEvents[0])
 	t.Require().Equal("parsing new sharding key: invalid type %!t(string=1)", err.Error())
 }

--- a/state_tracker.go
+++ b/state_tracker.go
@@ -113,14 +113,14 @@ func NewStateTrackerFromSerializedState(speedLogCount int, serializedState *Seri
 	return s
 }
 
-func (s *StateTracker) UpdateLastWrittenBinlogPosition(pos mysql.Position) {
+func (s *StateTracker) UpdateLastResumableBinlogPosition(pos mysql.Position) {
 	s.BinlogRWMutex.Lock()
 	defer s.BinlogRWMutex.Unlock()
 
 	s.lastWrittenBinlogPosition = pos
 }
 
-func (s *StateTracker) UpdateLastStoredBinlogPositionForInlineVerifier(pos mysql.Position) {
+func (s *StateTracker) UpdateLastResumableBinlogPositionForInlineVerifier(pos mysql.Position) {
 	s.BinlogRWMutex.Lock()
 	defer s.BinlogRWMutex.Unlock()
 

--- a/test/go/dml_events_test.go
+++ b/test/go/dml_events_test.go
@@ -61,7 +61,7 @@ func (this *DMLEventsTestSuite) TestBinlogInsertEventGeneratesInsertQuery() {
 		},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogInsertEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogInsertEvents(this.sourceTable, rowsEvent, mysql.Position{}, mysql.Position{})
 	this.Require().Nil(err)
 	this.Require().Equal(2, len(dmlEvents))
 
@@ -80,7 +80,7 @@ func (this *DMLEventsTestSuite) TestBinlogInsertEventWithWrongColumnsReturnsErro
 		Rows:  [][]interface{}{{1000}},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogInsertEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogInsertEvents(this.sourceTable, rowsEvent, mysql.Position{}, mysql.Position{})
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 
@@ -95,7 +95,7 @@ func (this *DMLEventsTestSuite) TestBinlogInsertEventMetadata() {
 		Rows:  [][]interface{}{{1000}},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogInsertEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogInsertEvents(this.sourceTable, rowsEvent, mysql.Position{}, mysql.Position{})
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 	this.Require().Equal("test_schema", dmlEvents[0].Database())
@@ -115,7 +115,7 @@ func (this *DMLEventsTestSuite) TestBinlogUpdateEventGeneratesUpdateQuery() {
 		},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.sourceTable, rowsEvent, mysql.Position{}, mysql.Position{})
 	this.Require().Nil(err)
 	this.Require().Equal(2, len(dmlEvents))
 
@@ -134,7 +134,7 @@ func (this *DMLEventsTestSuite) TestBinlogUpdateEventWithWrongColumnsReturnsErro
 		Rows:  [][]interface{}{{1000}, {1000}},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.sourceTable, rowsEvent, mysql.Position{}, mysql.Position{})
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 
@@ -152,7 +152,7 @@ func (this *DMLEventsTestSuite) TestBinlogUpdateEventWithNull() {
 		},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.sourceTable, rowsEvent, mysql.Position{}, mysql.Position{})
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 
@@ -167,7 +167,7 @@ func (this *DMLEventsTestSuite) TestBinlogUpdateEventMetadata() {
 		Rows:  [][]interface{}{{1000}, {1001}},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.sourceTable, rowsEvent, mysql.Position{}, mysql.Position{})
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 	this.Require().Equal("test_schema", dmlEvents[0].Database())
@@ -185,7 +185,7 @@ func (this *DMLEventsTestSuite) TestBinlogDeleteEventGeneratesDeleteQuery() {
 		},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.sourceTable, rowsEvent, mysql.Position{}, mysql.Position{})
 	this.Require().Nil(err)
 	this.Require().Equal(2, len(dmlEvents))
 
@@ -206,7 +206,7 @@ func (this *DMLEventsTestSuite) TestBinlogDeleteEventWithNull() {
 		},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.sourceTable, rowsEvent, mysql.Position{}, mysql.Position{})
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 
@@ -221,7 +221,7 @@ func (this *DMLEventsTestSuite) TestBinlogDeleteEventWithWrongColumnsReturnsErro
 		Rows:  [][]interface{}{{1000}},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.sourceTable, rowsEvent, mysql.Position{}, mysql.Position{})
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 
@@ -236,7 +236,7 @@ func (this *DMLEventsTestSuite) TestBinlogDeleteEventMetadata() {
 		Rows:  [][]interface{}{{1000}},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.sourceTable, rowsEvent, mysql.Position{})
+	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.sourceTable, rowsEvent, mysql.Position{}, mysql.Position{})
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 	this.Require().Equal("test_schema", dmlEvents[0].Database())

--- a/test/integration/trivial_test.rb
+++ b/test/integration/trivial_test.rb
@@ -26,14 +26,16 @@ class TrivialIntegrationTests < GhostferryTestCase
   def test_logged_query_omits_columns
     seed_simple_database_with_single_table
 
-    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
-    ghostferry.run
+    with_env('CI', nil) do
+      ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+      ghostferry.run
 
-    assert ghostferry.logrus_lines["cursor"].length > 0
+      assert ghostferry.logrus_lines["cursor"].length > 0
 
-    ghostferry.logrus_lines["cursor"].each do |line|
-      if line["msg"].start_with?("found ")
-        assert line["sql"].start_with?("SELECT [omitted] FROM")
+      ghostferry.logrus_lines["cursor"].each do |line|
+        if line["msg"].start_with?("found ")
+          assert line["sql"].start_with?("SELECT [omitted] FROM")
+        end
       end
     end
   end

--- a/test/lib/go/integrationferry.go
+++ b/test/lib/go/integrationferry.go
@@ -248,6 +248,9 @@ func NewStandardConfig() (*ghostferry.Config, error) {
 func main() {
 	logrus.SetFormatter(&logrus.JSONFormatter{})
 	logrus.SetLevel(logrus.DebugLevel)
+	if os.Getenv("CI") == "true" {
+		logrus.SetLevel(logrus.ErrorLevel)
+	}
 
 	config, err := NewStandardConfig()
 	if err != nil {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -113,4 +113,12 @@ class GhostferryTestCase < Minitest::Test
     refute dumped_state["CompletedTables"].nil?
     refute dumped_state["LastWrittenBinlogPosition"].nil?
   end
+
+  def with_env(key, value)
+    previous_value = ENV.delete(key)
+    ENV[key] = value
+    yield
+  ensure
+    ENV[key] = previous_value
+  end
 end

--- a/testhelpers/unit_test_suite.go
+++ b/testhelpers/unit_test_suite.go
@@ -17,6 +17,9 @@ func SetupTest() {
 	var err error
 
 	logrus.SetLevel(logrus.DebugLevel)
+	if os.Getenv("CI") == "true" {
+		logrus.SetLevel(logrus.ErrorLevel)
+	}
 
 	seed := time.Now().UnixNano()
 	envseed := os.Getenv("SEED")


### PR DESCRIPTION
Alternative to https://github.com/Shopify/ghostferry/pull/160 (and also makes use of the same added test with slight modifications).

As described in the other PR, attempting to resume Ghostferry from an invalid binlog position will result in an error as the preceding `TableMapEvent` is required to properly translate `RowsEvents`. 

This adds a resumable position and interface to the `DMLEvent` that the `InlineVerifier` and `BinlogWriter` persist during interruption to be reused during resume. 

The last resumable position is stored as a member of the `BinlogStreamer` and is periodically updated as the `BinlogStreamer` sees new resumable events (`GTIDEvents` and `XIDEvents`). This position is then sent along with the corresponding `DMLEvent`. The resumable position is made available on the `DMLEvents` using a new interface method - `ResumableBinlogPosition`.

/cc @Shopify/pods 