### PR TITLE
Clean up binlog streamer state tracking and reduce binlog file size to test binlog rotations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ VERSION_STR     := $(VERSION)+$(DATETIME)+$(COMMIT)
 LDFLAGS         := -X github.com/Shopify/ghostferry.VersionString=$(VERSION_STR)
 
 # Paths
-GOBIN           := $(GOPATH)/bin
+FIRSTGOPATH     := $(firstword $(subst :, ,$(GOPATH)))
+GOBIN           := $(FIRSTGOPATH)/bin
 BUILD_DIR       := build
 DEB_PREFIX      := $(BUILD_DIR)/debian
 SHARE_DIR       := usr/share/ghostferry

--- a/batch_writer.go
+++ b/batch_writer.go
@@ -2,6 +2,8 @@ package ghostferry
 
 import (
 	"fmt"
+	"time"
+
 	sql "github.com/Shopify/ghostferry/sqlwrapper"
 
 	"github.com/sirupsen/logrus"
@@ -36,7 +38,7 @@ func (w *BatchWriter) Initialize() {
 }
 
 func (w *BatchWriter) WriteRowBatch(batch *RowBatch) error {
-	return WithRetries(w.WriteRetries, 0, w.logger, "write batch to target", func() error {
+	return WithRetries(w.WriteRetries, 500*time.Millisecond, w.logger, "write batch to target", func() error {
 		values := batch.Values()
 		if len(values) == 0 {
 			return nil

--- a/binlog_streamer.go
+++ b/binlog_streamer.go
@@ -181,11 +181,10 @@ func (s *BinlogStreamer) Run() {
 
 			isFakeRotateEvent := ev.Header.LogPos == 0 && ev.Header.Timestamp == 0
 			if isFakeRotateEvent {
-				// Sometimes the RotateEvent is fake and not a real rotation. we want to ignore those events
+				// Sometimes the RotateEvent is fake and not a real rotation. we want to ignore the log position for those events
 				// https://github.com/percona/percona-server/blob/3ff016a46ce2cde58d8007ec9834f958da53cbea/sql/rpl_binlog_sender.cc#L278-L287
 				// https://github.com/percona/percona-server/blob/3ff016a46ce2cde58d8007ec9834f958da53cbea/sql/rpl_binlog_sender.cc#L904-L907
 				isEventPositionValid = false
-				break // out of the switch statement
 			}
 
 			nextFilename = string(e.NextLogName)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,17 @@
 mysql-1:
   image: percona:5.7
-  command: --server-id=1 --log-bin=mysql-bin --binlog-format=ROW --sync-binlog=1 --log-slave-updates=ON --gtid-mode=ON --enforce-gtid-consistency=ON --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --max-connections=1000 --read-only=OFF
+  command: --server-id=1
+    --log-bin=mysql-bin
+    --max-binlog-size=4096
+    --binlog-format=ROW
+    --sync-binlog=1
+    --log-slave-updates=ON
+    --gtid-mode=ON
+    --enforce-gtid-consistency=ON
+    --character-set-server=utf8mb4
+    --collation-server=utf8mb4_unicode_ci
+    --max-connections=1000
+    --read-only=OFF
   environment:
     MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
   volumes:
@@ -10,7 +21,17 @@ mysql-1:
 
 mysql-2:
   image: percona:5.7
-  command: --server-id=2 --log-bin=mysql-bin --binlog-format=ROW --sync-binlog=1 --log-slave-updates=ON --gtid-mode=ON --enforce-gtid-consistency=ON --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --max-connections=1000
+  command: --server-id=2
+    --log-bin=mysql-bin
+    --binlog-format=ROW
+    --max-binlog-size=4096
+    --sync-binlog=1
+    --log-slave-updates=ON
+    --gtid-mode=ON
+    --enforce-gtid-consistency=ON
+    --character-set-server=utf8mb4
+    --collation-server=utf8mb4_unicode_ci
+    --max-connections=1000
   environment:
     MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
   volumes:
@@ -20,7 +41,17 @@ mysql-2:
 
 mysql-3:
   image: percona:5.7
-  command: --server-id=3 --log-bin=mysql-bin --binlog-format=ROW --sync-binlog=1 --log-slave-updates=ON --gtid-mode=ON --enforce-gtid-consistency=ON --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --max-connections=1000
+  command: --server-id=3
+    --log-bin=mysql-bin
+    --binlog-format=ROW
+    --max-binlog-size=4096
+    --sync-binlog=1
+    --log-slave-updates=ON
+    --gtid-mode=ON
+    --enforce-gtid-consistency=ON
+    --character-set-server=utf8mb4
+    --collation-server=utf8mb4_unicode_ci
+    --max-connections=1000
   environment:
     MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
   volumes:

--- a/ferry.go
+++ b/ferry.go
@@ -752,7 +752,7 @@ func (f *Ferry) Progress() *Progress {
 	// Binlog Progress
 	s.LastSuccessfulBinlogPos = f.BinlogStreamer.lastStreamedBinlogPosition
 	s.BinlogStreamerLag = time.Now().Sub(f.BinlogStreamer.lastProcessedEventTime).Seconds()
-	s.FinalBinlogPos = f.BinlogStreamer.targetBinlogPosition
+	s.FinalBinlogPos = f.BinlogStreamer.stopAtBinlogPosition
 
 	// Table Progress
 	serializedState := f.StateTracker.Serialize(nil, nil)

--- a/status_deprecated.go
+++ b/status_deprecated.go
@@ -76,7 +76,7 @@ func FetchStatusDeprecated(f *Ferry, v Verifier) *StatusDeprecated {
 	status.AutomaticCutover = f.Config.AutomaticCutover
 	status.BinlogStreamerStopRequested = f.BinlogStreamer.stopRequested
 	status.LastSuccessfulBinlogPos = f.BinlogStreamer.lastStreamedBinlogPosition
-	status.TargetBinlogPos = f.BinlogStreamer.targetBinlogPosition
+	status.TargetBinlogPos = f.BinlogStreamer.stopAtBinlogPosition
 
 	status.Throttled = f.Throttler.Throttled()
 

--- a/test/helpers/data_writer_helper.rb
+++ b/test/helpers/data_writer_helper.rb
@@ -107,8 +107,9 @@ module DataWriterHelper
       table = @tables.sample
       insert_statement = connection.prepare("INSERT INTO #{table} (id, data) VALUES (?, ?)")
       insert_statement.execute(nil, DbHelper.rand_data)
-      insert_statement.close
       connection.last_id
+    ensure
+      insert_statement&.close
     end
 
     def update_data(connection)
@@ -116,8 +117,9 @@ module DataWriterHelper
       id = random_real_id(connection, table)
       update_statement = connection.prepare("UPDATE #{table} SET data = ? WHERE id >= ? LIMIT 1")
       update_statement.execute(DbHelper.rand_data, id)
-      update_statement.close
       id
+    ensure
+      update_statement&.close
     end
 
     def delete_data(connection)
@@ -125,8 +127,9 @@ module DataWriterHelper
       id = random_real_id(connection, table)
       delete_statement = connection.prepare("DELETE FROM #{table} WHERE id >= ? LIMIT 1")
       delete_statement.execute(id)
-      delete_statement.close
       id
+    ensure
+      delete_statement&.close
     end
 
     def random_real_id(connection, table)

--- a/test/helpers/db_helper.rb
+++ b/test/helpers/db_helper.rb
@@ -58,6 +58,12 @@ module DbHelper
     end
   end
 
+  def teardown_connections
+    @connections.each_value do |conn|
+      conn&.close
+    end
+  end
+
   def source_db
     @connections[:source]
   end

--- a/test/integration/interrupt_resume_test.rb
+++ b/test/integration/interrupt_resume_test.rb
@@ -315,8 +315,8 @@ class InterruptResumeTest < GhostferryTestCase
     # DML event.
     # Since we are racing between applying rows and sending the shutdown event,
     # we emit a whole bunch of them
-    num_batches = 20
-    num_values_per_batch = 1000
+    num_batches = 10
+    num_values_per_batch = 200
     row_id = 0
     ghostferry.on_status(Ghostferry::Status::BINLOG_STREAMING_STARTED) do
       for _batch_id in 0..num_batches do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -77,6 +77,10 @@ class GhostferryTestCase < Minitest::Test
     end
   end
 
+  def after_all
+    teardown_connections
+  end
+
   #####################
   # Assertion Helpers #
   #####################


### PR DESCRIPTION
Lot of small changes here:

* Reduce `max_binlog_size` in tests. This will exercise the binlog rotation codepath a lot more.
* Introduce a `currentBinlogFilename` variable and remove the implicit assumption that `lastStreamedPosition.Name` is the _current_ filename as well. This is a source of a lot of confusion.
* Consider fake events (some `RotateEvent`s and some `FormatDescriptionEvent`s) positions as invalid and don't advance our binlog position based on them
* Remove all mutations of all `mysql.Position` variables. Recreate the values from fresh state instead.
* Make the event handler `switch` statement completely imperative. Make it extra clear when `s.updateLastStreamedPosAndTime` is called.
* Fix a bug where we don't update the binlog position on `GenericEvent`s. This was causing tests to hang forever when the binlog is rotated and the target binlog position is in the _next_ file.

cc @Shopify/pods 