### PR TITLE
add default marginalia value

### DIFF
--- a/config.go
+++ b/config.go
@@ -19,6 +19,8 @@ const (
 	VerifierTypeIterative      = "Iterative"
 	VerifierTypeInline         = "Inline"
 	VerifierTypeNoVerification = "NoVerification"
+
+	DefaultMarginalia = "application:ghostferry"
 )
 
 type TLSConfig struct {
@@ -56,11 +58,12 @@ type DatabaseConfig struct {
 	Pass      string
 	Collation string
 	Params    map[string]string
-	// SQL query comments to differentiate Ghostferry's binlog events
-	// Optional: defaults to empty string (no comments)
-	Marginalia string
+	TLS       *TLSConfig
 
-	TLS *TLSConfig
+	// SQL annotations used to differentiate Ghostferry's DMLs
+	// against other actor's. This will default to the defaultMarginalia
+	// constant above if not set.
+	Marginalia string
 }
 
 func (c *DatabaseConfig) MySQLConfig() (*mysql.Config, error) {
@@ -115,6 +118,10 @@ func (c *DatabaseConfig) Validate() error {
 	err = c.assertParamSet("sql_mode", "'STRICT_ALL_TABLES,NO_BACKSLASH_ESCAPES'")
 	if err != nil {
 		return err
+	}
+
+	if c.Marginalia == "" {
+		c.Marginalia = DefaultMarginalia
 	}
 
 	return nil

--- a/sqlwrapper/ghostferry_db.go
+++ b/sqlwrapper/ghostferry_db.go
@@ -3,6 +3,7 @@ package sqlwrapper
 import (
 	"context"
 	sqlorig "database/sql"
+	"fmt"
 )
 
 type DB struct {
@@ -90,5 +91,5 @@ func (tx Tx) QueryRow(query string, args ...interface{}) *sqlorig.Row {
 }
 
 func Annotate(query, marginalia string) string {
-	return marginalia + query
+	return fmt.Sprintf("/*%s*/ %s", marginalia, query)
 }

--- a/test/go/config_test.go
+++ b/test/go/config_test.go
@@ -150,6 +150,13 @@ func (this *ConfigTestSuite) TestParamsAndCollationGetsPassedToMysqlConfig() {
 	this.Require().Equal("'STRICT_ALL_TABLES,NO_BACKSLASH_ESCAPES'", mysqlConfig.Params["sql_mode"])
 }
 
+func (this *ConfigTestSuite) TestDefaultMarginalia() {
+	this.config.Target.Marginalia = ""
+	err := this.config.ValidateConfig()
+	this.Require().Nil(err)
+	this.Require().Equal(ghostferry.DefaultMarginalia, this.config.Target.Marginalia)
+}
+
 func TestConfig(t *testing.T) {
 	testhelpers.SetupTest()
 	suite.Run(t, new(ConfigTestSuite))

--- a/testhelpers/test_ferry.go
+++ b/testhelpers/test_ferry.go
@@ -37,7 +37,6 @@ func NewTestConfig() *ghostferry.Config {
 			Params: map[string]string{
 				"charset": "utf8mb4",
 			},
-			Marginalia: "/*maintenance:ghostferry*/ ",
 		},
 
 		Target: &ghostferry.DatabaseConfig{


### PR DESCRIPTION
Follow up of https://github.com/Shopify/ghostferry/pull/155.

Sets a default marginalia value when not provided by the configuration.

Previous to this PR, if an annotation/marginalia was not provided, Ghostferry's DMLs would not have any annotation. After this change, if an annotation is not provided, Ghostferry will fallback to using the default annotation (`application:ghostferry`).

This is needed for an upcoming PR that will require use of these annotations to validate DMLs against the Target for the duration of the move (until cutover). 

/cc @Shopify/pods 