### PR TITLE
2x speed up in ruby integration tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gem "minitest"
 gem "minitest-hooks"
 gem "mysql2"
+gem "byebug"
 
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (11.1.1)
     minitest (5.11.3)
     minitest-hooks (1.5.0)
       minitest (> 5.3)
@@ -11,10 +12,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  byebug
   minitest
   minitest-hooks
   mysql2
   rake
 
 BUNDLED WITH
-   1.16.1
+   1.17.3


### PR DESCRIPTION
This almost doubles the ruby integration test performance:

on this branch:
```
Finished in 24.404618s, 0.4098 runs/s, 4.5893 assertions/s.

10 runs, 112 assertions, 0 failures, 0 errors, 0 skips
```

vs

`fast-rotations` branch:
```
Finished in 50.197126s, 0.1992 runs/s, 2.2312 assertions/s.

10 runs, 112 assertions, 0 failures, 0 errors, 0 skips
```