### PR TITLE
Capture RowsQueryEvents; add annotations to DML events

### DIFF
--- a/binlog_writer.go
+++ b/binlog_writer.go
@@ -78,7 +78,7 @@ func (b *BinlogWriter) BufferBinlogEvents(events []DMLEvent) error {
 func (b *BinlogWriter) writeEvents(events []DMLEvent) error {
 	WaitForThrottle(b.Throttler)
 
-	queryBuffer := []byte("BEGIN;\n")
+	queryBuffer := []byte(sql.AnnotateStmt("BEGIN;\n", b.DB.Marginalia))
 
 	for _, ev := range events {
 		eventDatabaseName := ev.Database()
@@ -91,12 +91,12 @@ func (b *BinlogWriter) writeEvents(events []DMLEvent) error {
 			eventTableName = targetTableName
 		}
 
-		sql, err := ev.AsSQLString(eventDatabaseName, eventTableName)
+		sqlStmt, err := ev.AsSQLString(eventDatabaseName, eventTableName)
 		if err != nil {
 			return fmt.Errorf("generating sql query at pos %v: %v", ev.BinlogPosition(), err)
 		}
 
-		queryBuffer = append(queryBuffer, sql...)
+		queryBuffer = append(queryBuffer, sql.AnnotateStmt(sqlStmt, b.DB.Marginalia)...)
 		queryBuffer = append(queryBuffer, ";\n"...)
 	}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ mysql-1:
     --collation-server=utf8mb4_unicode_ci
     --max-connections=1000
     --read-only=OFF
+    --binlog-rows-query-log-events=ON
   environment:
     MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
   volumes:
@@ -32,6 +33,7 @@ mysql-2:
     --character-set-server=utf8mb4
     --collation-server=utf8mb4_unicode_ci
     --max-connections=1000
+    --binlog-rows-query-log-events=ON
   environment:
     MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
   volumes:
@@ -52,6 +54,7 @@ mysql-3:
     --character-set-server=utf8mb4
     --collation-server=utf8mb4_unicode_ci
     --max-connections=1000
+    --binlog-rows-query-log-events=ON
   environment:
     MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
   volumes:

--- a/sharding/test/copy_filter_test.go
+++ b/sharding/test/copy_filter_test.go
@@ -141,8 +141,15 @@ func (t *CopyFilterTestSuite) TestShardingValueTypes() {
 		int64(1), int32(1), int16(1), int8(1), int(1),
 	}
 
+	eventBase := ghostferry.NewDMLEventBase(
+		t.normalTable,
+		mysql.Position{},
+		mysql.Position{},
+		nil,
+	)
+
 	for _, tenantId := range tenantIds {
-		dmlEvents, _ := ghostferry.NewBinlogInsertEvents(t.normalTable, t.newRowsEvent([]interface{}{1001, tenantId, "data"}), mysql.Position{}, mysql.Position{})
+		dmlEvents, _ := ghostferry.NewBinlogInsertEvents(eventBase, t.newRowsEvent([]interface{}{1001, tenantId, "data"}))
 		applicable, err := t.filter.ApplicableEvent(dmlEvents[0])
 		t.Require().Nil(err)
 		t.Require().True(applicable, fmt.Sprintf("value %t wasn't applicable", tenantId))
@@ -150,7 +157,14 @@ func (t *CopyFilterTestSuite) TestShardingValueTypes() {
 }
 
 func (t *CopyFilterTestSuite) TestInvalidShardingValueTypesErrors() {
-	dmlEvents, err := ghostferry.NewBinlogInsertEvents(t.normalTable, t.newRowsEvent([]interface{}{1001, string("1"), "data"}), mysql.Position{}, mysql.Position{})
+	eventBase := ghostferry.NewDMLEventBase(
+		t.normalTable,
+		mysql.Position{},
+		mysql.Position{},
+		nil,
+	)
+
+	dmlEvents, err := ghostferry.NewBinlogInsertEvents(eventBase, t.newRowsEvent([]interface{}{1001, string("1"), "data"}))
 	_, err = t.filter.ApplicableEvent(dmlEvents[0])
 	t.Require().Equal("parsing new sharding key: invalid type %!t(string=1)", err.Error())
 }

--- a/sqlwrapper/ghostferry_db.go
+++ b/sqlwrapper/ghostferry_db.go
@@ -8,7 +8,7 @@ import (
 
 type DB struct {
 	*sqlorig.DB
-	marginalia string
+	Marginalia string
 }
 
 type Tx struct {
@@ -22,11 +22,11 @@ func Open(driverName, dataSourceName, marginalia string) (*DB, error) {
 }
 
 func (db DB) PrepareContext(ctx context.Context, query string) (*sqlorig.Stmt, error) {
-	return db.DB.PrepareContext(ctx, Annotate(query, db.marginalia))
+	return db.DB.PrepareContext(ctx, AnnotateStmt(query, db.Marginalia))
 }
 
 func (db DB) ExecContext(ctx context.Context, query string, args ...interface{}) (sqlorig.Result, error) {
-	return db.DB.ExecContext(ctx, Annotate(query, db.marginalia), args...)
+	return db.DB.ExecContext(ctx, AnnotateStmt(query, db.Marginalia), args...)
 }
 
 func (db DB) QueryContext(ctx context.Context, query string, args ...interface{}) (*sqlorig.Rows, error) {
@@ -34,11 +34,11 @@ func (db DB) QueryContext(ctx context.Context, query string, args ...interface{}
 }
 
 func (db DB) Exec(query string, args ...interface{}) (sqlorig.Result, error) {
-	return db.DB.Exec(Annotate(query, db.marginalia), args...)
+	return db.DB.Exec(AnnotateStmt(query, db.Marginalia), args...)
 }
 
 func (db DB) Prepare(query string) (*sqlorig.Stmt, error) {
-	return db.DB.Prepare(Annotate(query, db.marginalia))
+	return db.DB.Prepare(AnnotateStmt(query, db.Marginalia))
 }
 
 func (db DB) Query(query string, args ...interface{}) (*sqlorig.Rows, error) {
@@ -55,23 +55,23 @@ func (db DB) QueryRowContext(ctx context.Context, query string, args ...interfac
 
 func (db DB) Begin() (*Tx, error) {
 	tx, err := db.DB.Begin()
-	return &Tx{tx, db.marginalia}, err
+	return &Tx{tx, db.Marginalia}, err
 }
 
 func (tx Tx) ExecContext(ctx context.Context, query string, args ...interface{}) (sqlorig.Result, error) {
-	return tx.Tx.ExecContext(ctx, Annotate(query, tx.marginalia), args...)
+	return tx.Tx.ExecContext(ctx, AnnotateStmt(query, tx.marginalia), args...)
 }
 
 func (tx Tx) Exec(query string, args ...interface{}) (sqlorig.Result, error) {
-	return tx.Tx.Exec(Annotate(query, tx.marginalia), args...)
+	return tx.Tx.Exec(AnnotateStmt(query, tx.marginalia), args...)
 }
 
 func (tx Tx) Prepare(query string) (*sqlorig.Stmt, error) {
-	return tx.Tx.Prepare(Annotate(query, tx.marginalia))
+	return tx.Tx.Prepare(AnnotateStmt(query, tx.marginalia))
 }
 
 func (tx Tx) PrepareContext(ctx context.Context, query string) (*sqlorig.Stmt, error) {
-	return tx.Tx.PrepareContext(ctx, Annotate(query, tx.marginalia))
+	return tx.Tx.PrepareContext(ctx, AnnotateStmt(query, tx.marginalia))
 }
 
 func (tx Tx) QueryContext(ctx context.Context, query string, args ...interface{}) (*sqlorig.Rows, error) {
@@ -90,6 +90,11 @@ func (tx Tx) QueryRow(query string, args ...interface{}) *sqlorig.Row {
 	return tx.Tx.QueryRow(query, args...)
 }
 
-func Annotate(query, marginalia string) string {
+// AnnotateStmt annotates a single SQL statement with the configured marginalia.
+//
+// *NOTE*
+// This is NOT SAFE to use with multiple SQL statements as it naively annotates
+// the single query string provided and does not attempt to parse the provided SQL
+func AnnotateStmt(query, marginalia string) string {
 	return fmt.Sprintf("/*%s*/ %s", marginalia, query)
 }

--- a/test/go/race_conditions_integration_test.go
+++ b/test/go/race_conditions_integration_test.go
@@ -19,7 +19,7 @@ func setupSingleEntryTable(f *testhelpers.TestFerry, sourceDB, targetDB *sql.DB)
 func annotate(queries []string, marginalia string) []string {
 	annotatedQueries := make([]string, len(queries))
 	for i, q := range queries {
-		annotatedQueries[i] = sql.Annotate(q, marginalia)
+		annotatedQueries[i] = sql.AnnotateStmt(q, marginalia)
 	}
 	return annotatedQueries
 }


### PR DESCRIPTION
Part of https://github.com/Shopify/ghostferry/issues/173.

Captures `RowsQueryEvent`s in the `BinlogStreamer` and passes them to the `DMLEvent`s. An added `Annotation` method is provided on the `DMLEvent` interface to expose annotations/marginalia in the `DMLEvent`s query.

This also includes a slight refactor of the `DMLEvent`s to accept a `DMLEventBase` directly instead of instantiating the struct directly inside each individual DML. 

Lastly, the `Annotate` method was moved into the `BinlogWriter` to support transactions and multiple statements as the `BinlogWriter` uses a `BEGIN; ...; COMMIT` syntax. Additional tests will be added with the follow-up PR in integration tests.

A follow up PR will be created to use these annotations to validate the `DMLEvent`s streamed from the `BinlogStreamer`.

/cc @Shopify/pods 