### PR TITLE
Allow target table to already exist in CopydbFerry

### DIFF
--- a/copydb/config.go
+++ b/copydb/config.go
@@ -72,7 +72,8 @@ type Config struct {
 	WaitForReplicationTimeout string
 
 	// Ghostferry will by default create tables on your target and fail if these already exist.
-	// This allows pre-existing tables on your target, schemas won't be validated.
+	// This allows pre-existing tables on your target, schemas and data compatibility won't be validated.
+	// Use at your own risk.
 	AllowExistingTargetTable bool
 }
 

--- a/copydb/config.go
+++ b/copydb/config.go
@@ -70,6 +70,10 @@ type Config struct {
 
 	// The duration to wait for the replication to catchup before aborting. Only use if RunFerryFromReplica is true.
 	WaitForReplicationTimeout string
+
+	// Ghostferry will by default create tables on your target and fail if these already exist.
+	// This allows pre-existing tables on your target, schemas won't be validated.
+	AllowExistingTargetTable bool
 }
 
 func (c *Config) InitializeAndValidateConfig() error {

--- a/copydb/copydb.go
+++ b/copydb/copydb.go
@@ -159,7 +159,7 @@ func (this *CopydbFerry) createDatabaseIfExistsOnTarget(database string) error {
 }
 
 func (this *CopydbFerry) createTableOnTarget(database, table string) error {
-	var tableNameAgain, createTableQuery string
+	var tableNameAgain, createTableQuery, createStatement string
 
 	r := this.Ferry.SourceDB.QueryRow(fmt.Sprintf("SHOW CREATE TABLE `%s`.`%s`", database, table))
 	err := r.Scan(&tableNameAgain, &createTableQuery)
@@ -180,10 +180,16 @@ func (this *CopydbFerry) createTableOnTarget(database, table string) error {
 		tableNameAgain = targetTableName
 	}
 
+	if this.config.AllowExistingTargetTable {
+		createStatement = "CREATE TABLE IF NOT EXISTS `%s`.`%s`"
+	} else {
+		createStatement = "CREATE TABLE `%s`.`%s`"
+	}
+
 	createTableQueryReplaced := strings.Replace(
 		createTableQuery,
 		fmt.Sprintf("CREATE TABLE `%s`", table),
-		fmt.Sprintf("CREATE TABLE `%s`.`%s`", database, tableNameAgain),
+		fmt.Sprintf(createStatement, database, tableNameAgain),
 		1,
 	)
 

--- a/copydb/test/copydb_test.go
+++ b/copydb/test/copydb_test.go
@@ -85,6 +85,29 @@ func (t *CopydbTestSuite) TestCreateDatabaseAndTableWithRewrites() {
 	t.Require().Equal(renamedTableName, value)
 }
 
+func (t *CopydbTestSuite) TestCreateDatabasesAndTablesAlreadyExists() {
+	var err error
+	t.copydbFerry.Ferry.Tables, err = ghostferry.LoadTables(t.ferry.SourceDB, t.copydbFerry.Ferry.TableFilter, nil, nil, nil)
+	t.Require().Nil(err)
+
+	testhelpers.SeedInitialData(t.ferry.TargetDB, renamedSchemaName, renamedTableName, 1)
+
+	err = t.copydbFerry.CreateDatabasesAndTables()
+	t.Require().EqualError(err, "Error 1050: Table 'test_table_1_renamed' already exists")
+}
+
+func (t *CopydbTestSuite) TestCreateDatabasesAndTablesAlreadyExistsAllowed() {
+	var err error
+	t.copydbFerry.Ferry.Tables, err = ghostferry.LoadTables(t.ferry.SourceDB, t.copydbFerry.Ferry.TableFilter, nil, nil, nil)
+	t.Require().Nil(err)
+
+	testhelpers.SeedInitialData(t.ferry.TargetDB, renamedSchemaName, renamedTableName, 1)
+	t.copydbConfig.AllowExistingTargetTable = true
+
+	err = t.copydbFerry.CreateDatabasesAndTables()
+	t.Require().Nil(err)
+}
+
 func (t *CopydbTestSuite) TestCreateDatabaseAndTableWithOrdering() {
 	// NOTE: Here we just ensure passing a table does not cause issues in the
 	// invocation. A more thorough test is done in the table-schema tests


### PR DESCRIPTION
This will make it configurable to allow an already existing table in target. Default will be to not allow it, just like today.

There are a few use-cases where this could make sense, for example if you want to make changes to a large table before you fill it with data (eg. new defaults, new composite primary key or new indices). Another use case is if you already have a table with data that you want to pad with data from your source database.