### PR TITLE
Introduce "Lock Strategy" option

### DIFF
--- a/examples/copydb/run-on-replica.conf.json
+++ b/examples/copydb/run-on-replica.conf.json
@@ -22,6 +22,7 @@
   },
 
   "RunFerryFromReplica": true,
+  "LockStrategy": "LockInGhostferry",
   "SourceReplicationMaster": {
     "Host": "127.0.0.1",
     "Port": 29291,

--- a/ferry.go
+++ b/ferry.go
@@ -110,6 +110,7 @@ func (f *Ferry) NewDataIterator() *DataIterator {
 			ReadRetries: f.Config.DBReadRetries,
 		},
 		StateTracker: f.StateTracker,
+		LockStrategy: f.Config.LockStrategy,
 	}
 
 	if f.CopyFilter != nil {
@@ -149,6 +150,7 @@ func (f *Ferry) NewBinlogWriter() *BinlogWriter {
 
 		BatchSize:    f.Config.BinlogEventBatchSize,
 		WriteRetries: f.Config.DBWriteRetries,
+		LockStrategy: f.Config.LockStrategy,
 
 		ErrorHandler: f.ErrorHandler,
 		StateTracker: f.StateTracker,

--- a/iterative_verifier.go
+++ b/iterative_verifier.go
@@ -384,7 +384,7 @@ func (v *IterativeVerifier) iterateAllTables(mismatchedPaginationKeyFunc func(ui
 func (v *IterativeVerifier) iterateTableFingerprints(table *TableSchema, mismatchedPaginationKeyFunc func(uint64, *TableSchema) error) error {
 	// The cursor will stop iterating when it cannot find anymore rows,
 	// so it will not iterate until MaxUint64.
-	cursor := v.CursorConfig.NewCursorWithoutRowLock(table, 0, math.MaxUint64)
+	cursor := v.CursorConfig.NewCursorWithoutRowLock(table, 0, math.MaxUint64, nil)
 
 	// It only needs the PaginationKeys, not the entire row.
 	cursor.ColumnsToSelect = []string{fmt.Sprintf("`%s`", table.GetPaginationColumn().Name)}

--- a/test/helpers/ghostferry_helper.rb
+++ b/test/helpers/ghostferry_helper.rb
@@ -243,6 +243,10 @@ module GhostferryHelper
           environment["GHOSTFERRY_MARGINALIA"] = @config[:marginalia]
         end
 
+        if @config[:lock_strategy]
+          environment["GHOSTFERRY_LOCK_STRATEGY"] = @config[:lock_strategy]
+        end
+
         @logger.info("starting ghostferry test binary #{@compiled_binary_path}")
         Open3.popen3(environment, @compiled_binary_path) do |stdin, stdout, stderr, wait_thr|
           stdin.puts(resuming_state) unless resuming_state.nil?

--- a/test/integration/trivial_test.rb
+++ b/test/integration/trivial_test.rb
@@ -39,4 +39,13 @@ class TrivialIntegrationTests < GhostferryTestCase
       end
     end
   end
+
+  def test_lock_strategy_in_ghostferry
+    seed_simple_database_with_single_table
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { lock_strategy: "LockInGhostferry" })
+    ghostferry.run
+
+    assert_test_table_is_identical
+  end
 end

--- a/test/lib/go/integrationferry.go
+++ b/test/lib/go/integrationferry.go
@@ -247,6 +247,10 @@ func NewStandardConfig() (*ghostferry.Config, error) {
 		}
 	}
 
+	if lockStrategy := os.Getenv("GHOSTFERRY_LOCK_STRATEGY"); lockStrategy != "" {
+		config.LockStrategy = lockStrategy
+	}
+
 	return config, config.ValidateConfig()
 }
 


### PR DESCRIPTION
With this commit, we allow using an in-application lock in ghostferry,
instead of using the source DB as lock. The lock is required to avoid
race conditions between the data iteration/copy and the binlog writer.

The default behavior is preserved; a new option "LockStrategy" allows
moving the lock from the source DB into ghostferry, or disabling the
lock altogether.

This fixes #169 