### PR TITLE
Catch error from queries in getFingerprintDataFromDb

### DIFF
--- a/inline_verifier.go
+++ b/inline_verifier.go
@@ -424,6 +424,9 @@ func (v *InlineVerifier) getFingerprintDataFromDb(db *sql.DB, stmtCache *StmtCac
 	}
 
 	rows, err := fingerprintStmt.Query(args...)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	columns, err := rows.Columns()
 	if err != nil {


### PR DESCRIPTION
We failed to check the error object after running the fingerprint query in the inline verifier.

Panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x50a1ec]
goroutine 277 [running]:
database/sql.(*Rows).Columns(0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /usr/lib/go-1.10/src/database/sql/sql.go:2700 +0x3c
github.com/Shopify/ghostferry.(*InlineVerifier).getFingerprintDataFromDb(0xc4202a5c80, 0xc4201530c0, 0xc4202e6780, 0xc420028960, 0x18, 0xc4201c2130, 0xc, 0xc428eaafc0, 0xc42002dcc0, 0xc423359800, ...)
        /go/src/github.com/Shopify/ghostferry/inline_verifier.go:428 +0x227
github.com/Shopify/ghostferry.(*InlineVerifier).getFingerprintDataFromTargetDb(0xc4202a5c80, 0xc420028960, 0x18, 0xc4201c2130, 0xc, 0xc428eaafc0, 0xc42002dcc0, 0xc423359800, 0xc8, 0xc8, ...)
        /go/src/github.com/Shopify/ghostferry/inline_verifier.go:407 +0xc7
github.com/Shopify/ghostferry.(*InlineVerifier).CheckFingerprintInline(0xc4202a5c80, 0xc428eaafc0, 0xc420028960, 0x18, 0xc4201c2130, 0xc, 0xc4202696b0, 0x0, 0x3e8, 0x3e8, ...)
        /go/src/github.com/Shopify/ghostferry/inline_verifier.go:262 +0x210
github.com/Shopify/ghostferry.(*BatchWriter).WriteRowBatch.func1(0xc42646b828, 0x4c8d47)
        /go/src/github.com/Shopify/ghostferry/batch_writer.go:98 +0x9c2
github.com/Shopify/ghostferry.WithRetriesContext(0x0, 0x0, 0x5, 0x4c4b40, 0xc4201b1f80, 0x8f75fe, 0x15, 0xc42646b940, 0x8a1440, 0xc420269680)
        /go/src/github.com/Shopify/ghostferry/utils.go:38 +0x210
github.com/Shopify/ghostferry.WithRetries(0x5, 0x4c4b40, 0xc4201b1f80, 0x8f75fe, 0x15, 0xc42646b940, 0x0, 0xc4202696a8)
        /go/src/github.com/Shopify/ghostferry/utils.go:19 +0x6f
github.com/Shopify/ghostferry.(*BatchWriter).WriteRowBatch(0xc420297440, 0xc4202696b0, 0x1, 0xc4202696b0)
        /go/src/github.com/Shopify/ghostferry/batch_writer.go:50 +0x82
github.com/Shopify/ghostferry.(*BatchWriter).WriteRowBatch-fm(0xc4202696b0, 0xc4202696b0, 0x9c33a)
        /go/src/github.com/Shopify/ghostferry/ferry.go:500 +0x34
github.com/Shopify/ghostferry.(*DataIterator).Run.func1.1(0xc4202696b0, 0x0, 0xc425174c40)
        /go/src/github.com/Shopify/ghostferry/data_iterator.go:130 +0x17b
github.com/Shopify/ghostferry.(*Cursor).Each(0xc42646bf40, 0xc42646bed0, 0x1, 0x1)
        /go/src/github.com/Shopify/ghostferry/cursor.go:133 +0x357
github.com/Shopify/ghostferry.(*DataIterator).Run.func1(0xc420482190, 0xc420266120, 0xc4202a5c00)
        /go/src/github.com/Shopify/ghostferry/data_iterator.go:100 +0x42d
created by github.com/Shopify/ghostferry.(*DataIterator).Run
        /go/src/github.com/Shopify/ghostferry/data_iterator.go:64 +0x4c7
```