### PR TITLE
Moved VerifyBeforeCutover after wait for cutover

### DIFF
--- a/ferry.go
+++ b/ferry.go
@@ -653,6 +653,10 @@ func (f *Ferry) Run() {
 
 	dataIteratorWg.Wait()
 
+	f.logger.Info("data copy is complete, waiting for cutover")
+	f.OverallState.Store(StateWaitingForCutover)
+	f.waitUntilAutomaticCutoverIsTrue()
+
 	if f.inlineVerifier != nil {
 		// Stops the periodic verification of binlogs in the inline verifier
 		// This should be okay as we enqueue the binlog events into the verifier,
@@ -674,10 +678,6 @@ func (f *Ferry) Run() {
 			}
 		})
 	}
-
-	f.logger.Info("data copy is complete, waiting for cutover")
-	f.OverallState.Store(StateWaitingForCutover)
-	f.waitUntilAutomaticCutoverIsTrue()
 
 	// Cutover is a cooperative activity between the Ghostferry library and
 	// applications built on Ghostferry:


### PR DESCRIPTION
As it stands, the inline verifier periodic reverifier will be stopped the moment data copy is complete. Then, `VerifyBeforeCutover` is called which further reduces the reverification queue. After this, the reverification queue can only grow. When AutomaticCutover is set to false, the code is blocked until that variable is set to true (which occurs when a human operator hits a button in the ControlServer). This means the growth of that reverification queue is unbounded. Since the reverification is performed during the cutover, this means the verification could take an unbounded amount of time.

The above described scenario really only impacts copydb, as sharding always sets AutomaticCutover to be true and coordinates with an external service using HTTP to perform cutover. As a result, the blocking until AutomaticCutover becomes true is a no-op. Thus, when we stop the inline verifier periodic reverifier doesn't matter in sharding. This matters a great deal in copydb as the wait for automatic cutover stage is likely reached at some point when the human operators are AFK, which means the queue can get quite large by the time they come back and become ready to perform cutover.