### PR TITLE
Display additional verifier info in progress

### DIFF
--- a/ferry.go
+++ b/ferry.go
@@ -828,6 +828,11 @@ func (f *Ferry) Progress() *Progress {
 		return true
 	})
 
+	// Verifier information
+	if f.Verifier != nil {
+		s.VerifierMessage = f.Verifier.Message()
+	}
+
 	tables := f.Tables.AsSlice()
 
 	for _, table := range tables {

--- a/inline_verifier.go
+++ b/inline_verifier.go
@@ -205,6 +205,10 @@ func (s *BinlogVerifyStore) Batches(batchsize int) []BinlogVerifyBatch {
 	return batches
 }
 
+func (s *BinlogVerifyStore) CurrentRowCount() uint64 {
+	return s.currentRowCount
+}
+
 func (s *BinlogVerifyStore) Serialize() BinlogVerifySerializedStore {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
@@ -273,6 +277,10 @@ func (v *InlineVerifier) StartInBackground() error {
 
 func (v *InlineVerifier) Wait() {
 	v.backgroundVerificationWg.Wait()
+}
+
+func (v *InlineVerifier) Message() string {
+	return fmt.Sprintf("BinlogVerifyStore.currentRowCount = %d", v.reverifyStore.CurrentRowCount())
 }
 
 func (v *InlineVerifier) Result() (VerificationResultAndStatus, error) {

--- a/iterative_verifier.go
+++ b/iterative_verifier.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	sql "github.com/Shopify/ghostferry/sqlwrapper"
 	"math"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	sql "github.com/Shopify/ghostferry/sqlwrapper"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/siddontang/go-mysql/schema"
@@ -279,6 +280,10 @@ func (v *IterativeVerifier) StartInBackground() error {
 
 func (v *IterativeVerifier) Wait() {
 	v.backgroundVerificationWg.Wait()
+}
+
+func (v *IterativeVerifier) Message() string {
+	return ""
 }
 
 func (v *IterativeVerifier) Result() (VerificationResultAndStatus, error) {

--- a/progress.go
+++ b/progress.go
@@ -36,6 +36,9 @@ type Progress struct {
 	// For example: a long cutover is OK if
 	VerifierType string
 
+	// The message that the verifier may emit for additional information
+	VerifierMessage string
+
 	// These are some variables that are only filled when CurrentState == done.
 	FinalBinlogPos mysql.Position
 

--- a/status_deprecated.go
+++ b/status_deprecated.go
@@ -49,6 +49,7 @@ type StatusDeprecated struct {
 
 	VerifierSupport     bool
 	VerifierAvailable   bool
+	VerifierMessage     string
 	VerificationStarted bool
 	VerificationDone    bool
 	VerificationResult  VerificationResult
@@ -200,6 +201,7 @@ func FetchStatusDeprecated(f *Ferry, v Verifier) *StatusDeprecated {
 		result, err := v.Result()
 		status.VerificationStarted = result.IsStarted()
 		status.VerificationDone = result.IsDone()
+		status.VerifierMessage = v.Message()
 
 		// We can only run the verifier if we're not copying and not verifying
 		status.VerifierAvailable = status.OverallState != StateStarting && status.OverallState != StateCopying && (!status.VerificationStarted || status.VerificationDone)

--- a/test/integration/callbacks_test.rb
+++ b/test/integration/callbacks_test.rb
@@ -4,7 +4,7 @@ class CallbacksTest < GhostferryTestCase
   def test_progress_callback
     seed_simple_database_with_single_table
 
-    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline" })
     progress = []
     ghostferry.on_callback("progress") do |progress_data|
       progress << progress_data
@@ -24,6 +24,8 @@ class CallbacksTest < GhostferryTestCase
     refute progress.last["LastSuccessfulBinlogPos"]["Pos"].nil?
     assert progress.last["BinlogStreamerLag"] > 0
     assert_equal progress.last["LastSuccessfulBinlogPos"], progress.last["FinalBinlogPos"]
+
+    assert progress.last["VerifierMessage"].start_with?("BinlogVerifyStore.currentRowCount =")
 
     assert_equal false, progress.last["Throttled"]
 

--- a/verifier.go
+++ b/verifier.go
@@ -4,9 +4,10 @@ import (
 	sqlorig "database/sql"
 	"errors"
 	"fmt"
-	sql "github.com/Shopify/ghostferry/sqlwrapper"
 	"sync"
 	"time"
+
+	sql "github.com/Shopify/ghostferry/sqlwrapper"
 
 	"github.com/sirupsen/logrus"
 )
@@ -72,6 +73,10 @@ type Verifier interface {
 	// A verification is "done" when it verified the dbs (either
 	// correct or incorrect) OR when it experiences an error.
 	Wait()
+
+	// Returns arbitrary message that is consumed by the control server.
+	// Can just be "".
+	Message() string
 
 	// Returns the result and the status of the verification.
 	// To check the status, call IsStarted() and IsDone() on
@@ -238,6 +243,10 @@ func (v *ChecksumTableVerifier) StartInBackground() error {
 	}()
 
 	return nil
+}
+
+func (v *ChecksumTableVerifier) Message() string {
+	return ""
 }
 
 func (v *ChecksumTableVerifier) Wait() {

--- a/webui/index.html
+++ b/webui/index.html
@@ -94,6 +94,10 @@
                 <th>Verification Started</th>
                 <td>{{.VerificationStarted}}</td>
               </tr>
+              <tr>
+                <th>Verifier Message</th>
+                <td>{{.VerifierMessage}}</td>
+              </tr>
               {{if .VerificationDone}}
                 {{if not .VerificationErr }}
                   <tr>
@@ -102,7 +106,7 @@
                   </tr>
                   {{if .VerificationResult.Message}}
                     <tr>
-                      <th>Verification Message</th>
+                      <th>Verification Result Additional Message</th>
                       <td>{{.VerificationResult.Message}}</td>
                     </tr>
                   {{end}}


### PR DESCRIPTION
This way the InlineVerifier can report how many rows is in its reverify queue, which may help sanity check in a move. Example screen shot:

![Screenshot_2020-06-25 Ghostferry 127 0 0 1 29291 - 127 0 0 1 29292](https://user-images.githubusercontent.com/338100/85788287-bac87500-b6fa-11ea-92c2-6c875841d2c8.png)

I also added this to `ReportProgress`, which means any consumer of Ghostferry's API callbacks can also use this information.