### PR TITLE
Ghostferry idempotence

### DIFF
--- a/binlog_streamer.go
+++ b/binlog_streamer.go
@@ -329,7 +329,6 @@ func (s *BinlogStreamer) updateLastStreamedPosAndTime(evTimestamp uint32, evPos 
 }
 
 func (s *BinlogStreamer) handleRowsEvent(ev *replication.BinlogEvent, query []byte) error {
-	eventTime := time.Unix(int64(ev.Header.Timestamp), 0)
 	rowsEvent := ev.Event.(*replication.RowsEvent)
 
 	if ev.Header.LogPos == 0 {

--- a/binlog_streamer.go
+++ b/binlog_streamer.go
@@ -369,11 +369,6 @@ func (s *BinlogStreamer) handleRowsEvent(ev *replication.BinlogEvent, query []by
 		}
 
 		events = append(events, dmlEv)
-		s.logger.WithFields(logrus.Fields{
-			"database": dmlEv.Database(),
-			"table":    dmlEv.Table(),
-			"position": pos,
-		}).Debugf("received event %T at %v", dmlEv, eventTime)
 
 		metrics.Count("RowEvent", 1, []MetricTag{
 			MetricTag{"table", dmlEv.Table()},

--- a/go.mod
+++ b/go.mod
@@ -22,9 +22,7 @@ require (
 	github.com/onsi/gomega v1.9.0 // indirect
 	github.com/ooyala/go-dogstatsd v0.0.0-20140922214459-23f2a1659b02 // indirect
 	github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712 // indirect
-	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24
-	github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726 // indirect
 	github.com/siddontang/go-log v0.0.0-20180807004314-8d05993dda07
 	github.com/siddontang/go-mysql v0.0.0-20200424072754-803944a6e4ea
 	github.com/sirupsen/logrus v1.4.1

--- a/test/helpers/ghostferry_helper.rb
+++ b/test/helpers/ghostferry_helper.rb
@@ -123,6 +123,15 @@ module GhostferryHelper
       raise "Ghostferry did not get interrupted"
     end
 
+    # Same as above - ensure that the datawriter has been
+    # stopped properly (if you're using stop_datawriter_during_cutover).
+    def run_expecting_failure(resuming_state = nil)
+      run(resuming_state)
+    rescue GhostferryExitFailure
+    else
+      raise "Ghostferry did not fail"
+    end
+
     def run_with_logs(resuming_state = nil)
       with_env('CI', nil) { run(resuming_state) }
     end
@@ -343,6 +352,11 @@ module GhostferryHelper
 
     def term_and_wait_for_exit
       send_signal("TERM")
+      @subprocess_thread.join
+    end
+
+    def kill_and_wait_for_exit
+      send_signal("KILL")
       @subprocess_thread.join
     end
 

--- a/test/helpers/ghostferry_helper.rb
+++ b/test/helpers/ghostferry_helper.rb
@@ -123,6 +123,10 @@ module GhostferryHelper
       raise "Ghostferry did not get interrupted"
     end
 
+    def run_with_logs(resuming_state = nil)
+      with_env('CI', nil) { run(resuming_state) }
+    end
+
     ######################################################
     # Methods representing the different stages of `run` #
     ######################################################
@@ -362,6 +366,14 @@ module GhostferryHelper
 
     def json_log_line?(line)
       line.start_with?("{")
+    end
+
+    def with_env(key, value)
+      previous_value = ENV.delete(key)
+      ENV[key] = value
+      yield
+    ensure
+      ENV[key] = previous_value
     end
   end
 end

--- a/test/integration/interrupt_resume_test.rb
+++ b/test/integration/interrupt_resume_test.rb
@@ -415,7 +415,7 @@ class InterruptResumeTest < GhostferryTestCase
     with_env('CI', nil) { ghostferry.run(dumped_state) }
 
     assert_test_table_is_identical
-    assert_run_complete(ghostferry, times: 2)
+    assert_runs_complete(ghostferry, times: 2)
   end
 
   def test_interrupt_resume_idempotency_with_writes_to_source
@@ -450,6 +450,68 @@ class InterruptResumeTest < GhostferryTestCase
     with_env('CI', nil) { ghostferry.run(dumped_state) }
 
     assert_test_table_is_identical
-    assert_run_complete(ghostferry, times: 2)
+    assert_runs_complete(ghostferry, times: 2)
+  end
+
+  def test_interrupt_resume_idempotency_with_multiple_interrupts
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+
+    ghostferry.on_status(Ghostferry::Status::AFTER_ROW_COPY) do
+      ghostferry.send_signal("TERM")
+    end
+
+    dumped_state = ghostferry.run_expecting_interrupt
+    assert_basic_fields_exist_in_dumped_state(dumped_state)
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+
+    ghostferry.on_status(Ghostferry::Status::AFTER_ROW_COPY) do
+      ghostferry.send_signal("TERM")
+    end
+
+    with_env('CI', nil) { ghostferry.run_expecting_interrupt(dumped_state) }
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+    with_env('CI', nil) { ghostferry.run(dumped_state) }
+
+    assert_test_table_is_identical
+    assert_runs_complete(ghostferry, times: 1)
+  end
+
+  def test_interrupt_resume_idempotency_with_multiple_interrupts_and_writes_to_source
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+
+    datawriter = new_source_datawriter
+    start_datawriter_with_ghostferry(datawriter, ghostferry)
+
+    batches_written = 0
+    ghostferry.on_status(Ghostferry::Status::AFTER_ROW_COPY) do
+      batches_written += 1
+      if batches_written >= 2
+        ghostferry.send_signal("TERM")
+      end
+    end
+
+    dumped_state = ghostferry.run_expecting_interrupt
+    assert_basic_fields_exist_in_dumped_state(dumped_state)
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+
+    batches_written = 0
+    ghostferry.on_status(Ghostferry::Status::AFTER_ROW_COPY) do
+      batches_written += 1
+      if batches_written >= 2
+        ghostferry.send_signal("TERM")
+      end
+    end
+
+    with_env('CI', nil) { ghostferry.run_expecting_interrupt(dumped_state) }
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+    stop_datawriter_during_cutover(datawriter, ghostferry)
+    with_env('CI', nil) { ghostferry.run(dumped_state) }
+
+    assert_test_table_is_identical
+    assert_runs_complete(ghostferry, times: 1)
   end
 end

--- a/test/integration/interrupt_resume_test.rb
+++ b/test/integration/interrupt_resume_test.rb
@@ -397,7 +397,7 @@ class InterruptResumeTest < GhostferryTestCase
     )
   end
 
-  def test_interrupt_resume_idempotency
+  def test_interrupt_resume_idempotence
     ghostferry = new_ghostferry_with_interrupt_after_row_copy(MINIMAL_GHOSTFERRY)
     dumped_state = ghostferry.run_expecting_interrupt
 
@@ -415,7 +415,7 @@ class InterruptResumeTest < GhostferryTestCase
     assert_ghostferry_completed(ghostferry, times: 2)
   end
 
-  def test_interrupt_resume_idempotency_with_writes_to_source
+  def test_interrupt_resume_idempotence_with_writes_to_source
     ghostferry = new_ghostferry_with_interrupt_after_row_copy(MINIMAL_GHOSTFERRY, after_batches_written: 2)
 
     datawriter = new_source_datawriter
@@ -439,7 +439,7 @@ class InterruptResumeTest < GhostferryTestCase
     assert_ghostferry_completed(ghostferry, times: 2)
   end
 
-  def test_interrupt_resume_idempotency_with_multiple_interrupts
+  def test_interrupt_resume_idempotence_with_multiple_interrupts
     ghostferry = new_ghostferry_with_interrupt_after_row_copy(MINIMAL_GHOSTFERRY, after_batches_written: 2)
 
     dumped_state = ghostferry.run_expecting_interrupt
@@ -455,7 +455,7 @@ class InterruptResumeTest < GhostferryTestCase
     assert_ghostferry_completed(ghostferry, times: 1)
   end
 
-  def test_interrupt_resume_idempotency_with_multiple_interrupts_and_writes_to_source
+  def test_interrupt_resume_idempotence_with_multiple_interrupts_and_writes_to_source
     ghostferry = new_ghostferry_with_interrupt_after_row_copy(MINIMAL_GHOSTFERRY, after_batches_written: 2)
 
     datawriter = new_source_datawriter
@@ -474,4 +474,23 @@ class InterruptResumeTest < GhostferryTestCase
     assert_test_table_is_identical
     assert_ghostferry_completed(ghostferry, times: 1)
   end
+
+  def test_interrupt_resume_idempotence_with_failure
+    ghostferry = new_ghostferry_with_interrupt_after_row_copy(MINIMAL_GHOSTFERRY)
+    dumped_state = ghostferry.run_expecting_interrupt
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+    ghostferry.run_with_logs(dumped_state)
+
+    assert_test_table_is_identical
+
+    # Logs are needed to assert how many times ghostferry successfully completed
+    ghostferry.run_with_logs(dumped_state)
+
+    assert_test_table_is_identical
+
+    # assert ghostferry successfuly ran twice
+    assert_ghostferry_completed(ghostferry, times: 2)
+  end
+
 end

--- a/test/integration/interrupt_resume_test.rb
+++ b/test/integration/interrupt_resume_test.rb
@@ -107,7 +107,6 @@ class InterruptResumeTest < GhostferryTestCase
 
       assert(found_signal, "Expected to receive a termination signal")
     end
-
   end
 
   def test_interrupt_resume_will_not_emit_binlog_position_for_inline_verifier_if_no_verification_is_used
@@ -396,5 +395,61 @@ class InterruptResumeTest < GhostferryTestCase
     assert ghostferry.error["ErrMessage"].include?(
       "row data with paginationKey #{chosen_id} on `gftest`.`test_table_1` has been corrupted"
     )
+  end
+
+  def test_interrupt_resume_idempotency
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+
+    ghostferry.on_status(Ghostferry::Status::AFTER_ROW_COPY) do
+      ghostferry.send_signal("TERM")
+    end
+
+    dumped_state = ghostferry.run_expecting_interrupt
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+    ghostferry.run(dumped_state)
+
+    assert_test_table_is_identical
+
+    # run again after first completion and assert the table is identical
+    ghostferry.run(dumped_state)
+
+    assert_test_table_is_identical
+    assert_run_complete(ghostferry, times: 2)
+  end
+
+  def test_interrupt_resume_idempotency_with_writes_to_source
+    datawriter = new_source_datawriter
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+
+    start_datawriter_with_ghostferry(datawriter, ghostferry)
+
+    batches_written = 0
+    ghostferry.on_status(Ghostferry::Status::AFTER_ROW_COPY) do
+      batches_written += 1
+      if batches_written >= 2
+        ghostferry.send_signal("TERM")
+      end
+    end
+
+    dumped_state = ghostferry.run_expecting_interrupt
+    assert_basic_fields_exist_in_dumped_state(dumped_state)
+
+    # Resume Ghostferry with dumped state
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+
+    # The datawriter is still writing to the database since earlier, so we need
+    # to stop it during cutover.
+    stop_datawriter_during_cutover(datawriter, ghostferry)
+
+    ghostferry.run(dumped_state)
+
+    assert_test_table_is_identical
+
+    # run again after first completion and assert the table is identical
+    ghostferry.run(dumped_state)
+
+    assert_test_table_is_identical
+    assert_run_complete(ghostferry, times: 2)
   end
 end

--- a/test/integration/interrupt_resume_test.rb
+++ b/test/integration/interrupt_resume_test.rb
@@ -480,17 +480,41 @@ class InterruptResumeTest < GhostferryTestCase
     dumped_state = ghostferry.run_expecting_interrupt
 
     ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+    # Fail the ghostferry run instead of interrupting a second time
+    ghostferry.on_status(Ghostferry::Status::AFTER_ROW_COPY) do
+      ghostferry.kill_and_wait_for_exit
+    end
+    ghostferry.run_expecting_failure(dumped_state)
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
     ghostferry.run_with_logs(dumped_state)
 
     assert_test_table_is_identical
 
-    # Logs are needed to assert how many times ghostferry successfully completed
-    ghostferry.run_with_logs(dumped_state)
-
-    assert_test_table_is_identical
-
-    # assert ghostferry successfuly ran twice
-    assert_ghostferry_completed(ghostferry, times: 2)
+    assert_ghostferry_completed(ghostferry, times: 1)
   end
 
+  def test_interrupt_resume_idempotence_with_failure_and_writes_to_source
+    ghostferry = new_ghostferry_with_interrupt_after_row_copy(MINIMAL_GHOSTFERRY, after_batches_written: 2)
+
+    datawriter = new_source_datawriter
+    start_datawriter_with_ghostferry(datawriter, ghostferry)
+
+    dumped_state = ghostferry.run_expecting_interrupt
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+    # Fail the ghostferry run instead of interrupting a second time
+    ghostferry.on_status(Ghostferry::Status::AFTER_ROW_COPY) do
+      ghostferry.kill_and_wait_for_exit
+    end
+    ghostferry.run_expecting_failure(dumped_state)
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+    stop_datawriter_during_cutover(datawriter, ghostferry)
+    ghostferry.run_with_logs(dumped_state)
+
+    assert_test_table_is_identical
+
+    assert_ghostferry_completed(ghostferry, times: 1)
+  end
 end

--- a/test/integration/interrupt_resume_test.rb
+++ b/test/integration/interrupt_resume_test.rb
@@ -407,12 +407,12 @@ class InterruptResumeTest < GhostferryTestCase
     dumped_state = ghostferry.run_expecting_interrupt
 
     ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
-    ghostferry.run(dumped_state)
+    with_env('CI', nil) { ghostferry.run(dumped_state) }
 
     assert_test_table_is_identical
 
     # run again after first completion and assert the table is identical
-    ghostferry.run(dumped_state)
+    with_env('CI', nil) { ghostferry.run(dumped_state) }
 
     assert_test_table_is_identical
     assert_run_complete(ghostferry, times: 2)
@@ -442,12 +442,12 @@ class InterruptResumeTest < GhostferryTestCase
     # to stop it during cutover.
     stop_datawriter_during_cutover(datawriter, ghostferry)
 
-    ghostferry.run(dumped_state)
+    with_env('CI', nil) { ghostferry.run(dumped_state) }
 
     assert_test_table_is_identical
 
     # run again after first completion and assert the table is identical
-    ghostferry.run(dumped_state)
+    with_env('CI', nil) { ghostferry.run(dumped_state) }
 
     assert_test_table_is_identical
     assert_run_complete(ghostferry, times: 2)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -153,7 +153,7 @@ class GhostferryTestCase < Minitest::Test
     refute dumped_state["LastWrittenBinlogPosition"].nil?
   end
 
-  def assert_run_complete(instance, times:)
+  def assert_runs_complete(instance, times:)
     started_runs = instance.logrus_lines["ferry"].select{ |line| line["msg"].include?("hello world") }.count
     completed_runs = instance.logrus_lines["ferry"].select{ |line| line["msg"].include?("ghostferry run is complete") }.count
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -57,13 +57,13 @@ class GhostferryTestCase < Minitest::Test
     g
   end
 
-  def new_ghostferry_with_interrupt_after_row_copy(filename, config: {}, with_batches_written: 0)
+  def new_ghostferry_with_interrupt_after_row_copy(filename, config: {}, after_batches_written: 0)
     g = new_ghostferry(filename, config)
 
     batches_written = 0
     g.on_status(Ghostferry::Status::AFTER_ROW_COPY) do
       batches_written += 1
-      if batches_written >= with_batches_written
+      if batches_written >= after_batches_written
         g.send_signal("TERM")
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -57,6 +57,20 @@ class GhostferryTestCase < Minitest::Test
     g
   end
 
+  def new_ghostferry_with_interrupt_after_row_copy(filename, config: {}, with_batches_written: 0)
+    g = new_ghostferry(filename, config)
+
+    batches_written = 0
+    g.on_status(Ghostferry::Status::AFTER_ROW_COPY) do
+      batches_written += 1
+      if batches_written >= with_batches_written
+        g.send_signal("TERM")
+      end
+    end
+
+    g
+  end
+
   def new_source_datawriter(*args)
     dw = DataWriter.new(source_db_config, *args, logger: @log_capturer.logger)
     @datawriter_instances << dw
@@ -153,7 +167,7 @@ class GhostferryTestCase < Minitest::Test
     refute dumped_state["LastWrittenBinlogPosition"].nil?
   end
 
-  def assert_runs_complete(instance, times:)
+  def assert_ghostferry_completed(instance, times:)
     started_runs = instance.logrus_lines["ferry"].select{ |line| line["msg"].include?("hello world") }.count
     completed_runs = instance.logrus_lines["ferry"].select{ |line| line["msg"].include?("ghostferry run is complete") }.count
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -153,6 +153,14 @@ class GhostferryTestCase < Minitest::Test
     refute dumped_state["LastWrittenBinlogPosition"].nil?
   end
 
+  def assert_run_complete(instance, times:)
+    started_runs = instance.logrus_lines["ferry"].select{ |line| line["msg"].include?("hello world") }.count
+    completed_runs = instance.logrus_lines["ferry"].select{ |line| line["msg"].include?("ghostferry run is complete") }.count
+
+    assert started_runs == times
+    assert completed_runs == times
+  end
+
   def with_env(key, value)
     previous_value = ENV.delete(key)
     ENV[key] = value

--- a/tlaplus/ghostferry.tla
+++ b/tlaplus/ghostferry.tla
@@ -296,8 +296,8 @@ PossibleRecords == Records \cup {NoRecordHere}
         either {
           lastSuccessfulPK := lastSuccessfulPK + 1;
         } or {
-          \* Do not increment the PK to model a copy of the same data. In this
-          \* way, we verify the idempotency of the TableIterator
+          \* Do not increment the PK to cause the spec to copy of the same data
+          \* multiple times to test idempotence in the TableIterator.
           lastSuccessfulPK := lastSuccessfulPK + 0;
         };
       };
@@ -330,10 +330,9 @@ PossibleRecords == Records \cup {NoRecordHere}
       \* BinlogWriteQueue to be applied again to verify idempotence
       \* in the BinlogWriter.
       \*
-      \* The order is important here; We must retain the ordering of events
-      \* as they were in the binlog and place the current item again at the front.
-      \* Otherwise, we may violate correctness as we cannot apply binlog events in
-      \* any arbitrary order.
+      \* We must retain the ordering of events as they were in the binlog and place
+      \* the current item again at the front of the BinlogWriteQueue. Otherwise,
+      \* we may violate correctness as we cannot apply binlog events in any arbitrary order.
       \*
       \* Note that modifying the order of the below operation will violate SourceTargetEquality
       reapply_binlog_write:

--- a/tlaplus/ghostferry.toolbox/ghostferry___GhostferryPrimaryModel.launch
+++ b/tlaplus/ghostferry.toolbox/ghostferry___GhostferryPrimaryModel.launch
@@ -1,60 +1,62 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.lamport.tla.toolbox.tool.tlc.modelCheck">
-<stringAttribute key="TLCCmdLineParameters" value=""/>
-<stringAttribute key="configurationName" value="GhostferryPrimaryModel"/>
-<booleanAttribute key="deferLiveness" value="false"/>
-<intAttribute key="dfidDepth" value="100"/>
-<booleanAttribute key="dfidMode" value="false"/>
-<intAttribute key="distributedFPSetCount" value="0"/>
-<stringAttribute key="distributedNetworkInterface" value="172.17.0.1"/>
-<intAttribute key="distributedNodesCount" value="1"/>
-<stringAttribute key="distributedTLC" value="off"/>
-<stringAttribute key="distributedTLCVMArgs" value=""/>
-<intAttribute key="fpBits" value="1"/>
-<intAttribute key="fpIndex" value="1"/>
-<intAttribute key="maxHeapSize" value="25"/>
-<intAttribute key="maxSetSize" value="1000000"/>
-<booleanAttribute key="mcMode" value="true"/>
-<stringAttribute key="modelBehaviorInit" value=""/>
-<stringAttribute key="modelBehaviorNext" value=""/>
-<stringAttribute key="modelBehaviorSpec" value="Spec"/>
-<intAttribute key="modelBehaviorSpecType" value="1"/>
-<stringAttribute key="modelBehaviorVars" value="lastSuccessfulPK, CurrentMaxPrimaryKey, BinlogWriteQueue, chosenPK, SourceBinlog, currentRow, BinlogStreamingStopRequested, pc, newRecord, oldRecord, TargetTable, TargetBinlogPos, currentBinlogEntry, lastWrittenBinlogPos, ApplicationReadonly, SourceTable, lastSuccessfulBinlogPos"/>
-<stringAttribute key="modelComments" value=""/>
-<booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
-<listAttribute key="modelCorrectnessInvariants">
-<listEntry value="1SourceTargetEquality"/>
-</listAttribute>
-<listAttribute key="modelCorrectnessProperties">
-<listEntry value="1Termination"/>
-</listAttribute>
-<stringAttribute key="modelExpressionEval" value=""/>
-<stringAttribute key="modelParameterActionConstraint" value="BinlogSizeActionConstraint"/>
-<listAttribute key="modelParameterConstants">
-<listEntry value="defaultInitValue;;defaultInitValue;1;0"/>
-<listEntry value="Records;;{r0, r1};1;0"/>
-<listEntry value="MaxPrimaryKey;;2;0;0"/>
-<listEntry value="Ferry;;Ferry;1;0"/>
-<listEntry value="InitialTable;;&lt;&lt;r0, r1, NoRecordHere&gt;&gt;;0;0"/>
-<listEntry value="Application;;Application;1;0"/>
-<listEntry value="BinlogStreamer;;BinlogStreamer;1;0"/>
-<listEntry value="TableIterator;;TableIterator;1;0"/>
-<listEntry value="MaxBinlogSize;;3;0;0"/>
-<listEntry value="BinlogWriter;;BinlogWriter;1;0"/>
-</listAttribute>
-<stringAttribute key="modelParameterContraint" value=""/>
-<listAttribute key="modelParameterDefinitions">
-<listEntry value="NoRecordHere;;NoRecordHere;1;0"/>
-</listAttribute>
-<stringAttribute key="modelParameterModelValues" value="{}"/>
-<stringAttribute key="modelParameterNewDefinitions" value=""/>
-<intAttribute key="numberOfWorkers" value="3"/>
-<booleanAttribute key="recover" value="false"/>
-<stringAttribute key="result.mail.address" value=""/>
-<intAttribute key="simuAril" value="-1"/>
-<intAttribute key="simuDepth" value="100"/>
-<intAttribute key="simuSeed" value="-1"/>
-<stringAttribute key="specName" value="ghostferry"/>
-<stringAttribute key="view" value=""/>
-<booleanAttribute key="visualizeStateGraph" value="false"/>
+    <stringAttribute key="TLCCmdLineParameters" value=""/>
+    <stringAttribute key="configurationName" value="GhostferryPrimaryModel"/>
+    <booleanAttribute key="deferLiveness" value="false"/>
+    <intAttribute key="dfidDepth" value="100"/>
+    <booleanAttribute key="dfidMode" value="false"/>
+    <intAttribute key="distributedFPSetCount" value="0"/>
+    <stringAttribute key="distributedNetworkInterface" value="172.17.0.1"/>
+    <intAttribute key="distributedNodesCount" value="1"/>
+    <stringAttribute key="distributedTLC" value="off"/>
+    <stringAttribute key="distributedTLCVMArgs" value=""/>
+    <intAttribute key="fpBits" value="1"/>
+    <intAttribute key="fpIndex" value="117"/>
+    <intAttribute key="maxHeapSize" value="25"/>
+    <intAttribute key="maxSetSize" value="1000000"/>
+    <booleanAttribute key="mcMode" value="true"/>
+    <stringAttribute key="modelBehaviorInit" value=""/>
+    <stringAttribute key="modelBehaviorNext" value=""/>
+    <stringAttribute key="modelBehaviorSpec" value="Spec"/>
+    <intAttribute key="modelBehaviorSpecType" value="1"/>
+    <stringAttribute key="modelBehaviorVars" value="lastSuccessfulPK, CurrentMaxPrimaryKey, BinlogWriteQueue, chosenPK, SourceBinlog, currentRow, BinlogStreamingStopRequested, pc, newRecord, oldRecord, TargetTable, TargetBinlogPos, currentBinlogEntry, lastWrittenBinlogPos, ApplicationReadonly, SourceTable, lastSuccessfulBinlogPos"/>
+    <stringAttribute key="modelComments" value=""/>
+    <booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
+    <listAttribute key="modelCorrectnessInvariants">
+        <listEntry value="1SourceTargetEquality"/>
+    </listAttribute>
+    <listAttribute key="modelCorrectnessProperties">
+        <listEntry value="1Termination"/>
+    </listAttribute>
+    <intAttribute key="modelEditorOpenTabs" value="8"/>
+    <stringAttribute key="modelExpressionEval" value=""/>
+    <stringAttribute key="modelParameterActionConstraint" value="BinlogSizeActionConstraint"/>
+    <listAttribute key="modelParameterConstants">
+        <listEntry value="defaultInitValue;;defaultInitValue;1;0"/>
+        <listEntry value="Records;;{r0, r1};1;0"/>
+        <listEntry value="MaxPrimaryKey;;2;0;0"/>
+        <listEntry value="Ferry;;Ferry;1;0"/>
+        <listEntry value="InitialTable;;&lt;&lt;r0, r1, NoRecordHere&gt;&gt;;0;0"/>
+        <listEntry value="Application;;Application;1;0"/>
+        <listEntry value="BinlogStreamer;;BinlogStreamer;1;0"/>
+        <listEntry value="TableIterator;;TableIterator;1;0"/>
+        <listEntry value="MaxBinlogSize;;3;0;0"/>
+        <listEntry value="BinlogWriter;;BinlogWriter;1;0"/>
+    </listAttribute>
+    <stringAttribute key="modelParameterContraint" value=""/>
+    <listAttribute key="modelParameterDefinitions">
+        <listEntry value="NoRecordHere;;NoRecordHere;1;0"/>
+    </listAttribute>
+    <stringAttribute key="modelParameterModelValues" value="{}"/>
+    <stringAttribute key="modelParameterNewDefinitions" value=""/>
+    <intAttribute key="modelVersion" value="20191005"/>
+    <intAttribute key="numberOfWorkers" value="3"/>
+    <booleanAttribute key="recover" value="false"/>
+    <stringAttribute key="result.mail.address" value=""/>
+    <intAttribute key="simuAril" value="-1"/>
+    <intAttribute key="simuDepth" value="100"/>
+    <intAttribute key="simuSeed" value="-1"/>
+    <stringAttribute key="specName" value="ghostferry"/>
+    <stringAttribute key="view" value=""/>
+    <booleanAttribute key="visualizeStateGraph" value="false"/>
 </launchConfiguration>

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -53,13 +53,11 @@ github.com/pingcap/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/satori/go.uuid v1.2.0
-## explicit
 github.com/satori/go.uuid
 # github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24
 ## explicit
 github.com/shopspring/decimal
 # github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726
-## explicit
 github.com/siddontang/go/hack
 # github.com/siddontang/go-log v0.0.0-20180807004314-8d05993dda07
 ## explicit


### PR DESCRIPTION
## Overview
This PR adds both integration tests and TLA+ spec modifications that explicitly verify the idempotence of ghostferry's algorithm.

### Integration Tests
Several tests were added to the ruby integration test suite that perform combinations of interrupting, resuming, and interrupting or failing again before running finally to completion. These tests utilize assertions that the source and target are equal and some assertions that inspect the logs to ensure it indeed ran the intended number of times.

### TLA+ Spec
Additions to the TLA+ specification (via Pluscal) were added and checked with TLC to verify the correctness of these changes. 

To model the idempotence of the `TableIterator`, an `either...or` clause in the `tblit_upkey` label was added that may or may not increment the `PK` of the `TableIterator` as it is iterating the data of the source table. The effect of this is that the current row may be applied more than one time as the data is being copied.

Likewise, a `label` was added to the `BinlogWriter` (`reapply_binlog_write`) that duplicates the first entry to the `BinlogWriteQueue`. The effect of this is that any binlog entry may be applied more than once, but while also preserving the order of entries in this queue.

Following the other simplifications and proofs by induction in the spec, we make the simplification that replaying the current row in the `TableIterator` and current entry in the `BinlogStreamer` is the same as replaying the last _N_ rows or operations (in order).

Also note that while making these changes, I was able to violate the `SourceTargetEquality` condition in a TLC run by copying the current first element of the `BinlogWriteQueue` to the _end_ of the queue instead of placing it again at the _beginning_. This proves further that, as we have modeled in the implementation, the ordering of these events must remain the same and that we cannot apply them arbitrarily, and as long as they are applied in order, idempotence does indeed hold. 

### Why?
See https://github.com/Shopify/ghostferry/issues/200 for details.

/cc @Shopify/pods 