### PR TITLE
Add periodic state callback

### DIFF
--- a/config.go
+++ b/config.go
@@ -445,6 +445,12 @@ type Config struct {
 	ProgressCallback        HTTPCallback
 	ProgressReportFrequency int
 
+	// Report state via an HTTP callback. The Payload field of the callback
+	// will be sent to the server as the CustomPayload field in the State
+	// struct The unit of StateReportFrequency is in milliseconds.
+	StateCallback        HTTPCallback
+	StateReportFrequency int
+
 	// The state to resume from as dumped by the PanicErrorHandler.
 	// If this is null, a new Ghostferry run will be started. Otherwise, the
 	// reconciliation process will start and Ghostferry will resume after that.

--- a/config.go
+++ b/config.go
@@ -441,13 +441,13 @@ type Config struct {
 
 	// Report progress via an HTTP callback. The Payload field of the callback
 	// will be sent to the server as the CustomPayload field in the Progress
-	// struct The unit of ProgressReportFrequency is in milliseconds.
+	// struct. The unit of ProgressReportFrequency is in milliseconds.
 	ProgressCallback        HTTPCallback
 	ProgressReportFrequency int
 
-	// Report state via an HTTP callback. The Payload field of the callback
-	// will be sent to the server as the CustomPayload field in the State
-	// struct The unit of StateReportFrequency is in milliseconds.
+	// Report state via an HTTP callback. The SerializedState struct will be
+	// sent as the Payload parameter. The unit of StateReportFrequency is
+	// in milliseconds.
 	StateCallback        HTTPCallback
 	StateReportFrequency int
 

--- a/ferry.go
+++ b/ferry.go
@@ -912,14 +912,13 @@ func (f *Ferry) ReportState() {
 	callback := f.Config.StateCallback
 	state, err := f.SerializeStateToJSON()
 	if err != nil {
-		f.logger.WithError(err).Error("failed to dump state to JSON")
-		return
+		f.logger.Panicf("failed to serialize state to JSON: %s", err)
 	}
 
 	callback.Payload = string(state)
 	err = callback.Post(&http.Client{})
 	if err != nil {
-		f.logger.WithError(err).Errorf("failed to post state to callback: %s", callback)
+		f.logger.Panicf("failed to post state to callback: %s with err: %s", callback, err)
 	}
 }
 

--- a/ferry.go
+++ b/ferry.go
@@ -908,6 +908,8 @@ func (f *Ferry) ReportProgress() {
 	}
 }
 
+// ReportState may have a slight performance impact as it will temporarily
+// lock the StateTracker when it is serialized before posting to the callback
 func (f *Ferry) ReportState() {
 	callback := f.Config.StateCallback
 	state, err := f.SerializeStateToJSON()

--- a/test/helpers/ghostferry_helper.rb
+++ b/test/helpers/ghostferry_helper.rb
@@ -209,6 +209,19 @@ module GhostferryHelper
         end
       end
 
+      @server.mount_proc "/callbacks/state" do |req, resp|
+        begin
+          unless req.body
+            @server_last_error = ArgumentError.new("Ghostferry is improperly implemented and did not send data")
+            resp.status = 400
+            @server.shutdown
+          end
+          data = JSON.parse(JSON.parse(req.body)["Payload"])
+          @callback_handlers["state"].each { |f| f.call(data) } unless @callback_handlers["state"].nil?
+        rescue StandardError
+        end
+      end
+
       @server.mount_proc "/callbacks/error" do |req, resp|
         @error = JSON.parse(JSON.parse(req.body)["Payload"])
       end

--- a/test/integration/callbacks_test.rb
+++ b/test/integration/callbacks_test.rb
@@ -33,4 +33,19 @@ class CallbacksTest < GhostferryTestCase
     refute progress.last["ETA"].nil?
     assert progress.last["TimeTaken"] > 0
   end
+
+  def test_state_callback
+    seed_simple_database_with_single_table
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline" })
+    state = []
+    ghostferry.on_callback("state") do |state_data|
+      state << state_data
+    end
+
+    ghostferry.run
+
+    assert state.length >= 1
+    assert_basic_fields_exist_in_dumped_state(state.last)
+  end
 end

--- a/test/integration/callbacks_test.rb
+++ b/test/integration/callbacks_test.rb
@@ -38,14 +38,16 @@ class CallbacksTest < GhostferryTestCase
     seed_simple_database_with_single_table
 
     ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline" })
-    state = []
+    states = []
     ghostferry.on_callback("state") do |state_data|
-      state << state_data
+      states << state_data
     end
 
     ghostferry.run
 
-    assert state.length >= 1
-    assert_basic_fields_exist_in_dumped_state(state.last)
+    assert states.length >= 1
+    states.each do |state|
+      assert_basic_fields_exist_in_dumped_state(state)
+    end
   end
 end

--- a/test/integration/interrupt_resume_test.rb
+++ b/test/integration/interrupt_resume_test.rb
@@ -517,4 +517,25 @@ class InterruptResumeTest < GhostferryTestCase
 
     assert_ghostferry_completed(ghostferry, times: 1)
   end
+
+  def test_resume_from_failure_with_state_callback
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+
+    state_from_callback = nil
+    ghostferry.on_callback("state") do |state_data|
+      state_from_callback = state_data
+      ghostferry.kill_and_wait_for_exit
+    end
+
+    ghostferry.run_expecting_failure
+
+    refute_nil state_from_callback
+    assert_basic_fields_exist_in_dumped_state(state_from_callback)
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY)
+    ghostferry.run_with_logs(state_from_callback)
+
+    assert_test_table_is_identical
+    assert_ghostferry_completed(ghostferry, times: 1)
+  end
 end

--- a/test/lib/go/integrationferry.go
+++ b/test/lib/go/integrationferry.go
@@ -216,6 +216,11 @@ func NewStandardConfig() (*ghostferry.Config, error) {
 	}
 	config.ProgressReportFrequency = 500
 
+	config.StateCallback = ghostferry.HTTPCallback{
+		URI: fmt.Sprintf("http://localhost:%s/callbacks/state", integrationPort),
+	}
+	config.StateReportFrequency = 500
+
 	resumeStateJSON, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Part of https://github.com/Shopify/ghostferry/issues/200

This PR adds a periodic callback of the run's state, very similar to how the progress callback is performed. Tests were added that both verify the callback is performed correctly and also that the state sent in the callback can be used to successfully resume an interrupted/failed move.

While we're still yet to complete formal verification of Ghostferry's idempotence with TLA+, we have verified the correctness with [integration tests](https://github.com/Shopify/ghostferry/pull/202), and have enough confidence to move forward with this PR.

[This branch](https://github.com/Shopify/ghostferry/tree/idempotence-tla-shuhao) contains the latest TLA+ proving the DataIterator's idempotence (the BinlogStreamer is next). We're targeting to wrap up the TLA+ changes in the next couple of weeks.

/cc @Shopify/pods 