### PR TITLE
Run DataIterator over tables in descending order of pagination key

### DIFF
--- a/vendor/github.com/sirupsen/logrus/go.mod
+++ b/vendor/github.com/sirupsen/logrus/go.mod
@@ -1,5 +1,7 @@
 module github.com/sirupsen/logrus
 
+go 1.14
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1


### PR DESCRIPTION
Closes https://github.com/Shopify/ghostferry/issues/194

Estimate the size of the table to be copied by counting the number of pagination keys of that table. Start copying the largest tables first in order to avoid large table from being the bottleneck near the end of copying tables. 