### PR TITLE
Ghostferry interrupt resume idempotence TLA+ modifications

### DIFF
--- a/tlaplus/ghostferry.tla
+++ b/tlaplus/ghostferry.tla
@@ -349,7 +349,7 @@ PossibleSourceBinlogs == [{1} -> PossibleBinlogEntries]
       \* TODO: model this with TLA+ and validate its correctness.
       tblit_loop:  while (LastSuccessfulPK < MaxPrimaryKey) {
       tblit_rw:      currentRow := SourceTable[LastSuccessfulPK + 1];
-                     if (currentRow # NoRecordHere /\ TargetTable[LastSuccessfulPK + 1] = NoRecordHere) { \* TODO (NOW): This should fail because the second part of the database is not correctly constructed?
+                     if (currentRow # NoRecordHere /\ TargetTable[LastSuccessfulPK + 1] = NoRecordHere) {
                        TargetTable[LastSuccessfulPK + 1] := currentRow;
                      };
       tblit_upkey:   LastSuccessfulPK := LastSuccessfulPK + 1;
@@ -470,7 +470,7 @@ PossibleSourceBinlogs == [{1} -> PossibleBinlogEntries]
 }
 
  ***************************************************************************)
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-0fb2191b7ea3f2d9d2ddacddfb52ede1 (chksum(pcal) \in STRING /\ chksum(tla) \in STRING) (chksum(pcal) = "cad34be2" /\ chksum(tla) = "7a595238") (chksum(pcal) = "5f2f1443" /\ chksum(tla) = "7ebd37e2") (chksum(pcal) = "59302a14" /\ chksum(tla) = "7ebd37e2") (chksum(pcal) = "605b0be6" /\ chksum(tla) = "9b1e66de") (chksum(pcal) = "cccf8dab" /\ chksum(tla) = "fb6ea81b") (chksum(pcal) = "ddab7822" /\ chksum(tla) = "8c2fdca7") (chksum(pcal) = "dd200a77" /\ chksum(tla) = "108353c1") (chksum(pcal) = "dd200a77" /\ chksum(tla) = "5f47d505") PCal-88d6f264d1db8757d257b45fcc829f8a
+\* BEGIN TRANSLATION - the hash of the PCal code: PCal-88d6f264d1db8757d257b45fcc829f8a
 CONSTANT defaultInitValue
 VARIABLES MaxPrimaryKey, CurrentMaxPrimaryKey, LastSuccessfulPK, 
           ActualCopiedPK, SourceTable, TargetTable, SourceBinlog, 
@@ -781,5 +781,5 @@ BinlogSizeActionConstraint == Len(SourceBinlog) <= MaxBinlogSize
 
 =============================================================================
 \* Modification History
-\* Last modified Wed Sep 16 15:27:21 EDT 2020 by shuhao
+\* Last modified Wed Sep 16 16:07:45 EDT 2020 by shuhao
 \* Created Thu Jan 18 11:35:40 EST 2018 by shuhao

--- a/tlaplus/ghostferry.toolbox/ghostferry___GhostferryPrimaryModel.launch
+++ b/tlaplus/ghostferry.toolbox/ghostferry___GhostferryPrimaryModel.launch
@@ -1,60 +1,64 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.lamport.tla.toolbox.tool.tlc.modelCheck">
-<stringAttribute key="TLCCmdLineParameters" value=""/>
-<stringAttribute key="configurationName" value="GhostferryPrimaryModel"/>
-<booleanAttribute key="deferLiveness" value="false"/>
-<intAttribute key="dfidDepth" value="100"/>
-<booleanAttribute key="dfidMode" value="false"/>
-<intAttribute key="distributedFPSetCount" value="0"/>
-<stringAttribute key="distributedNetworkInterface" value="172.17.0.1"/>
-<intAttribute key="distributedNodesCount" value="1"/>
-<stringAttribute key="distributedTLC" value="off"/>
-<stringAttribute key="distributedTLCVMArgs" value=""/>
-<intAttribute key="fpBits" value="1"/>
-<intAttribute key="fpIndex" value="1"/>
-<intAttribute key="maxHeapSize" value="25"/>
-<intAttribute key="maxSetSize" value="1000000"/>
-<booleanAttribute key="mcMode" value="true"/>
-<stringAttribute key="modelBehaviorInit" value=""/>
-<stringAttribute key="modelBehaviorNext" value=""/>
-<stringAttribute key="modelBehaviorSpec" value="Spec"/>
-<intAttribute key="modelBehaviorSpecType" value="1"/>
-<stringAttribute key="modelBehaviorVars" value="lastSuccessfulPK, CurrentMaxPrimaryKey, BinlogWriteQueue, chosenPK, SourceBinlog, currentRow, BinlogStreamingStopRequested, pc, newRecord, oldRecord, TargetTable, TargetBinlogPos, currentBinlogEntry, lastWrittenBinlogPos, ApplicationReadonly, SourceTable, lastSuccessfulBinlogPos"/>
-<stringAttribute key="modelComments" value=""/>
-<booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
-<listAttribute key="modelCorrectnessInvariants">
-<listEntry value="1SourceTargetEquality"/>
-</listAttribute>
-<listAttribute key="modelCorrectnessProperties">
-<listEntry value="1Termination"/>
-</listAttribute>
-<stringAttribute key="modelExpressionEval" value=""/>
-<stringAttribute key="modelParameterActionConstraint" value="BinlogSizeActionConstraint"/>
-<listAttribute key="modelParameterConstants">
-<listEntry value="defaultInitValue;;defaultInitValue;1;0"/>
-<listEntry value="Records;;{r0, r1};1;0"/>
-<listEntry value="MaxPrimaryKey;;2;0;0"/>
-<listEntry value="Ferry;;Ferry;1;0"/>
-<listEntry value="InitialTable;;&lt;&lt;r0, r1, NoRecordHere&gt;&gt;;0;0"/>
-<listEntry value="Application;;Application;1;0"/>
-<listEntry value="BinlogStreamer;;BinlogStreamer;1;0"/>
-<listEntry value="TableIterator;;TableIterator;1;0"/>
-<listEntry value="MaxBinlogSize;;3;0;0"/>
-<listEntry value="BinlogWriter;;BinlogWriter;1;0"/>
-</listAttribute>
-<stringAttribute key="modelParameterContraint" value=""/>
-<listAttribute key="modelParameterDefinitions">
-<listEntry value="NoRecordHere;;NoRecordHere;1;0"/>
-</listAttribute>
-<stringAttribute key="modelParameterModelValues" value="{}"/>
-<stringAttribute key="modelParameterNewDefinitions" value=""/>
-<intAttribute key="numberOfWorkers" value="3"/>
-<booleanAttribute key="recover" value="false"/>
-<stringAttribute key="result.mail.address" value=""/>
-<intAttribute key="simuAril" value="-1"/>
-<intAttribute key="simuDepth" value="100"/>
-<intAttribute key="simuSeed" value="-1"/>
-<stringAttribute key="specName" value="ghostferry"/>
-<stringAttribute key="view" value=""/>
-<booleanAttribute key="visualizeStateGraph" value="false"/>
+    <stringAttribute key="TLCCmdLineParameters" value=""/>
+    <intAttribute key="collectCoverage" value="1"/>
+    <stringAttribute key="configurationName" value="GhostferryPrimaryModel"/>
+    <booleanAttribute key="deferLiveness" value="false"/>
+    <intAttribute key="dfidDepth" value="100"/>
+    <booleanAttribute key="dfidMode" value="false"/>
+    <intAttribute key="distributedFPSetCount" value="0"/>
+    <stringAttribute key="distributedNetworkInterface" value="172.22.100.3"/>
+    <intAttribute key="distributedNodesCount" value="1"/>
+    <stringAttribute key="distributedTLC" value="off"/>
+    <stringAttribute key="distributedTLCVMArgs" value=""/>
+    <intAttribute key="fpBits" value="1"/>
+    <intAttribute key="fpIndex" value="12"/>
+    <booleanAttribute key="fpIndexRandom" value="true"/>
+    <intAttribute key="maxHeapSize" value="75"/>
+    <intAttribute key="maxSetSize" value="1000000"/>
+    <booleanAttribute key="mcMode" value="true"/>
+    <stringAttribute key="modelBehaviorInit" value=""/>
+    <stringAttribute key="modelBehaviorNext" value=""/>
+    <stringAttribute key="modelBehaviorSpec" value="Spec"/>
+    <intAttribute key="modelBehaviorSpecType" value="1"/>
+    <stringAttribute key="modelBehaviorVars" value="lastSuccessfulPK, CurrentMaxPrimaryKey, BinlogWriteQueue, chosenPK, SourceBinlog, MaxPrimaryKey, currentRow, BinlogStreamingStopRequested, pc, newRecord, oldRecord, LastSuccessfulPK, TargetTable, TargetBinlogPos, currentBinlogEntry, ApplicationReadonly, SourceTable, lastSuccessfulBinlogPos"/>
+    <stringAttribute key="modelComments" value=""/>
+    <booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
+    <listAttribute key="modelCorrectnessInvariants">
+        <listEntry value="1SourceTargetEquality"/>
+    </listAttribute>
+    <listAttribute key="modelCorrectnessProperties">
+        <listEntry value="0Termination"/>
+    </listAttribute>
+    <intAttribute key="modelEditorOpenTabs" value="12"/>
+    <stringAttribute key="modelExpressionEval" value=""/>
+    <stringAttribute key="modelParameterActionConstraint" value="BinlogSizeActionConstraint"/>
+    <listAttribute key="modelParameterConstants">
+        <listEntry value="defaultInitValue;;defaultInitValue;1;0"/>
+        <listEntry value="Records;;{r0, r1};1;0"/>
+        <listEntry value="Ferry;;Ferry;1;0"/>
+        <listEntry value="Application;;Application;1;0"/>
+        <listEntry value="BinlogStreamer;;BinlogStreamer;1;0"/>
+        <listEntry value="TableIterator;;TableIterator;1;0"/>
+        <listEntry value="MaxBinlogSize;;3;0;0"/>
+        <listEntry value="BinlogWriter;;BinlogWriter;1;0"/>
+        <listEntry value="TableCapacity;;3;0;0"/>
+    </listAttribute>
+    <stringAttribute key="modelParameterContraint" value=""/>
+    <listAttribute key="modelParameterDefinitions">
+        <listEntry value="NoRecordHere;;NoRecordHere;1;0"/>
+    </listAttribute>
+    <stringAttribute key="modelParameterModelValues" value="{}"/>
+    <stringAttribute key="modelParameterNewDefinitions" value=""/>
+    <intAttribute key="modelVersion" value="20191005"/>
+    <intAttribute key="numberOfWorkers" value="16"/>
+    <booleanAttribute key="recover" value="false"/>
+    <stringAttribute key="result.mail.address" value=""/>
+    <intAttribute key="simuAril" value="-1"/>
+    <intAttribute key="simuDepth" value="100"/>
+    <intAttribute key="simuSeed" value="-1"/>
+    <stringAttribute key="specName" value="ghostferry"/>
+    <stringAttribute key="tlcResourcesProfile" value="local custom"/>
+    <stringAttribute key="view" value=""/>
+    <booleanAttribute key="visualizeStateGraph" value="false"/>
 </launchConfiguration>


### PR DESCRIPTION
Huge thanks to @fjordan for helping me with all of these. We tackled this problem via the multiple starting state feature of TLC as follows:

## TLA+ for DataIterator interrupt/resume

Instead of interrupting and then resuming in TLA as that would be messy and difficult to check, we generate starting states for the SourceTable and TargetTable such that it looks like it was previously interrupted. This is a multiple-starting state approach that significantly increases the search space of the TLC run.

We also generate a valid "LastSuccessfulPK" that will be valid given the table states such that some of the initial states will cause the Ghostferry algorithm to re-copy previously copied rows. There's no mathematical proof that as long as we can re-copy one row correctly, we can re-copy n rows correctly, but intuition says this is indeed the case.

## TLA+ for BinlogStreamer interrupt/resume

Taking a similar approach with the TLA+ for the DataIterator, the idea here is we generate a possible SourceBinlog sequence at the initial starting state.

This time, we generate a SourceBinlog that's either an empty sequence (simulating a fresh Ghostferry run) or contains a single binlog entry that has already been previously copied over to the TargetTable. The TLA+ specification is constructed such that when Ghostferry starts, it will attempt to copy that binlog over to the target again. Effectively, this simulates when Ghostferry is resumed from a binlog coordinate that is "outdated": i.e. if a binlog is already copied but the last successful binlog position is not updated, it is safe to resume from an outdated position.

Once again, this is only a single binlog entry and we do not have a mathematical proof that if it works with a single binlog entry, it works with n binlog entries. However, strong intuitions suggests that this is the case so this proof is omitted for now.

## Other notes

Checking this with TLC on My Ryzen 7 3700X machine took about 17min. On a 2020 MBP with a 6core/12thread processor it took about 38min. 

Most of the code changes are generated by TLA+ Toolbox. The actual changes is relatively small.