### PR TITLE
Re-apply UNIX support and load config before RunFerryFromReplica

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ const (
 	VerifierTypeInline         = "Inline"
 	VerifierTypeNoVerification = "NoVerification"
 
+	DefaultNet        = "tcp"
 	DefaultMarginalia = "application:ghostferry"
 )
 
@@ -54,6 +55,7 @@ func (this *TLSConfig) BuildConfig() (*tls.Config, error) {
 type DatabaseConfig struct {
 	Host      string
 	Port      uint16
+	Net       string
 	User      string
 	Pass      string
 	Collation string
@@ -71,11 +73,19 @@ type DatabaseConfig struct {
 }
 
 func (c *DatabaseConfig) MySQLConfig() (*mysql.Config, error) {
+	var addr string
+
+	if c.Net == "unix" {
+		addr = c.Host
+	} else {
+		addr = fmt.Sprintf("%s:%d", c.Host, c.Port)
+	}
+
 	cfg := &mysql.Config{
 		User:                 c.User,
 		Passwd:               c.Pass,
-		Net:                  "tcp",
-		Addr:                 fmt.Sprintf("%s:%d", c.Host, c.Port),
+		Net:                  c.Net,
+		Addr:                 addr,
 		Collation:            c.Collation,
 		Params:               c.Params,
 		AllowNativePasswords: true,
@@ -108,6 +118,14 @@ func (c *DatabaseConfig) Validate() error {
 
 	if c.Port == 0 {
 		return fmt.Errorf("port is not specified")
+	}
+
+	if c.Net == "" {
+		c.Net = DefaultNet
+	} else if c.Net == "unix" {
+		c.Port = 0
+	} else if c.Net != "tcp" && c.Net != "unix" {
+		return fmt.Errorf("net is unknown (valid modes: tcp, unix)")
 	}
 
 	if c.User == "" {

--- a/copydb/copydb.go
+++ b/copydb/copydb.go
@@ -35,16 +35,16 @@ func NewFerry(config *Config) *CopydbFerry {
 }
 
 func (this *CopydbFerry) Initialize() error {
+	err := this.Ferry.Initialize()
+	if err != nil {
+		return err
+	}
+
 	if this.config.RunFerryFromReplica {
 		err := this.initializeWaitUntilReplicaIsCaughtUpToMasterConnection()
 		if err != nil {
 			return err
 		}
-	}
-
-	err := this.Ferry.Initialize()
-	if err != nil {
-		return err
 	}
 
 	this.controlServer.Verifier = this.Ferry.Verifier

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -76,18 +76,18 @@ func NewFerry(config *Config) (*ShardingFerry, error) {
 }
 
 func (r *ShardingFerry) Initialize() error {
+	err := r.Ferry.Initialize()
+	if err != nil {
+		r.Ferry.ErrorHandler.ReportError("ferry.initialize", err)
+		return err
+	}
+
 	if r.config.RunFerryFromReplica {
 		err := r.initializeWaitUntilReplicaIsCaughtUpToMasterConnection()
 		if err != nil {
 			r.logger.WithField("error", err).Errorf("could not open connection to master replica")
 			return err
 		}
-	}
-
-	err := r.Ferry.Initialize()
-	if err != nil {
-		r.Ferry.ErrorHandler.ReportError("ferry.initialize", err)
-		return err
 	}
 
 	return nil


### PR DESCRIPTION
We noticed an issue with config not being loaded and validated fully before `RunFerryFromReplica` acquire its first connection in sharding. This PR will re-apply UNIX support and delay `RunFerryFromReplica` initialization to after config is fully loaded.