### PR TITLE
False positive InlineVerifier errors

### DIFF
--- a/batch_writer.go
+++ b/batch_writer.go
@@ -96,7 +96,7 @@ func (w *BatchWriter) WriteRowBatch(batch *RowBatch) error {
 		}
 
 		if w.InlineVerifier != nil {
-			mismatches, err := w.InlineVerifier.CheckFingerprintInline(tx, db, table, batch)
+			mismatches, err := w.InlineVerifier.CheckFingerprintInline(tx, db, table, batch, w.EnforceInlineVerification)
 			if err != nil {
 				tx.Rollback()
 				return fmt.Errorf("during fingerprint checking for paginationKey %v -> %v (%s): %v", startPaginationKeypos, endPaginationKeypos, query, err)

--- a/batch_writer.go
+++ b/batch_writer.go
@@ -28,9 +28,10 @@ func (e BatchWriterVerificationFailed) Error() string {
 }
 
 type BatchWriter struct {
-	DB             *sql.DB
-	InlineVerifier *InlineVerifier
-	StateTracker   *StateTracker
+	DB                        *sql.DB
+	InlineVerifier            *InlineVerifier
+	StateTracker              *StateTracker
+	EnforceInlineVerification bool // Only needed when running the BatchWriter during cutover
 
 	DatabaseRewrites map[string]string
 	TableRewrites    map[string]string
@@ -95,10 +96,21 @@ func (w *BatchWriter) WriteRowBatch(batch *RowBatch) error {
 		}
 
 		if w.InlineVerifier != nil {
-			err := w.InlineVerifier.CheckFingerprintInline(tx, db, table, batch)
+			mismatches, err := w.InlineVerifier.CheckFingerprintInline(tx, db, table, batch)
 			if err != nil {
 				tx.Rollback()
 				return fmt.Errorf("during fingerprint checking for paginationKey %v -> %v (%s): %v", startPaginationKeypos, endPaginationKeypos, query, err)
+			}
+
+			if w.EnforceInlineVerification {
+				// This code should only be active if the InlineVerifier background
+				// reverification is not occuring. An example of this would be when you
+				// run the BatchWriter as a part of copying the primary table or delta
+				// copying the joined table.
+				if len(mismatches) > 0 {
+					tx.Rollback()
+					return BatchWriterVerificationFailed{mismatches, batch.TableSchema().String()}
+				}
 			}
 		}
 

--- a/batch_writer.go
+++ b/batch_writer.go
@@ -95,15 +95,10 @@ func (w *BatchWriter) WriteRowBatch(batch *RowBatch) error {
 		}
 
 		if w.InlineVerifier != nil {
-			mismatches, err := w.InlineVerifier.CheckFingerprintInline(tx, db, table, batch)
+			err := w.InlineVerifier.CheckFingerprintInline(tx, db, table, batch)
 			if err != nil {
 				tx.Rollback()
 				return fmt.Errorf("during fingerprint checking for paginationKey %v -> %v (%s): %v", startPaginationKeypos, endPaginationKeypos, query, err)
-			}
-
-			if len(mismatches) > 0 {
-				tx.Rollback()
-				return BatchWriterVerificationFailed{mismatches, batch.TableSchema().String()}
 			}
 		}
 

--- a/ferry.go
+++ b/ferry.go
@@ -744,6 +744,7 @@ func (f *Ferry) RunStandaloneDataCopy(tables []*TableSchema) error {
 	// Always use the InlineVerifier to verify the copied data here.
 	dataIterator.SelectFingerprint = true
 	batchWriter.InlineVerifier = f.NewInlineVerifierWithoutStateTracker()
+	batchWriter.EnforceInlineVerification = true // Don't have the Binlog component at this stage, so no reverify
 
 	// BUG: if the PanicErrorHandler fires while running the standalone copy, we
 	// will get an error dump even though we should not get one, which could be

--- a/inline_verifier.go
+++ b/inline_verifier.go
@@ -287,14 +287,14 @@ func (v *InlineVerifier) Result() (VerificationResultAndStatus, error) {
 	return v.backgroundVerificationResultAndStatus, v.backgroundVerificationErr
 }
 
-func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetSchema, targetTable string, sourceBatch *RowBatch) ([]uint64, error) {
+func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetSchema, targetTable string, sourceBatch *RowBatch) error {
 	table := sourceBatch.TableSchema()
 
 	paginationKeys := make([]uint64, len(sourceBatch.Values()))
 	for i, row := range sourceBatch.Values() {
 		paginationKey, err := row.GetUint64(sourceBatch.PaginationKeyIndex())
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		paginationKeys[i] = paginationKey
@@ -303,7 +303,7 @@ func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetSchema, target
 	// Fetch target data
 	targetFingerprints, targetDecompressedData, err := v.getFingerprintDataFromTargetDb(targetSchema, targetTable, tx, table, paginationKeys)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// Fetch source data
@@ -313,7 +313,7 @@ func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetSchema, target
 	for _, rowData := range sourceBatch.Values() {
 		paginationKey, err := rowData.GetUint64(sourceBatch.PaginationKeyIndex())
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		sourceDecompressedData[paginationKey] = make(map[string][]byte)
@@ -326,14 +326,24 @@ func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetSchema, target
 
 			compressedData, ok = rowData[idx].([]byte)
 			if !ok {
-				return nil, fmt.Errorf("cannot convert column %v to []byte", col.Name)
+				return fmt.Errorf("cannot convert column %v to []byte", col.Name)
 			}
 
 			sourceDecompressedData[paginationKey][col.Name], err = v.decompressData(table, col.Name, compressedData)
 		}
 	}
 
-	return v.compareHashesAndData(sourceFingerprints, targetFingerprints, sourceDecompressedData, targetDecompressedData), nil
+	mismatches := v.compareHashesAndData(sourceFingerprints, targetFingerprints, sourceDecompressedData, targetDecompressedData)
+
+	for _, mismatchedPk := range mismatches {
+		v.reverifyStore.Add(table, mismatchedPk)
+	}
+
+	if len(mismatches) > 0 {
+		v.logger.WithField("mismatches", mismatches).Info("inline verification during data copy noticed mismatched pk, which is okay (issue 149)")
+	}
+
+	return nil
 }
 
 func (v *InlineVerifier) PeriodicallyVerifyBinlogEvents(ctx context.Context) {

--- a/inline_verifier.go
+++ b/inline_verifier.go
@@ -287,7 +287,7 @@ func (v *InlineVerifier) Result() (VerificationResultAndStatus, error) {
 	return v.backgroundVerificationResultAndStatus, v.backgroundVerificationErr
 }
 
-func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetSchema, targetTable string, sourceBatch *RowBatch) ([]uint64, error) {
+func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetSchema, targetTable string, sourceBatch *RowBatch, enforceInlineVerification bool) ([]uint64, error) {
 	table := sourceBatch.TableSchema()
 
 	paginationKeys := make([]uint64, len(sourceBatch.Values()))
@@ -335,12 +335,14 @@ func (v *InlineVerifier) CheckFingerprintInline(tx *sql.Tx, targetSchema, target
 
 	mismatches := v.compareHashesAndData(sourceFingerprints, targetFingerprints, sourceDecompressedData, targetDecompressedData)
 
-	for _, mismatchedPk := range mismatches {
-		v.reverifyStore.Add(table, mismatchedPk)
-	}
+	if !enforceInlineVerification {
+		for _, mismatchedPk := range mismatches {
+			v.reverifyStore.Add(table, mismatchedPk)
+		}
 
-	if len(mismatches) > 0 {
-		v.logger.WithField("mismatches", mismatches).Info("inline verification during data copy noticed mismatched pk, which may be okay (issue 149, unless overwritten due to EnforceInlineVerification)")
+		if len(mismatches) > 0 {
+			v.logger.WithField("mismatches", mismatches).Info("inline verification during data copy noticed mismatched pk, which is okay")
+		}
 	}
 
 	return mismatches, nil

--- a/test/helpers/ghostferry_helper.rb
+++ b/test/helpers/ghostferry_helper.rb
@@ -224,6 +224,7 @@ module GhostferryHelper
 
       @server.mount_proc "/callbacks/error" do |req, resp|
         @error = JSON.parse(JSON.parse(req.body)["Payload"])
+        @callback_handlers["error"].each { |f| f.call(@error) } unless @callback_handlers["state"].nil?
       end
 
       @server_thread = Thread.new do

--- a/test/helpers/ghostferry_helper.rb
+++ b/test/helpers/ghostferry_helper.rb
@@ -224,7 +224,7 @@ module GhostferryHelper
 
       @server.mount_proc "/callbacks/error" do |req, resp|
         @error = JSON.parse(JSON.parse(req.body)["Payload"])
-        @callback_handlers["error"].each { |f| f.call(@error) } unless @callback_handlers["state"].nil?
+        @callback_handlers["error"].each { |f| f.call(@error) } unless @callback_handlers["error"].nil?
       end
 
       @server_thread = Thread.new do


### PR DESCRIPTION
This commit fixes a false positive problem with the InlineVerifier, which is documented in #149. That bug report documented a relatively complex and uncommon race condition that could occur and result in a false positive inline verifier error. However, with the presence of interrupt resume with periodic snapshots in the past, this problem becomes a lot more prevalent. An example case is given in the test, and is also given below for reference:

| Step | Action             | Source | Target | Notes |
|------|--------------------|--------|--------|-------|
| 0    | Initial State      | v1     | nil    |       |
| 1    | State Dump         | v1     | nil    |       |
| 2    | Copy row           | v1     | v1     |       |
| 3    | Interrupt          | v1     | v1     |       |
| 4    | App UPDATE         | v2     | v1     |       |
| 5    | Resume from step 1 | v2     | v1     |       |
| 6    | Copy row           | v2     | v1     | NO-OP due to insert ignore. |
| 7    | CHECKSUM           | v2     | v1     | InlineVerifier error here.  |
| 8    | Process halted     | v2     | v1     |       |

This means that if a move fail like this, it might never resume, as the binlog streamer could be quite lagged and therefore the error will repeat itself on every resume. Suppose if we do not error immediately on step 7 and allow the process to continue, the binlog streamer will eventually catch up and correct that row before cutover. This checksum table error could be queued in the background reverify store and periodically reverified until either the source and target matches, or until cutover, when it would fail if the discrepency is not resolved.

The following example is a run after this commit:

| Step | Action             | Source | Target | Notes |
|------|--------------------|--------|--------|-------|
| 0    | Initial State      | v1     | nil    |       |
| 1    | State Dump         | v1     | nil    |       |
| 2    | Copy row           | v1     | v1     |       |
| 3    | Interrupt          | v1     | v1     |       |
| 4    | App UPDATE         | v2     | v1     |       |
| 5    | Resume from step 1 | v2     | v1     |       |
| 6    | Copy row           | v2     | v1     | NO-OP due to insert ignore. |
| 7    | CHECKSUM           | v2     | v1     | Row added to reverify store.|
| 8    | Binlog apply       | v2     | v2     |       |
| 9    | Reverify           | v2     | v2     | Verification successful, row is dropped from reverify store |

If step 9 is not successful here because step 8 failed to apply correctly, resulting in a data corruption, the row will not be dropped
from the reverify store. During cutover, a final verification will be performed, and the Ghostferry process will error due to a verification error.

Additionally, we have some consumers of the BatchWriter that must error immediately without a background verification component. In these cases, EnforceInlineVerification is available for the BatchWriter, which will cause BatchWriter to error if mismatches are detected. This is used for the delta copier and the primary key table copier during cutover for ghostferry-sharding.