### PR TITLE
Remove schema cache from state dump

### DIFF
--- a/config.go
+++ b/config.go
@@ -435,6 +435,11 @@ type Config struct {
 	// The dumped state can be used to resume Ghostferry.
 	DumpStateOnSignal bool
 
+	// This excludes schema cache from the state dump in both the HTTP callback
+	// and the stdout dumping. This may save a lot of space if you don't need
+	// to deal with schema migrations.
+	DoNotIncludeSchemaCacheInStateDump bool
+
 	// Config for the ControlServer
 	ServerBindAddr string
 	WebBasedir     string

--- a/ferry.go
+++ b/ferry.go
@@ -819,6 +819,10 @@ func (f *Ferry) SerializeStateToJSON() (string, error) {
 
 	serializedState := f.StateTracker.Serialize(f.Tables, binlogVerifyStore)
 
+	if f.Config.DoNotIncludeSchemaCacheInStateDump {
+		serializedState.LastKnownTableSchemaCache = nil
+	}
+
 	stateBytes, err := json.MarshalIndent(serializedState, "", " ")
 	return string(stateBytes), err
 }


### PR DESCRIPTION
The schema cache can be quite big. Not emitting it may play nicer with HTTP requests max size...