### PR TITLE
Move replica initialization before ferry initialization

### DIFF
--- a/config.go
+++ b/config.go
@@ -79,6 +79,9 @@ func (c *DatabaseConfig) MySQLConfig() (*mysql.Config, error) {
 		addr = c.Host
 	} else {
 		addr = fmt.Sprintf("%s:%d", c.Host, c.Port)
+		if c.Net == "" {
+			c.Net = DefaultNet
+		}
 	}
 
 	cfg := &mysql.Config{

--- a/copydb/copydb.go
+++ b/copydb/copydb.go
@@ -35,16 +35,16 @@ func NewFerry(config *Config) *CopydbFerry {
 }
 
 func (this *CopydbFerry) Initialize() error {
-	err := this.Ferry.Initialize()
-	if err != nil {
-		return err
-	}
-
 	if this.config.RunFerryFromReplica {
 		err := this.initializeWaitUntilReplicaIsCaughtUpToMasterConnection()
 		if err != nil {
 			return err
 		}
+	}
+
+	err := this.Ferry.Initialize()
+	if err != nil {
+		return err
 	}
 
 	this.controlServer.Verifier = this.Ferry.Verifier

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -76,18 +76,18 @@ func NewFerry(config *Config) (*ShardingFerry, error) {
 }
 
 func (r *ShardingFerry) Initialize() error {
-	err := r.Ferry.Initialize()
-	if err != nil {
-		r.Ferry.ErrorHandler.ReportError("ferry.initialize", err)
-		return err
-	}
-
 	if r.config.RunFerryFromReplica {
 		err := r.initializeWaitUntilReplicaIsCaughtUpToMasterConnection()
 		if err != nil {
 			r.logger.WithField("error", err).Errorf("could not open connection to master replica")
 			return err
 		}
+	}
+
+	err := r.Ferry.Initialize()
+	if err != nil {
+		r.Ferry.ErrorHandler.ReportError("ferry.initialize", err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
When `RunFerryFromReplica` is turned on, there is an error introduced in PR #209 during the ferry initialization. `WaitUntilReplicaIsCaughtUpToMaster` needs to be initialized before we initialize the ferry. In addition, we need to set to connect to the databases via TCP when such information is not specified.
