### PR TITLE
Make MySQL read and write timeout configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -62,6 +62,14 @@ type DatabaseConfig struct {
 	Params    map[string]string
 	TLS       *TLSConfig
 
+	// ReadTimeout is used to configure the MySQL client timeout for waiting for data from server.
+	// Timeout is in seconds. Defaults to unlimited.
+	ReadTimeout uint64
+
+	// WriteTimeout is used to configure the MySQL client timeout for writing data to server.
+	// Timeout is in seconds. Defaults to unlimited.
+	WriteTimeout uint64
+
 	// SQL annotations used to differentiate Ghostferry's DMLs
 	// against other actor's. This will default to the defaultMarginalia
 	// constant above if not set.
@@ -90,6 +98,14 @@ func (c *DatabaseConfig) MySQLConfig() (*mysql.Config, error) {
 		Params:               c.Params,
 		AllowNativePasswords: true,
 		MultiStatements:      true,
+	}
+
+	if c.ReadTimeout != 0 {
+		cfg.ReadTimeout = time.Duration(c.ReadTimeout) * time.Second
+	}
+
+	if c.WriteTimeout != 0 {
+		cfg.WriteTimeout = time.Duration(c.WriteTimeout) * time.Second
 	}
 
 	if c.TLS != nil {

--- a/config.go
+++ b/config.go
@@ -63,11 +63,11 @@ type DatabaseConfig struct {
 	TLS       *TLSConfig
 
 	// ReadTimeout is used to configure the MySQL client timeout for waiting for data from server.
-	// Timeout is in seconds. Defaults to unlimited.
+	// Timeout is in seconds. Defaults to 0, which means no timeout.
 	ReadTimeout uint64
 
 	// WriteTimeout is used to configure the MySQL client timeout for writing data to server.
-	// Timeout is in seconds. Defaults to unlimited.
+	// Timeout is in seconds. Defaults to 0, which means no timeout.
 	WriteTimeout uint64
 
 	// SQL annotations used to differentiate Ghostferry's DMLs


### PR DESCRIPTION
We have had a couple of 4 hour slow queries during a migration. These could have been more easily found if the MySQL client in Ghostferry would have timed out faster and retried or crashed after 4 retries if persistent. I've set the time to 30 seconds for both reads and writes here, maybe we want this configurable, but also don't feel for adding more complexity to config.

Ps. Using a very large chunk size might mean it takes more than 30 seconds, this case isn't really cared for in this PR. We could increase the time to 60s or so, everything is better than 4 hours here.

**Update:** I've made it configurable and set fallback to 60s.