### PR TITLE
Allow index forcing in inline verifier

### DIFF
--- a/config.go
+++ b/config.go
@@ -558,8 +558,8 @@ type Config struct {
 	// Example:
 	//
 	// "ForceIndexForVerification": {
-	//   "gftest": {
-	//     "table1": "forced_index_name"
+	//   "blog": {
+	//     "users": "ix_users_some_id"
 	//   }
 	// }
 	//

--- a/config.go
+++ b/config.go
@@ -554,6 +554,15 @@ type Config struct {
 
 	// Map an index to a table, will add `FORCE INDEX (index_name)` to the fingerprint SELECT query.
 	// Index hinting might be necessary if you are running into slow queries during copy on your target.
+	//
+	// Example:
+	//
+	// "ForceIndexForVerification": {
+	//   "gftest": {
+	//     "table1": "forced_index_name"
+	//   }
+	// }
+	//
 	ForceIndexForVerification ForceIndexConfig
 
 	// Ghostferry requires a single numeric column to paginate over tables. Inferring that column is done in the following exact order:

--- a/config.go
+++ b/config.go
@@ -317,6 +317,24 @@ func (c ColumnIgnoreConfig) IgnoredColumnsFor(schemaName, tableName string) map[
 	return columnsConfig
 }
 
+// SchemaName => TableName => IndexName
+// These indices will be forced for queries in InlineVerification
+type ForceIndexConfig map[string]map[string]string
+
+func (c ForceIndexConfig) IndexFor(schemaName, tableName string) string {
+	tableConfig, found := c[schemaName]
+	if !found {
+		return ""
+	}
+
+	index, found := tableConfig[tableName]
+	if !found {
+		return ""
+	}
+
+	return index
+}
+
 // CascadingPaginationColumnConfig to configure pagination columns to be
 // used. The term `Cascading` to denote that greater specificity takes
 // precedence.
@@ -533,6 +551,10 @@ type Config struct {
 	// - Putting the column in this config will cause the InlineVerifier to skip
 	//   this column for verification.
 	IgnoredColumnsForVerification ColumnIgnoreConfig
+
+	// Map an index to a table, will add `FORCE INDEX (index_name)` to the fingerprint SELECT query.
+	// Index hinting might be necessary if you are running into slow queries during copy on your target.
+	ForceIndexForVerification ForceIndexConfig
 
 	// Ghostferry requires a single numeric column to paginate over tables. Inferring that column is done in the following exact order:
 	// 1. Use the PerTable pagination column, if configured for a table. Fail if we cannot find this column in the table.

--- a/copydb/test/copydb_test.go
+++ b/copydb/test/copydb_test.go
@@ -67,7 +67,7 @@ func (t *CopydbTestSuite) TearDownTest() {
 
 func (t *CopydbTestSuite) TestCreateDatabaseAndTableWithRewrites() {
 	var err error
-	t.copydbFerry.Ferry.Tables, err = ghostferry.LoadTables(t.ferry.SourceDB, t.copydbFerry.Ferry.TableFilter, nil, nil, nil)
+	t.copydbFerry.Ferry.Tables, err = ghostferry.LoadTables(t.ferry.SourceDB, t.copydbFerry.Ferry.TableFilter, nil, nil, nil, nil)
 	t.Require().Nil(err)
 
 	err = t.copydbFerry.CreateDatabasesAndTables()
@@ -87,7 +87,7 @@ func (t *CopydbTestSuite) TestCreateDatabaseAndTableWithRewrites() {
 
 func (t *CopydbTestSuite) TestCreateDatabasesAndTablesAlreadyExists() {
 	var err error
-	t.copydbFerry.Ferry.Tables, err = ghostferry.LoadTables(t.ferry.SourceDB, t.copydbFerry.Ferry.TableFilter, nil, nil, nil)
+	t.copydbFerry.Ferry.Tables, err = ghostferry.LoadTables(t.ferry.SourceDB, t.copydbFerry.Ferry.TableFilter, nil, nil, nil, nil)
 	t.Require().Nil(err)
 
 	testhelpers.SeedInitialData(t.ferry.TargetDB, renamedSchemaName, renamedTableName, 1)
@@ -98,7 +98,7 @@ func (t *CopydbTestSuite) TestCreateDatabasesAndTablesAlreadyExists() {
 
 func (t *CopydbTestSuite) TestCreateDatabasesAndTablesAlreadyExistsAllowed() {
 	var err error
-	t.copydbFerry.Ferry.Tables, err = ghostferry.LoadTables(t.ferry.SourceDB, t.copydbFerry.Ferry.TableFilter, nil, nil, nil)
+	t.copydbFerry.Ferry.Tables, err = ghostferry.LoadTables(t.ferry.SourceDB, t.copydbFerry.Ferry.TableFilter, nil, nil, nil, nil)
 	t.Require().Nil(err)
 
 	testhelpers.SeedInitialData(t.ferry.TargetDB, renamedSchemaName, renamedTableName, 1)

--- a/copydb/test/filter_test.go
+++ b/copydb/test/filter_test.go
@@ -40,6 +40,7 @@ func (this *FilterTestSuite) TestLoadTablesWithWhitelist() {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	this.Require().Nil(err)
@@ -63,6 +64,7 @@ func (this *FilterTestSuite) TestLoadTablesWithBlacklist() {
 				Blacklist: []string{"test_table_2"},
 			},
 		),
+		nil,
 		nil,
 		nil,
 		nil,

--- a/examples/copydb/conf.json
+++ b/examples/copydb/conf.json
@@ -29,6 +29,12 @@
     "Blacklist": ["schema_migrations"]
   },
 
+  "ForceIndexForVerification": {
+    "abc": {
+      "table1": "forced_index_name"
+    },
+  },
+
   "DumpStateOnSignal": true,
 
   "VerifierType": "ChecksumTable"

--- a/examples/copydb/conf.json
+++ b/examples/copydb/conf.json
@@ -32,7 +32,7 @@
   "ForceIndexForVerification": {
     "abc": {
       "table1": "forced_index_name"
-    },
+    }
   },
 
   "DumpStateOnSignal": true,

--- a/ferry.go
+++ b/ferry.go
@@ -427,7 +427,7 @@ func (f *Ferry) Initialize() (err error) {
 	// changed.
 	if f.StateToResumeFrom == nil || f.StateToResumeFrom.LastKnownTableSchemaCache == nil {
 		metrics.Measure("LoadTables", nil, 1.0, func() {
-			f.Tables, err = LoadTables(f.SourceDB, f.TableFilter, f.CompressedColumnsForVerification, f.IgnoredColumnsForVerification, f.CascadingPaginationColumnConfig)
+			f.Tables, err = LoadTables(f.SourceDB, f.TableFilter, f.CompressedColumnsForVerification, f.IgnoredColumnsForVerification, f.ForceIndexForVerification, f.CascadingPaginationColumnConfig)
 		})
 		if err != nil {
 			return err

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -215,7 +215,7 @@ func (r *ShardingFerry) copyPrimaryKeyTables() error {
 	r.config.TableFilter.(*ShardedTableFilter).PrimaryKeyTables = primaryKeyTables
 	r.config.CopyFilter.(*ShardedCopyFilter).PrimaryKeyTables = primaryKeyTables
 
-	sourceDbTables, err := ghostferry.LoadTables(r.Ferry.SourceDB, r.config.TableFilter, r.config.CompressedColumnsForVerification, r.config.IgnoredColumnsForVerification, r.config.CascadingPaginationColumnConfig)
+	sourceDbTables, err := ghostferry.LoadTables(r.Ferry.SourceDB, r.config.TableFilter, r.config.CompressedColumnsForVerification, r.config.IgnoredColumnsForVerification, r.config.ForceIndexForVerification, r.config.CascadingPaginationColumnConfig)
 	if err != nil {
 		return err
 	}

--- a/test/go/binlog_streamer_test.go
+++ b/test/go/binlog_streamer_test.go
@@ -46,6 +46,7 @@ func (this *BinlogStreamerTestSuite) SetupTest() {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 	this.Require().Nil(err)
 

--- a/test/go/data_iterator_test.go
+++ b/test/go/data_iterator_test.go
@@ -34,7 +34,7 @@ func (this *DataIteratorTestSuite) SetupTest() {
 		TablesFunc: nil,
 	}
 
-	tables, err := ghostferry.LoadTables(sourceDb, tableFilter, nil, nil, nil)
+	tables, err := ghostferry.LoadTables(sourceDb, tableFilter, nil, nil, nil, nil)
 	this.Require().Nil(err)
 
 	this.tables = tables.AsSlice()

--- a/test/go/iterative_verifier_test.go
+++ b/test/go/iterative_verifier_test.go
@@ -370,7 +370,7 @@ func (t *IterativeVerifierTestSuite) reloadTables() {
 		TablesFunc: nil,
 	}
 
-	tables, err := ghostferry.LoadTables(t.db, tableFilter, nil, nil, nil)
+	tables, err := ghostferry.LoadTables(t.db, tableFilter, nil, nil, nil, nil)
 	t.Require().Nil(err)
 
 	t.Ferry.Tables = tables


### PR DESCRIPTION
Sometime you might run in to a mad query plan during copy, this new option will help to force an index during inline verification.

Example config:
```json
 "ForceIndexForVerification": {
    "gftest": {
      "table1": "forced_index_name"
    }
  }
```