### PR TITLE
Log binlog streamer error for now

### DIFF
--- a/binlog_streamer.go
+++ b/binlog_streamer.go
@@ -150,6 +150,8 @@ func (s *BinlogStreamer) Run() {
 			if er == context.DeadlineExceeded {
 				timedOut = true
 				return nil
+			} else if er != nil {
+				s.logger.WithError(er).Warn("failed to call binlogStreamer.GetEvent")
 			}
 
 			return er


### PR DESCRIPTION
I have strong suspicion that the `WithRetries` for `binlogStreamer.GetEvent` (siddontang library call) in `BinlogStreamer.Run` (ghostferry code) is not needed. If we look at the `binlogStreamer.GetEvent` code, it is:

```
// GetEvent gets the binlog event one by one, it will block until Syncer receives any events from MySQL
// or meets a sync error. You can pass a context (like Cancel or Timeout) to break the block.
func (s *BinlogStreamer) GetEvent(ctx context.Context) (*BinlogEvent, error) {
	if s.err != nil {
		return nil, ErrNeedSyncAgain
	}

	select {
	case c := <-s.ch:
		return c, nil
	case s.err = <-s.ech:
		return nil, s.err
	case <-ctx.Done():
		return nil, ctx.Err()
	}
}
```

There are two possible error cases: (1) when `ctx.Done()` is true, and (2) when `s.ech` receives an error. In the first case, we detect that with `if er == context.DeadlineExceeded` and set `timedOut = true`, which we then use to skip the iteration in `BinlogStreamer.Run`. In the second case, we would then perform a retry. However, upon retry, `s.err` would no longer be returned and `ErrNeedSyncAgain` will be returned. In fact, `GetEvent` will never succeed again since `s.err` is now permanently set.

This masks the true error of the binlogStreamer and this is the error that bubbles up in Ghostferry's logs and we therefore do not know the true case of why the binlog streamer failed.

This commit takes a conservative approach for now: we log the error if it is not DeadlineExceeded and not nil. In a future commit, we can remove the `WithRetries` call wrapping `GetEvent`.