### PR TITLE
Edit Documentation

### DIFF
--- a/docs/source/copydbinprod.rst
+++ b/docs/source/copydbinprod.rst
@@ -78,7 +78,7 @@ To Verify Or Not To Verify
 Ghostferry has two built-in verifiers. They are designed to give you certainty
 that the data of the source and the target are identical after a move and
 nothing was corrupted/missed. They are designed to be used during the cutover
-process, when writes to the source database has stopped and writes to the
+process, when writes to the source database have stopped and writes to the
 target have not yet started. During the run, both the source and target must
 be kept read only and thus incur downtime for your dataset. The two different
 verifiers have different downtime characteristics. See the :ref:`verifiers`

--- a/docs/source/copydbinterruptresume.rst
+++ b/docs/source/copydbinterruptresume.rst
@@ -113,5 +113,5 @@ Some other considerations/notes:
 
 * Verifiers are not resumable, including the IterativeVerifier. This may change
   in the future.
-* While we are confident that the algorithm to be correct, this is still a
+* While we are confident the algorithm is correct, this is still a
   highly experimental feature. USE AT YOUR OWN RISK.

--- a/docs/source/technicaloverview.rst
+++ b/docs/source/technicaloverview.rst
@@ -38,7 +38,7 @@ Ghostferry works:
    available position on the source database. This is done so we don't initiate
    the cutover process when there is a large backlog of binlog entries to be
    applied to the target, thereby reducing the downtime required.
-5. Outside of Ghostferry: you should allow no more writes to to the source
+5. Outside of Ghostferry: you should allow no more writes to the source
    database via either a read_only flag (for whole database copies) or some
    sort of application level lock (for partial database copies).
 6. Instruct Ghostferry to enter the cutover phase. This essentially tells
@@ -71,7 +71,7 @@ figure below. It shows the basic flow of all the background tasks, along with
 how each task is spawned (starting from ``Ferry.Run``). Arrows pointing towards
 outside of an encapsulating box indicate the task will exit.  The red arrows
 with "Error action" indicates an error has occurred and the error is sent to
-the ``ErrorHandler``, at which the ErrorHandler flow takes over.
+the ``ErrorHandler``, at which point the ErrorHandler flow takes over.
 
 .. image:: _static/ghostferry-architecture.png
    :align: center
@@ -88,13 +88,13 @@ Limitations
   - An error will be emitted during the beginning of the run if such a primary
     key is not detected.
   - In the near future, we will extend support to arbitrary primary key types.
-  - To work around this restrictions, you can use mysqldump to dump and restore
+  - To work around these restrictions, you can use mysqldump to dump and restore
     the table during the cutover.
 
 - Ghostferry can only be used on a source database with FULL RBR.
 
   - An error will be emitted during the beginning of the run if FULL RBR is
-    not turned on the source database.
+    An error will be emitted during the beginning of the run if FULL RBR is not enabled on the source database.
   - Without FULL RBR, the integrity of the data cannot be guaranteed.
 
 - Ghostferry does not support tables with foreign key constraints.

--- a/docs/source/tutorialcopydb.rst
+++ b/docs/source/tutorialcopydb.rst
@@ -58,8 +58,8 @@ This created two tables under the database ``abc``. We will be moving
 (Mirrors Production) Create Ghostferry Users
 --------------------------------------------
 
-We then need to create an user with the appropriate permissions for Ghostferry
-to connect with to perform the move with on both server. For this move, we
+We then need to create a user with the appropriate permissions for Ghostferry
+to connect with, to perform the move on both servers. For this move, we
 neglect SSL connections to MySQL and thus do not require SSL for the user. In
 production, you may want to enable that.
 
@@ -264,7 +264,7 @@ we get into the habit of thinking of this step:
 
 The last step ``FLUSH BINARY LOGS`` is not necessarily required if you run your
 MySQL server with ``sync_binlog=1``. If you're running Ghostferry from a source
-that is a replica, you need to also use turn option ``RunFerryFromReplica`` on
+that is a replica, you need to also turn on the option ``RunFerryFromReplica`` 
 in the config json as well as other options. See
 `<https://godoc.org/github.com/Shopify/ghostferry/copydb#Config>`_ for more
 details.
@@ -297,7 +297,7 @@ Ghostferry will no longer propagate data from 29291 to 29292. In a production
 situation, you can now notify all applications using the source database to use
 the target database.
 
-The control server UI will stay up indefinitely, to stop it, simply press
+The control server UI will stay up indefinitely. To stop it, simply press
 CTRL+C to interrupt the ghostferry-copydb process.
 
 To run Ghostferry in production, you should read through :ref:`copydbinprod`.

--- a/docs/source/verifiers.rst
+++ b/docs/source/verifiers.rst
@@ -4,10 +4,10 @@
 Verifiers
 =========
 
-Verifiers in Ghostferry is designed to ensure that Ghostferry did not
+Verifiers in Ghostferry are designed to ensure that Ghostferry did not
 corrupt/miss data. There are three different verifiers: the
-``ChecksumTableVerifier`` and the ``InlineVerifier``. A comparison of them are
-given below:
+``ChecksumTableVerifier``, the ``InlineVerifier``, and the ``TargetVerifier``. A comparison of the 
+``ChecksumTableVerifier`` and ``InlineVerifier`` are given below:
 
 +-----------------------+-----------------------+-----------------------------+
 |                       | ChecksumTableVerifier | InlineVerifier              |
@@ -27,7 +27,7 @@ given below:
 |Partial table copy     | Not supported         | Supported                   |
 +-----------------------+-----------------------+-----------------------------+
 |Worst Case Scenario    | Large databases causes| Verification is slower than |
-|                       | unacceptable downtime | the change rate of the DB;  |
+|                       | unacceptable downtime | the change rate of the DB   |
 +-----------------------+-----------------------+-----------------------------+
 
 .. [1] Additional improvements could be made to reduce this as long as
@@ -42,7 +42,7 @@ first if you're copying whole tables at a time. If that takes too long, you can
 try using the ``InlineVerifier``.  Alternatively, you can verify in a staging
 run and not verify during the production run (see :ref:`copydbinprod`).
 
-Note that the ``InlineVerifier`` on its own may miss some potentially
+Note that the ``InlineVerifier`` on its own may potentially miss some 
 cases, and using it with the ``TargetVerifier`` is recommended if these
 cases are possible.
 
@@ -83,11 +83,11 @@ cases are possible.
        https://bugs.mysql.com/bug.php?id=87847. This applies to every row in
        this table.
 
-.. [4] If the rows modified by the the rogue application is modified again on
+.. [4] If the rows modified by the rogue application are modified again on
        the source after Ghostferry starts, the InlineVerifier's binlog tailer
        should pick up that row and attempt to reverify it.
 
-.. [5] If the rows missed after resume is modified again on the source after
+.. [5] If the rows missed after resume are modified again on the source after
        Ghostferry starts, the InlineVerifier's binlog tailer should pick up
        that row and attempt to reverify it.
 


### PR DESCRIPTION
I was going through the (awesome) documentation and noticed some typos and a few inconsistencies.

This is a small PR to address some of those.

It appears the ~`TargetVerifier`~ `IterativeVerifier` is deprecated, and not referenced within the main section of `Verifiers`. I've updated that part of the documentation to state there are two verifiers currently supported.