### PR TITLE
Add estimated row batch size in bytes to state

### DIFF
--- a/batch_writer.go
+++ b/batch_writer.go
@@ -107,7 +107,7 @@ func (w *BatchWriter) WriteRowBatch(batch *RowBatch) error {
 			if w.EnforceInlineVerification {
 				// This code should only be active if the InlineVerifier background
 				// reverification is not occuring. An example of this would be when you
-				// run the BatchWriter as a part of copying the primary table or delta
+				// run the BatchWriter as a part of copying the primary table or the delta
 				// copying the joined table.
 				if len(mismatches) > 0 {
 					tx.Rollback()

--- a/batch_writer.go
+++ b/batch_writer.go
@@ -123,7 +123,7 @@ func (w *BatchWriter) WriteRowBatch(batch *RowBatch) error {
 		// Note that the state tracker expects us the track based on the original
 		// database and table names as opposed to the target ones.
 		if w.StateTracker != nil {
-			w.StateTracker.UpdateLastSuccessfulPaginationKey(batch.TableSchema().String(), endPaginationKeypos, uint64(batch.Size()))
+			w.StateTracker.UpdateLastSuccessfulPaginationKey(batch.TableSchema().String(), endPaginationKeypos, uint64(batch.Size()), batch.EstimateByteSize())
 		}
 
 		return nil

--- a/config.go
+++ b/config.go
@@ -700,7 +700,7 @@ type Config struct {
 	//
 	// Required: defaults to false
 	SkipTargetVerification bool
-	//
+
 	// During initialization, Ghostferry will raise an error if any
 	// foreign key constraints are detected in the source database.
 	//
@@ -712,6 +712,11 @@ type Config struct {
 	//
 	// Required: defaults to false
 	SkipForeignKeyConstraintsCheck bool
+
+	// EnableRowBatchsize is used to enable or disable the calculation of number of bytes written for each row batch.
+	//
+	// Optional: Defaults to false.
+	EnableRowBatchSize bool
 }
 
 func (c *Config) ValidateConfig() error {

--- a/config.go
+++ b/config.go
@@ -716,6 +716,11 @@ type Config struct {
 	// EnableRowBatchsize is used to enable or disable the calculation of number of bytes written for each row batch.
 	//
 	// Optional: Defaults to false.
+	//
+	// NOTE:
+	// Turning off the EnableRowBatchSize flag would show the NumBytes written per RowBatch to be zero
+	// in the Progress. This behaviour is perfectly okay and doesn't mean there are no rows being written
+	// to the target DB.
 	EnableRowBatchSize bool
 }
 

--- a/cursor.go
+++ b/cursor.go
@@ -79,7 +79,6 @@ type Cursor struct {
 
 	paginationKeyColumn         *schema.TableColumn
 	lastSuccessfulPaginationKey uint64
-	rowsExamined                uint64
 	logger                      *logrus.Entry
 }
 
@@ -152,7 +151,6 @@ func (c *Cursor) Each(f func(*RowBatch) error) error {
 		tx.Rollback()
 
 		c.lastSuccessfulPaginationKey = paginationKeypos
-		c.rowsExamined += uint64(batch.Size())
 	}
 
 	return nil

--- a/ferry.go
+++ b/ferry.go
@@ -193,7 +193,8 @@ func (f *Ferry) NewBatchWriter() *BatchWriter {
 		DatabaseRewrites: f.Config.DatabaseRewrites,
 		TableRewrites:    f.Config.TableRewrites,
 
-		WriteRetries: f.Config.DBWriteRetries,
+		WriteRetries:       f.Config.DBWriteRetries,
+		enableRowBatchSize: f.Config.EnableRowBatchSize,
 	}
 
 	batchWriter.Initialize()

--- a/ferry.go
+++ b/ferry.go
@@ -898,7 +898,7 @@ func (f *Ferry) Progress() *Progress {
 	serializedState := f.StateTracker.Serialize(nil, nil)
 	// Note the below will not necessarily be synchronized with serializedState.
 	// This is fine as we don't need to be super precise with performance data.
-	rowsWrittenPerTable := f.StateTracker.RowsWrittenPerTable()
+	rowStatsWrittenPerTable := f.StateTracker.RowStatsWrittenPerTable()
 
 	s.Tables = make(map[string]TableProgress)
 	targetPaginationKeys := make(map[string]uint64)
@@ -928,14 +928,15 @@ func (f *Ferry) Progress() *Progress {
 			currentAction = TableActionWaiting
 		}
 
-		rowsWritten, _ := rowsWrittenPerTable[tableName]
+		rowWrittenStats, _ := rowStatsWrittenPerTable[tableName]
 
 		s.Tables[tableName] = TableProgress{
 			LastSuccessfulPaginationKey: lastSuccessfulPaginationKey,
 			TargetPaginationKey:         targetPaginationKeys[tableName],
 			CurrentAction:               currentAction,
-			RowsWritten:                 rowsWritten,
 			BatchSize:                   f.DataIterator.CursorConfig.GetBatchSize(table.Schema, table.Name),
+			RowsWritten:                 rowWrittenStats.NumRows,
+			BytesWritten:                rowWrittenStats.NumBytes,
 		}
 	}
 

--- a/progress.go
+++ b/progress.go
@@ -16,6 +16,7 @@ type TableProgress struct {
 	CurrentAction               string // Possible values are defined via the constants TableAction*
 	RowsWritten                 uint64
 	BatchSize                   uint64
+	BytesWritten                uint64
 }
 
 type Progress struct {

--- a/row_batch.go
+++ b/row_batch.go
@@ -2,6 +2,7 @@ package ghostferry
 
 import (
 	"strings"
+	"encoding/json"
 )
 
 type RowBatch struct {
@@ -21,6 +22,19 @@ func NewRowBatch(table *TableSchema, values []RowData, paginationKeyIndex int) *
 
 func (e *RowBatch) Values() []RowData {
 	return e.values
+}
+
+func (e *RowBatch) EstimateByteSize() uint64 {
+	var total int
+	for _, v := range e.values {
+		size, err := json.Marshal(v)
+		if err != nil {
+			continue
+		}
+		total += len(size)
+	}
+
+	return uint64(total)
 }
 
 func (e *RowBatch) PaginationKeyIndex() int {

--- a/test/go/row_batch_test.go
+++ b/test/go/row_batch_test.go
@@ -108,6 +108,17 @@ func (this *RowBatchTestSuite) TestRowBatchNoPaginationKeyIndex() {
 	this.Require().Equal(false, batch.ValuesContainPaginationKey())
 }
 
+func (this *RowBatchTestSuite) TestEstimateBytesSize() {
+	vals := []ghostferry.RowData{
+		ghostferry.RowData{make([]byte, 100)},
+		ghostferry.RowData{make([]byte, 100)},
+	}
+
+	batch := ghostferry.NewRowBatch(this.sourceTable, vals, 0)
+
+	this.Require().GreaterOrEqual(batch.EstimateByteSize(), uint64(200), "estimated batch size should be greater then 200")
+}
+
 func TestRowBatchTestSuite(t *testing.T) {
 	suite.Run(t, new(RowBatchTestSuite))
 }

--- a/test/integration/callbacks_test.rb
+++ b/test/integration/callbacks_test.rb
@@ -4,7 +4,7 @@ class CallbacksTest < GhostferryTestCase
   def test_progress_callback
     seed_simple_database_with_single_table
 
-    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline" })
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline"})
     progress = []
     ghostferry.on_callback("progress") do |progress_data|
       progress << progress_data

--- a/test/integration/callbacks_test.rb
+++ b/test/integration/callbacks_test.rb
@@ -25,6 +25,9 @@ class CallbacksTest < GhostferryTestCase
     assert count > 0, "There should be some rows on the target, not 0."
     assert_equal count, progress.last["Tables"]["gftest.test_table_1"]["RowsWritten"]
 
+    # data column is 32 characters so each row should be at least 32 bytes
+    assert count * 32 < progress.last["Tables"]["gftest.test_table_1"]["BytesWritten"], "Each row should have more than 32 bytes"
+
     assert_equal 0, progress.last["ActiveDataIterators"]
 
     refute progress.last["LastSuccessfulBinlogPos"]["Name"].nil?

--- a/test/lib/go/integrationferry.go
+++ b/test/lib/go/integrationferry.go
@@ -204,6 +204,7 @@ func NewStandardConfig() (*ghostferry.Config, error) {
 
 		DumpStateOnSignal:      true,
 		SkipTargetVerification: (os.Getenv("GHOSTFERRY_SKIP_TARGET_VERIFICATION") == "true"),
+		EnableRowBatchSize:     true,
 	}
 
 	integrationPort := os.Getenv(portEnvName)


### PR DESCRIPTION
Related: https://github.com/Shopify/ghostferry/issues/226 

Similar PR: https://github.com/Shopify/ghostferry/pull/228 

Add an estimate of number of bytes for each row batch and sending it with the `progress` callback