### PR TITLE
Assert presence of docker-compose on dev up

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,13 @@ https://shopify.github.io/ghostferry/master/technicaloverview.html
 Development Setup
 -----------------
 
-Install:
+### Installation
+
+#### For Internal Contributors
+
+`dev up`
+
+#### For External Contributors
 
 - Have Docker installed
 - Clone the repo

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Talk to us on IRC at [irc.freenode.net #ghostferry](https://webchat.freenode.net
 Overview of How it Works
 ------------------------
 
-An overview of Ghostferry's high-level design is expressed in the TLA+
-specification, under the `tlaplus` directory. It maybe good to consult with
+An overview of Ghostferry's high-level design is expressed in the [TLA+
+specification](https://en.wikipedia.org/wiki/TLA%2B), under the `tlaplus` directory. It may be good to consult with
 that as it has a concise definition. However, the specification might not be
 entirely correct as proofs remain elusive.
 
@@ -44,18 +44,20 @@ Development Setup
 - Clone the repo
 - `docker-compose up -d mysql-1 mysql-2`
 
-Run tests:
+Testing
+---------------
+
+#### Run all tests
 
 - `make test`
 
-Test copydb:
+#### Run example copydb usage
 
 - `make copydb && ghostferry-copydb -verbose examples/copydb/conf.json`
 - For a more detailed tutorial, see the
   [documentation](https://shopify.github.io/ghostferry).
 
-Ruby Integration Tests
-----
+### Ruby Integration Tests
 
 Kindly take note of following options:
 *   `DEBUG=1`: To see more detailed debug output by `Ghostferry`

--- a/dev.yml
+++ b/dev.yml
@@ -9,8 +9,11 @@ up:
       version: 1.14.1
   - custom:
       name: Docker for Mac
-      met?: test -e /Applications/Docker.app
-      meet: echo "Docker not found. Install from https://docs.docker.com/docker-for-mac/"; false
+      met?: test -e /Applications/Docker.app && which docker-compose
+      meet: |
+        echo "Docker.app not found." ;
+        echo "Download Docker Desktop from https://docs.docker.com/docker-for-mac/install.\nInstallation includes necessary dependencies (ie. docker-compose)";
+        open "https://docs.docker.com/docker-for-mac/install" ;
   - custom:
       name: Go Dependencies
       met?: go mod download


### PR DESCRIPTION
For internal contributors, let's assert `docker-compose` is present in the `dev up` pipeline. On my machine, `Docker.app` was present but `Docker`, and its related tooling, wasn't yet installed. 

Let's strengthen the `met?` condition by asserting `which docker-compose` returns a non-error status code.

I also made some small additions to the README.