### PR TITLE
Report progress before cutover begins

### DIFF
--- a/ferry.go
+++ b/ferry.go
@@ -717,6 +717,9 @@ func (f *Ferry) Run() {
 
 	f.logger.Info("entering cutover phase, notifying caller that row copy is complete")
 	f.OverallState.Store(StateCutover)
+	if f.Config.ProgressCallback.URI != "" {
+		f.ReportProgress()
+	}
 	f.notifyRowCopyComplete()
 
 	binlogWg.Wait()

--- a/test/integration/callbacks_test.rb
+++ b/test/integration/callbacks_test.rb
@@ -42,6 +42,57 @@ class CallbacksTest < GhostferryTestCase
     assert progress.last["TimeTaken"] > 0
   end
 
+  def test_progress_callback_triggered_at_beginning_of_cutover_phase
+    # It's possible that during the cutover phase, a client of the Ghostferry library terminates.
+    # We report progress before entering this phase.
+    # This tests the case when the process exits before the last progress report.
+    seed_simple_database_with_single_table
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline" })
+
+    # Simulate a bad actor: the Ferry wrapper process fails after row copy completion.
+    ghostferry.on_status(Ghostferry::Status::ROW_COPY_COMPLETED) do
+      ghostferry.kill_and_wait_for_exit
+    end
+
+
+    progress = []
+    ghostferry.on_callback("progress") do |progress_data|
+      progress << progress_data
+    end
+
+    ghostferry.run_expecting_failure
+
+    assert progress.length >= 1
+
+    assert_equal "cutover", progress.last["CurrentState"]
+
+    assert_equal 1111, progress.last["Tables"]["gftest.test_table_1"]["LastSuccessfulPaginationKey"]
+    assert_equal 1111, progress.last["Tables"]["gftest.test_table_1"]["TargetPaginationKey"]
+    assert_equal "completed", progress.last["Tables"]["gftest.test_table_1"]["CurrentAction"]
+
+    result = target_db.query("SELECT COUNT(*) AS cnt FROM #{DEFAULT_FULL_TABLE_NAME}")
+    count = result.first["cnt"]
+    assert count > 0, "There should be some rows on the target, not 0."
+    assert_equal count, progress.last["Tables"]["gftest.test_table_1"]["RowsWritten"]
+
+    assert_equal 0, progress.last["ActiveDataIterators"]
+
+    # Note: we can't know the exact below positions, so we only refute they are empty
+    refute progress.last["LastSuccessfulBinlogPos"]["Name"].nil?
+    refute progress.last["LastSuccessfulBinlogPos"]["Pos"].nil?
+    assert progress.last["BinlogStreamerLag"] > 0
+
+
+    assert progress.last["VerifierMessage"].include?("currentRowCount =")
+    assert progress.last["VerifierMessage"].include?("currentEntryCount =")
+
+    assert_equal false, progress.last["Throttled"]
+
+    refute progress.last["PaginationKeysPerSecond"].nil?
+    refute progress.last["ETA"].nil?
+    assert progress.last["TimeTaken"] > 0
+  end
+
   def test_state_callback
     seed_simple_database_with_single_table
 


### PR DESCRIPTION
Closes #232

#### What was done?

This PR helps ensure progress is reported before beginning cutover.

Ghostferry, as a library, can't enforce or ensure that clients don't terminate/error-out during cutover. Custom code leaves this as a possibility.

Before notifying clients that row copy is complete, we should dispatch a progress callback. 

This conditional change comes before the notification (`notifyRowCopyCompletion`), to avoid any possible race conditions. If the notification of row completion occurs first, the client (ex: `copydb`, `sharding`) could execute, and possibly fail, before the progress callback is emitted.

---

#### Testing

I've add an integration test for this specific use case. Namely, simulate a Ghostferry client that is killed after row copy complete has finished.

Assertions are put in place to now make sure that – even in this case – progress is reported.

I've manually tested it out as well.