### PR TITLE
Added binlog verify store entry count

### DIFF
--- a/inline_verifier.go
+++ b/inline_verifier.go
@@ -67,6 +67,17 @@ func (s BinlogVerifySerializedStore) RowCount() uint64 {
 	return v
 }
 
+func (s BinlogVerifySerializedStore) EntriesCount() uint64 {
+	var v uint64 = 0
+	for _, dbStore := range s {
+		for _, tableStore := range dbStore {
+			v += uint64(len(tableStore))
+		}
+	}
+
+	return v
+}
+
 func (s BinlogVerifySerializedStore) Copy() BinlogVerifySerializedStore {
 	copyS := make(BinlogVerifySerializedStore)
 
@@ -209,6 +220,12 @@ func (s *BinlogVerifyStore) CurrentRowCount() uint64 {
 	return s.currentRowCount
 }
 
+func (s *BinlogVerifyStore) CurrentEntriesCount() uint64 {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return s.store.EntriesCount()
+}
+
 func (s *BinlogVerifyStore) Serialize() BinlogVerifySerializedStore {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
@@ -280,7 +297,7 @@ func (v *InlineVerifier) Wait() {
 }
 
 func (v *InlineVerifier) Message() string {
-	return fmt.Sprintf("BinlogVerifyStore.currentRowCount = %d", v.reverifyStore.CurrentRowCount())
+	return fmt.Sprintf("currentRowCount = %d, currentEntryCount = %d", v.reverifyStore.CurrentRowCount(), v.reverifyStore.CurrentEntriesCount())
 }
 
 func (v *InlineVerifier) Result() (VerificationResultAndStatus, error) {

--- a/test/integration/callbacks_test.rb
+++ b/test/integration/callbacks_test.rb
@@ -32,7 +32,8 @@ class CallbacksTest < GhostferryTestCase
     assert progress.last["BinlogStreamerLag"] > 0
     assert_equal progress.last["LastSuccessfulBinlogPos"], progress.last["FinalBinlogPos"]
 
-    assert progress.last["VerifierMessage"].start_with?("BinlogVerifyStore.currentRowCount =")
+    assert progress.last["VerifierMessage"].include?("currentRowCount =")
+    assert progress.last["VerifierMessage"].include?("currentEntryCount =")
 
     assert_equal false, progress.last["Throttled"]
 


### PR DESCRIPTION
The currentRowCount emitted before can count the same row multiple times, which does not allow for a great estimate of how big the state dump could be. With this patch, we emit both the row count (which is maybe useful to estimate how long it would take to reverify) and the entries count (which is useful to estimate how big the statedump is) in the VerifierMessage that's dumped to the progress, which will allow us to estimate the size of the state dump.

Fixes #234 