### PR TITLE
Reset database state after test suite runs

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -91,12 +91,14 @@ class GhostferryTestCase < Minitest::Test
   ##############
 
   def before_all
+    super
     @log_capturer = LogCapturer.new
     initialize_db_connections
     setup_signal_watcher
   end
 
   def before_setup
+    super
     reset_data
 
     # Any ghostferry instances created via the new_ghostferry method will be
@@ -119,6 +121,7 @@ class GhostferryTestCase < Minitest::Test
 
     @log_capturer.print_output if self.failure
     @log_capturer.reset
+    super
   end
 
   def on_term
@@ -127,7 +130,9 @@ class GhostferryTestCase < Minitest::Test
   end
 
   def after_all
+    reset_data
     teardown_connections
+    super
   end
 
   #####################


### PR DESCRIPTION
We prescribe using two MySQL instances in the [follow-along docs/tutorial](https://github.com/Shopify/ghostferry/blob/master/docs/source/tutorialcopydb.rst). We also use the same database instances for [running the test suite.](https://github.com/Shopify/ghostferry/blob/master/test/helpers/db_helper.rb#L6)

This left me in an interesting state. After running the test suite, and then later following along with the tutorial, my databases were pre-seeded.

This PR ensures that we clear test state after each the suite completes. I don't have particularly strong feelings on doing this, so I'm open to hear reasons against dropping state before and after every _test suite run_ (note: not every _test_ run). 

This PR also calls super in the `before_*` and `after_*` setup/teardown methods as [prescribed in the docs.](https://github.com/jeremyevans/minitest-hooks#in-tests-minitesttest-)