### PR TITLE
Dynamically calculate batch size per table

### DIFF
--- a/config.go
+++ b/config.go
@@ -442,7 +442,7 @@ func (d *DataIterationBatchSizePerTableOverride) UpdateBatchSizes(db *sql.DB, ta
 			// MySQL has an upper limit of 2^16 for num_params for prepared statements. This will cause an error when
 			// we attempt to execute a INSERT statement with > 65535 parameters.
 			// If batchSize > 65535/num_columns, we will use 65535/num_columns
-			batchSize := d.calculateBatchSize(avgRowLength)
+			batchSize := d.CalculateBatchSize(avgRowLength)
 			if batchSize >= maxBatchSize {
 				batchSize = maxBatchSize
 			}
@@ -453,7 +453,7 @@ func (d *DataIterationBatchSizePerTableOverride) UpdateBatchSizes(db *sql.DB, ta
 	return nil
 }
 
-func (d *DataIterationBatchSizePerTableOverride) calculateBatchSize(rowSize int) int {
+func (d *DataIterationBatchSizePerTableOverride) CalculateBatchSize(rowSize int) int {
 	if batchSize, found := d.ControlPoints[rowSize]; found {
 		return int(batchSize)
 	}

--- a/config.go
+++ b/config.go
@@ -376,11 +376,11 @@ func (c *CascadingPaginationColumnConfig) FallbackPaginationColumnName() (string
 }
 
 type DataIterationBatchSizePerTableOverride struct {
-	// Lower limit for rowLength, if a rowLength <= MinAvgRowLength, ControlPoints[MinAvgRowLength] will be used
-	MinAvgRowLength int
-	// Upper limit for rowLength, if a rowLength >= MaxAvgRowLength, ControlPoints[MaxAvgRowLength] will be used
-	MaxAvgRowLength int
-	// Map of rowLength => batchSize used to calculate batchSize for new rowLengths, results stored in TableOverride
+	// Lower limit for rowSize, if a rowSize <= MinRowSize, ControlPoints[MinRowSize] will be used
+	MinRowSize int
+	// Upper limit for rowSize, if a rowSize >= MaxRowSize, ControlPoints[MaxRowSize] will be used
+	MaxRowSize int
+	// Map of rowSize  => batchSize used to calculate batchSize for new rowSizes, results stored in TableOverride
 	ControlPoints map[int]uint64
 	// Map of schemaName(source schema) => tableName => batchSize to override default values for certain tables
 	TableOverride map[string]map[string]uint64
@@ -388,16 +388,15 @@ type DataIterationBatchSizePerTableOverride struct {
 
 func (d *DataIterationBatchSizePerTableOverride) Validate() error {
 	if d != nil {
-		if _, found := d.ControlPoints[d.MinAvgRowLength]; !found {
-			return fmt.Errorf("must provide batch size for MinAvgRowLength")
+		if _, found := d.ControlPoints[d.MinRowSize]; !found {
+			return fmt.Errorf("must provide batch size for MinRowSize")
 		}
-		if _, found := d.ControlPoints[d.MaxAvgRowLength]; !found {
-			return fmt.Errorf("must provide batch size for MaxAvgRowLength")
+		if _, found := d.ControlPoints[d.MaxRowSize]; !found {
+			return fmt.Errorf("must provide batch size for MaxRowSize")
 		}
 		if d.TableOverride == nil {
 			d.TableOverride = map[string]map[string]uint64{}
 		}
-
 	}
 	return nil
 }
@@ -470,7 +469,6 @@ type Config struct {
 	//
 	// Optional: defaults to 200
 	DataIterationBatchSize uint64
-	// Optional: Data Points to dynamically calculate batch size
 
 	// This optional config uses different data points to calculate
 	// batch size per table using linear interpolation

--- a/cursor.go
+++ b/cursor.go
@@ -62,7 +62,7 @@ func (c *CursorConfig) NewCursorWithoutRowLock(table *TableSchema, startPaginati
 }
 
 func (c CursorConfig) GetBatchSize(schemaName string, tableName string) uint64 {
-	if c.BatchSizePerTableOverride != nil{
+	if c.BatchSizePerTableOverride != nil {
 		if batchSize, found := c.BatchSizePerTableOverride.TableOverride[schemaName][tableName]; found {
 			return batchSize
 		}

--- a/cursor.go
+++ b/cursor.go
@@ -39,7 +39,7 @@ type CursorConfig struct {
 	ColumnsToSelect           []string
 	BuildSelect               func([]string, *TableSchema, uint64, uint64) (squirrel.SelectBuilder, error)
 	BatchSize                 uint64
-	BatchSizePerTableOverride map[string]map[string]uint64
+	BatchSizePerTableOverride *DataIterationBatchSizePerTableOverride
 	ReadRetries               int
 }
 
@@ -62,8 +62,10 @@ func (c *CursorConfig) NewCursorWithoutRowLock(table *TableSchema, startPaginati
 }
 
 func (c CursorConfig) GetBatchSize(schemaName string, tableName string) uint64 {
-	if batchSize, found := c.BatchSizePerTableOverride[schemaName][tableName]; found {
-		return batchSize
+	if c.BatchSizePerTableOverride != nil{
+		if batchSize, found := c.BatchSizePerTableOverride.TableOverride[schemaName][tableName]; found {
+			return batchSize
+		}
 	}
 	return c.BatchSize
 }

--- a/progress.go
+++ b/progress.go
@@ -15,6 +15,7 @@ type TableProgress struct {
 	TargetPaginationKey         uint64
 	CurrentAction               string // Possible values are defined via the constants TableAction*
 	RowsWritten                 uint64
+	BatchSize                   uint64
 }
 
 type Progress struct {

--- a/test/go/data_iterator_test.go
+++ b/test/go/data_iterator_test.go
@@ -179,7 +179,7 @@ func (this *DataIteratorTestSuite) TestDataIterationBatchSizePerTableOverride() 
 		},
 		TableOverride: map[string]map[string]uint64{},
 	}
-	err := this.Ferry.UpdateBatchSizes()
+	err := this.Ferry.DataIterationBatchSizePerTableOverride.UpdateBatchSizes(this.Ferry.SourceDB, this.Ferry.Tables)
 	this.di.CursorConfig.BatchSizePerTableOverride = this.Ferry.DataIterationBatchSizePerTableOverride
 	this.Require().Nil(err)
 
@@ -201,7 +201,7 @@ func (this *DataIteratorTestSuite) TestDataIterationBatchSizePerTableOverrideMin
 		},
 		TableOverride: map[string]map[string]uint64{},
 	}
-	err := this.Ferry.UpdateBatchSizes()
+	err := this.Ferry.DataIterationBatchSizePerTableOverride.UpdateBatchSizes(this.Ferry.SourceDB, this.Ferry.Tables)
 	this.di.CursorConfig.BatchSizePerTableOverride = this.Ferry.DataIterationBatchSizePerTableOverride
 	this.Require().Nil(err)
 
@@ -217,12 +217,12 @@ func (this *DataIteratorTestSuite) TestDataIterationBatchSizePerTableOverrideMax
 		MinRowSize: 1000,
 		MaxRowSize: 3000,
 		ControlPoints: map[int]uint64{
-			1000:  5000,
-			3000:  4000,
+			1000: 5000,
+			3000: 4000,
 		},
 		TableOverride: map[string]map[string]uint64{},
 	}
-	err := this.Ferry.UpdateBatchSizes()
+	err := this.Ferry.DataIterationBatchSizePerTableOverride.UpdateBatchSizes(this.Ferry.SourceDB, this.Ferry.Tables)
 	this.di.CursorConfig.BatchSizePerTableOverride = this.Ferry.DataIterationBatchSizePerTableOverride
 	this.Require().Nil(err)
 

--- a/test/go/data_iterator_test.go
+++ b/test/go/data_iterator_test.go
@@ -233,6 +233,37 @@ func (this *DataIteratorTestSuite) TestDataIterationBatchSizePerTableOverrideMax
 	}
 }
 
+func (this *DataIteratorTestSuite) TestDataIterationBatchSizePerTableOverrideCalculateBatchSize() {
+	this.Ferry.DataIterationBatchSizePerTableOverride = &ghostferry.DataIterationBatchSizePerTableOverride{
+		MinRowSize: 100,
+		MaxRowSize: 10000,
+		ControlPoints: map[int]uint64{
+			100:   2000,
+			10000: 200,
+		},
+		TableOverride: map[string]map[string]uint64{},
+	}
+
+	expectedResults := map[int]int{
+		1:     2000,
+		100:   2000,
+		200:   1981,
+		500:   1927,
+		1000:  1836,
+		2000:  1654,
+		3500:  1381,
+		5000:  1108,
+		10000: 200,
+		15000: 200,
+		20000: 200,
+	}
+
+	for rowSize, expectedBatchSize := range expectedResults {
+		batchSize := this.Ferry.DataIterationBatchSizePerTableOverride.CalculateBatchSize(rowSize)
+		this.Require().Equal(batchSize, expectedBatchSize)
+	}
+}
+
 func TestDataIterator(t *testing.T) {
 	testhelpers.SetupTest()
 	suite.Run(t, &DataIteratorTestSuite{GhostferryUnitTestSuite: &testhelpers.GhostferryUnitTestSuite{}})


### PR DESCRIPTION
This PR adds the ability to dynamically calculate the batch size using linear interpolation for all tables
Added a new `DataIterationBatchSizePerTableOverride` struct to the config 
For example, we can pass this into the config
```
{
  MinAvgRowLength: 200
  MaxAvgRowLength: 10000
  ControlPoints: {
    200:  5000,
    10000: 200,
    3000:  4000,
    4000:  3500,
    5000:  3000,
  }
}

Optionally, we can also pass in a set batch size for a given table if we don't want to calculate it for that specific table
{
  MinAvgRowLength: 200
  MaxAvgRowLength: 10000
  ControlPoints: {
    200:  5000,
    10000: 200,
    3000:  4000,
    4000:  3500,
    5000:  3000,
  }
  TableOverride : {
    "SchemaA": {
      "TableA": 200
    }
  }
}
```
For a table with `avg_row_length` of 3500, we would use the data points `3000` and `4000` to evaluate the batch size of `3750`

MySQL has an [upper limit](https://github.com/mysql/mysql-server/blob/5.7/sql/sql_prepare.cc#L2061-L2066) for [`num_params`](https://dev.mysql.com/doc/internals/en/com-stmt-prepare-response.html#packet-COM_STMT_PREPARE_OK) of `65536` for prepared statements which can cause problems [when we execute the constructed insert query](https://github.com/Shopify/ghostferry/blob/master/row_batch.go#L46-L61). if the calculated `batch size` > `65535/num_columns` we will use `65535/num_columns`

