### PR TITLE
Log when resuming from state

### DIFF
--- a/ferry.go
+++ b/ferry.go
@@ -415,6 +415,11 @@ func (f *Ferry) Initialize() (err error) {
 	if f.StateToResumeFrom == nil {
 		f.StateTracker = NewStateTracker(f.DataIterationConcurrency * 10)
 	} else {
+		f.logger.WithFields(logrus.Fields{
+			"LastWrittenBinlogPosition":                 f.StateToResumeFrom.LastWrittenBinlogPosition,
+			"LastStoredBinlogPositionForInlineVerifier": f.StateToResumeFrom.LastStoredBinlogPositionForInlineVerifier,
+			"LastStoredBinlogPositionForTargetVerifier": f.StateToResumeFrom.LastStoredBinlogPositionForTargetVerifier,
+		}).Info("resuming from state")
 		f.StateTracker = NewStateTrackerFromSerializedState(f.DataIterationConcurrency*10, f.StateToResumeFrom)
 	}
 


### PR DESCRIPTION
We currently don't log anything when resuming from state. This PR will add a log line and the MySQL positions. I'm not logging out any table positions nor schemas since this data might be very large at times.

~~Also found a state tracker init from state bug.~~

Edit: Moved the state tracker bug to a separate PR since it seems to be a bigger issue.