### PR TITLE
Set lastStoredBinlogPositionForTargetVerifier correctly on resume

### DIFF
--- a/state_tracker.go
+++ b/state_tracker.go
@@ -116,7 +116,7 @@ func NewStateTrackerFromSerializedState(speedLogCount int, serializedState *Seri
 	s.completedTables = serializedState.CompletedTables
 	s.lastWrittenBinlogPosition = serializedState.LastWrittenBinlogPosition
 	s.lastStoredBinlogPositionForInlineVerifier = serializedState.LastStoredBinlogPositionForInlineVerifier
-	s.lastStoredBinlogPositionForTargetVerifier = serializedState.LastStoredBinlogPositionForInlineVerifier
+	s.lastStoredBinlogPositionForTargetVerifier = serializedState.LastStoredBinlogPositionForTargetVerifier
 	return s
 }
 


### PR DESCRIPTION
When resuming from a state dump we accidentally initiated the state tracker's `lastStoredBinlogPositionForTargetVerifier` with the inline verifiers binlog position. This means that until an event is received on the target binlog streamer, we will report a corrupted state. Once an event is received, the value will auto-correct.