### PR TITLE
Enforce foreign key constraints are not present during initialization

### DIFF
--- a/config.go
+++ b/config.go
@@ -700,6 +700,18 @@ type Config struct {
 	//
 	// Required: defaults to false
 	SkipTargetVerification bool
+	//
+	// During initialization, Ghostferry will raise an error if any
+	// foreign key constraints are detected in the source database.
+	//
+	// This check can be bypassed by setting this value to true.
+	//
+	// WARNING:
+	// Using Ghostferry with foreign keys is highly discouraged and
+	// disabling this check makes no guarantees of the success of the run.
+	//
+	// Required: defaults to false
+	SkipForeignKeyConstraintsCheck bool
 }
 
 func (c *Config) ValidateConfig() error {

--- a/copydb/config.go
+++ b/copydb/config.go
@@ -50,6 +50,8 @@ type Config struct {
 	// If a table is to be created on start and appears in this list, it is
 	// created before any other table, and is created in the order listed here.
 	// All tables not specified in this list are created in arbitrary order.
+	//
+	// Note: if used to overcome foreign key restrictions, ensure SkipForeignKeyConstraintsCheck is true.
 	TablesToBeCreatedFirst []string
 
 	// If you're running Ghostferry from a read only replica, turn this option

--- a/ferry.go
+++ b/ferry.go
@@ -443,6 +443,15 @@ func (f *Ferry) Initialize() (err error) {
 		f.Tables = f.StateToResumeFrom.LastKnownTableSchemaCache
 	}
 
+	if !f.Config.SkipForeignKeyConstraintsCheck {
+		err = f.checkSourceForeignKeyConstraints()
+
+		if err != nil {
+			f.logger.WithError(err).Error("foreign key constraints detected on the source database. Enable SkipForeignKeyConstraintsCheck to ignore this check and allow foreign keys")
+			return err
+		}
+	}
+
 	if f.Config.DataIterationBatchSizePerTableOverride != nil {
 		err = f.Config.DataIterationBatchSizePerTableOverride.UpdateBatchSizes(f.SourceDB, f.Tables)
 		if err != nil {
@@ -1033,6 +1042,42 @@ func (f *Ferry) checkConnectionForBinlogFormat(db *sql.DB) error {
 		}
 		if strings.ToUpper(value) != "ON" {
 			return fmt.Errorf("binlog_rows_query_log_events must be ON, not %s", value)
+		}
+	}
+
+	return nil
+}
+
+func (f *Ferry) checkSourceForeignKeyConstraints() error {
+	for _, table := range f.Tables {
+		query := fmt.Sprintf(`
+		SELECT COUNT(*), constraint_name
+		FROM information_schema.table_constraints
+		WHERE constraint_type = 'FOREIGN KEY'
+		AND table_schema='%s'
+		AND table_name='%s'
+		GROUP BY constraint_name
+		`,
+			table.Schema,
+			table.Name,
+		)
+
+		rows, err := f.SourceDB.Query(query)
+		defer rows.Close()
+
+		var count int
+		var name string
+
+		for rows.Next() {
+			err = rows.Scan(&count, &name)
+
+			if err != nil {
+				return err
+			}
+
+			if count > 0 {
+				return fmt.Errorf("found at least 1 foreign key constraint on source DB. table: %s.%s, constraint: %s", table.Schema, table.Name, name)
+			}
 		}
 	}
 

--- a/test/go/ferry_test.go
+++ b/test/go/ferry_test.go
@@ -18,11 +18,6 @@ func (t *FerryTestSuite) SetupTest() {
 	t.GhostferryUnitTestSuite.SetupTest()
 }
 
-func (t *FerryTestSuite) TearDownTest() {
-	_, err := t.Ferry.TargetDB.Exec("SET GLOBAL read_only = OFF")
-	t.Require().Nil(err)
-}
-
 func (t *FerryTestSuite) TestReadOnlyDatabaseFailsInitialization() {
 	_, err := t.Ferry.TargetDB.Exec("SET GLOBAL read_only = ON")
 	t.Require().Nil(err)


### PR DESCRIPTION
Closes #3 

Ghostferry doesn't support copying tables with Foreign Key constraints. Currently, we let the Ghostferry run begin to eventually crash midway through the run.

We should enforce this decision by erroring out during initialization, instead.

This PR queries the `information_schemas` to determine if any `FOREIGN KEY` constraints exist on any of the tables that will be copied by the Ghostferry (namely those after filtering / that are applicable).

Clients of Ghostferry may want to skip the enforcement, therefore, we leave it as a configurable option.

One instance, for example, is #166. That PR allows the ability to configure a specific ordering on tables, intended to be used to circumvent FOREIGN KEY issues. In the case when `TablesToBeCreatedFirst ` is non-zero, the `SkipForeignKeyConstraintsCheck` is turned on.

#### Testing

To test this PR, one can do the following:

1. Setup ghostferry-copydb and the necessary MySQL instances (and their permissions) as [outlined in the tutorial.](https://shopify.github.io/ghostferry/master/tutorialcopydb.html)

2. Create a database and table on the source with a FOREIGN KEY.

```sql
DROP DATABASE IF EXISTS testfk;
CREATE DATABASE testfk;
CREATE TABLE IF NOT EXISTS testfk.t1 (
  id INTEGER AUTO_INCREMENT PRIMARY KEY,
  d1 VARCHAR(16)
);

CREATE TABLE IF NOT EXISTS testfk.t2 (
  id INTEGER AUTO_INCREMENT PRIMARY KEY,
  d2 VARCHAR(16),
  t1_id INTEGER,
  FOREIGN KEY (t1_id)
    REFERENCES t1(id)
);
```

3. Seed the database.
```sh
# seed.sh
if [ "$#" -ne 1 ]; then
  echo "Usage: seed.sh <n>"
  exit
fi

N=$1

for i in $(seq 1 $N); do
  echo "INSERT INTO testfk.t1 (id, d1) VALUES (${i}, '$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 16)');"
done

for i in $(seq 1 $N); do
  echo "INSERT INTO testfk.t2 (id, d2, t1_id) VALUES (${i}, '$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 16)', $(jot -r 1 1 $N));"
done

```

4. Run the ghostferry-copydb and observe the error printed during initialization.

```
DEBU[0000] loading tables from database                  database=testfk tag=table_schema_cache
DEBU[0000] fetching table schema                         database=testfk table=t1 tag=table_schema_cache
DEBU[0000] fetching table schema                         database=testfk table=t2 tag=table_schema_cache
DEBU[0000] caching table schema                          database=testfk table=t1 tag=table_schema_cache
DEBU[0000] caching table schema                          database=testfk table=t2 tag=table_schema_cache
INFO[0000] table schemas cached                          tables="[testfk.t1 testfk.t2]" tag=table_schema_cache
ERRO[0000] source contains foreign key constraints       error="source contains at least 1 foreign key constraint" tag=ferry
error: failed to initialize ferry: source contains at least 1 foreign key constraint
```





