### PR TITLE
allow checksumtable verification during cutover only when overallstat…

### DIFF
--- a/control_server.go
+++ b/control_server.go
@@ -241,8 +241,14 @@ func (this *ControlServer) fetchStatus() *ControlServerStatus {
 		status.VerificationStarted = result.IsStarted()
 		status.VerificationDone = result.IsDone()
 
-		// We can only run the verifier if we're not copying and not verifying
-		status.VerifierAvailable = status.OverallState != StateStarting && status.OverallState != StateCopying && (!status.VerificationStarted || status.VerificationDone)
+		// If the VerifierType is CheckSumTable we can only run the verifier when the we're done.
+		// For other verifiers we can run verification if we're not copying or verifying.
+		if this.F.Config.VerifierType == VerifierTypeChecksumTable {
+			status.VerifierAvailable = (status.OverallState == StateDone)
+		} else {
+			status.VerifierAvailable = status.OverallState != StateStarting && status.OverallState != StateCopying && (!status.VerificationStarted || status.VerificationDone)
+		}
+
 		status.VerificationResult = result.VerificationResult
 		status.VerificationErr = err
 	} else {

--- a/docs/source/tutorialcopydb.rst
+++ b/docs/source/tutorialcopydb.rst
@@ -234,11 +234,12 @@ to:
   allow external scripts (configured via the json configuration) to be
   automatically executed with the push of this button so you can perform
   operations you need to perform during cutover.
-- Run Verification: This button is only available during the Wait-For-Cutover
-  and Done phase of the move. It will run the ChecksumTable verifier we
-  specified earlier ensure the data are identical on the source and target. You
-  should only run this while the source is read only and when the target is not
-  yet written to.
+- Run Verification: This button is only available during the Done phase of the move 
+  if the VerifierType is ChecksumTable. For Verifiers other then ChecksumTable this 
+  button is available in Wait-For-Cutover and Done phase of the move. It will run 
+  the ChecksumTable verifier we specified earlier ensure the data are identical 
+  on the source and target. You should only run this while the source is read only 
+  and when the target is not yet written to.
 
 The page will refresh itself every 60 seconds.
 


### PR DESCRIPTION
Currently we allow running the verificaiton via webui if and only if ghostferry is in `wait-for-cutover` or `done` phase. We should not allow `ChecksumTable` verification if we're in the `wait-for-cutover` because `wait-for-cutover`  phase means that binlog-streamer is still running and neither source or target DB are read-only. Given that writes might be happening to source and target `ChecksumTable` verification will definetly fail. 

This PR makes the `ChecksumTable` verification available only if ghostferry is in `done` phase. 