### PR TITLE
Fix BinlogStreamer for TargetVerifier by correctly handling rewrites

### DIFF
--- a/binlog_streamer.go
+++ b/binlog_streamer.go
@@ -29,6 +29,11 @@ type BinlogStreamer struct {
 	binlogSyncer   *replication.BinlogSyncer
 	binlogStreamer *replication.BinlogStreamer
 
+	// These rewrite structures are used specifically for the Target
+	// Verifier as it needs to map events streamed from the Target back
+	// to the TableSchemaCache of the Source
+	//
+	// See https://github.com/Shopify/ghostferry/pull/258 for details
 	DatabaseRewrites map[string]string
 	TableRewrites    map[string]string
 

--- a/binlog_streamer.go
+++ b/binlog_streamer.go
@@ -29,6 +29,9 @@ type BinlogStreamer struct {
 	binlogSyncer   *replication.BinlogSyncer
 	binlogStreamer *replication.BinlogStreamer
 
+	DatabaseRewrites map[string]string
+	TableRewrites    map[string]string
+
 	lastStreamedBinlogPosition  mysql.Position
 	lastResumableBinlogPosition mysql.Position
 	stopAtBinlogPosition        mysql.Position
@@ -350,12 +353,22 @@ func (s *BinlogStreamer) handleRowsEvent(ev *replication.BinlogEvent, query []by
 		Pos:  ev.Header.LogPos,
 	}
 
-	table := s.TableSchema.Get(string(rowsEvent.Table.Schema), string(rowsEvent.Table.Table))
-	if table == nil {
+	db := string(rowsEvent.Table.Schema)
+	if rewrittenDBName, exists := s.DatabaseRewrites[db]; exists {
+		db = rewrittenDBName
+	}
+
+	table := string(rowsEvent.Table.Table)
+	if rewrittenTableName, exists := s.TableRewrites[table]; exists {
+		table = rewrittenTableName
+	}
+
+	tableFromSchemaCache := s.TableSchema.Get(db, table)
+	if tableFromSchemaCache == nil {
 		return nil
 	}
 
-	dmlEvs, err := NewBinlogDMLEvents(table, ev, pos, s.lastResumableBinlogPosition, query)
+	dmlEvs, err := NewBinlogDMLEvents(tableFromSchemaCache, ev, pos, s.lastResumableBinlogPosition, query)
 	if err != nil {
 		return err
 	}

--- a/ferry.go
+++ b/ferry.go
@@ -131,12 +131,12 @@ func (f *Ferry) NewSourceBinlogStreamer() *BinlogStreamer {
 }
 
 func (f *Ferry) NewTargetBinlogStreamer() (*BinlogStreamer, error) {
-	schemaRewrites, err := targetToSourceSchemaRewrites(f.Config.DatabaseRewrites)
+	schemaRewrites, err := TargetToSourceRewrites(f.Config.DatabaseRewrites)
 	if err != nil {
 		return nil, err
 	}
 
-	tableRewrites, err := targetToSourceTableRewrites(f.Config.TableRewrites)
+	tableRewrites, err := TargetToSourceRewrites(f.Config.TableRewrites)
 	if err != nil {
 		return nil, err
 	}

--- a/table_schema_cache.go
+++ b/table_schema_cache.go
@@ -304,30 +304,17 @@ func (c TableSchemaCache) Get(database, table string) *TableSchema {
 	return c[fullTableName(database, table)]
 }
 
-func targetToSourceSchemaRewrites(databaseRewrites map[string]string) (map[string]string, error) {
-	targetToSourceSchemaRewrites := make(map[string]string)
+func TargetToSourceRewrites(databaseRewrites map[string]string) (map[string]string, error) {
+	targetToSourceRewrites := make(map[string]string)
 
-	for sourceDB, targetDB := range databaseRewrites {
-		if _, exists := targetToSourceSchemaRewrites[targetDB]; exists {
-			return nil, errors.New("duplicate target to source schema rewrite detected")
+	for sourceVal, targetVal := range databaseRewrites {
+		if _, exists := targetToSourceRewrites[targetVal]; exists {
+			return nil, errors.New("duplicate target to source rewrite detected")
 		}
-		targetToSourceSchemaRewrites[targetDB] = sourceDB
+		targetToSourceRewrites[targetVal] = sourceVal
 	}
 
-	return targetToSourceSchemaRewrites, nil
-}
-
-func targetToSourceTableRewrites(tableRewrites map[string]string) (map[string]string, error) {
-	targetToSourceTableRewrites := make(map[string]string)
-
-	for sourceTable, targetTable := range tableRewrites {
-		if _, exists := targetToSourceTableRewrites[targetTable]; exists {
-			return nil, errors.New("duplicate target to source table rewrite detected")
-		}
-		targetToSourceTableRewrites[targetTable] = sourceTable
-	}
-
-	return targetToSourceTableRewrites, nil
+	return targetToSourceRewrites, nil
 }
 
 // Helper to sort a given map of tables with a second list giving a priority.

--- a/table_schema_cache.go
+++ b/table_schema_cache.go
@@ -2,6 +2,7 @@ package ghostferry
 
 import (
 	sqlorig "database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -303,24 +304,30 @@ func (c TableSchemaCache) Get(database, table string) *TableSchema {
 	return c[fullTableName(database, table)]
 }
 
-func targetToSourceSchemaRewrites(databaseRewrites map[string]string) map[string]string {
+func targetToSourceSchemaRewrites(databaseRewrites map[string]string) (map[string]string, error) {
 	targetToSourceSchemaRewrites := make(map[string]string)
 
 	for sourceDB, targetDB := range databaseRewrites {
+		if _, exists := targetToSourceSchemaRewrites[targetDB]; exists {
+			return nil, errors.New("duplicate target to source schema rewrite detected")
+		}
 		targetToSourceSchemaRewrites[targetDB] = sourceDB
 	}
 
-	return targetToSourceSchemaRewrites
+	return targetToSourceSchemaRewrites, nil
 }
 
-func targetToSourceTableRewrites(tableRewrites map[string]string) map[string]string {
+func targetToSourceTableRewrites(tableRewrites map[string]string) (map[string]string, error) {
 	targetToSourceTableRewrites := make(map[string]string)
 
 	for sourceTable, targetTable := range tableRewrites {
+		if _, exists := targetToSourceTableRewrites[targetTable]; exists {
+			return nil, errors.New("duplicate target to source table rewrite detected")
+		}
 		targetToSourceTableRewrites[targetTable] = sourceTable
 	}
 
-	return targetToSourceTableRewrites
+	return targetToSourceTableRewrites, nil
 }
 
 // Helper to sort a given map of tables with a second list giving a priority.

--- a/table_schema_cache.go
+++ b/table_schema_cache.go
@@ -3,8 +3,9 @@ package ghostferry
 import (
 	sqlorig "database/sql"
 	"fmt"
-	sql "github.com/Shopify/ghostferry/sqlwrapper"
 	"strings"
+
+	sql "github.com/Shopify/ghostferry/sqlwrapper"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/siddontang/go-mysql/schema"
@@ -300,6 +301,26 @@ func (c TableSchemaCache) AllTableNames() (tableNames []string) {
 
 func (c TableSchemaCache) Get(database, table string) *TableSchema {
 	return c[fullTableName(database, table)]
+}
+
+func targetToSourceSchemaRewrites(databaseRewrites map[string]string) map[string]string {
+	targetToSourceSchemaRewrites := make(map[string]string)
+
+	for sourceDB, targetDB := range databaseRewrites {
+		targetToSourceSchemaRewrites[targetDB] = sourceDB
+	}
+
+	return targetToSourceSchemaRewrites
+}
+
+func targetToSourceTableRewrites(tableRewrites map[string]string) map[string]string {
+	targetToSourceTableRewrites := make(map[string]string)
+
+	for sourceTable, targetTable := range tableRewrites {
+		targetToSourceTableRewrites[targetTable] = sourceTable
+	}
+
+	return targetToSourceTableRewrites
 }
 
 // Helper to sort a given map of tables with a second list giving a priority.

--- a/test/go/table_schema_cache_test.go
+++ b/test/go/table_schema_cache_test.go
@@ -427,7 +427,7 @@ func (this *TableSchemaCacheTestSuite) TestGetTableListWithPriorityIgnoreUnknown
 	this.Require().Equal(creationOrder[0], "schema.table2")
 }
 
-func (this *TableSchemaCacheTestSuite) TestTargetVerifierErrorsOnDuplicateRewriteValue() {
+func (this *TableSchemaCacheTestSuite) TestTargetToSourceRewritesErrorsOnDuplicateRewriteValue() {
 	rewrites := make(map[string]string)
 	rewrites["source"] = "target"
 

--- a/test/go/table_schema_cache_test.go
+++ b/test/go/table_schema_cache_test.go
@@ -405,8 +405,7 @@ func getMultiTableMap() *ghostferry.TableSchemaCache {
 
 func (this *TableSchemaCacheTestSuite) TestGetTableListWithPriorityNil() {
 	tables := getMultiTableMap()
-	// make sure we are not losing any elements, even if the priority does not
-	// mater
+	// make sure we are not losing any elements, even if the priority doesn't matter
 	creationOrder := tables.GetTableListWithPriority(nil)
 	this.Require().Equal(len(creationOrder), 3)
 	this.Require().ElementsMatch(creationOrder, tables.AllTableNames())
@@ -426,6 +425,23 @@ func (this *TableSchemaCacheTestSuite) TestGetTableListWithPriorityIgnoreUnknown
 	this.Require().Equal(len(creationOrder), 3)
 	this.Require().ElementsMatch(creationOrder, tables.AllTableNames())
 	this.Require().Equal(creationOrder[0], "schema.table2")
+}
+
+func (this *TableSchemaCacheTestSuite) TestTargetVerifierErrorsOnDuplicateRewriteValue() {
+	rewrites := make(map[string]string)
+	rewrites["source"] = "target"
+
+	reversed, err := ghostferry.TargetToSourceRewrites(rewrites)
+	this.Require().Nil(err)
+	this.Require().Equal(len(reversed), 1)
+	this.Require().Equal(reversed["target"], "source")
+
+	dupRewrites := make(map[string]string)
+	dupRewrites["source1"] = "target"
+	dupRewrites["source2"] = "target"
+
+	_, err = ghostferry.TargetToSourceRewrites(dupRewrites)
+	this.Require().Equal(err.Error(), "duplicate target to source rewrite detected")
 }
 
 func TestTableSchemaCache(t *testing.T) {

--- a/testhelpers/data_writer.go
+++ b/testhelpers/data_writer.go
@@ -2,9 +2,10 @@ package testhelpers
 
 import (
 	"fmt"
-	sql "github.com/Shopify/ghostferry/sqlwrapper"
 	"math/rand"
 	"sync"
+
+	sql "github.com/Shopify/ghostferry/sqlwrapper"
 
 	sq "github.com/Masterminds/squirrel"
 )
@@ -65,7 +66,7 @@ func SeedInitialData(db *sql.DB, dbname, tablename string, numberOfRows int) {
 	_, err = db.Exec(query)
 	PanicIfError(err)
 
-	query = "CREATE TABLE %s.%s (id bigint(20) not null auto_increment, data TEXT, primary key(id))"
+	query = "CREATE TABLE IF NOT EXISTS %s.%s (id bigint(20) not null auto_increment, data TEXT, primary key(id))"
 	query = fmt.Sprintf(query, dbname, tablename)
 
 	_, err = db.Exec(query)


### PR DESCRIPTION
## Overview

Fixes an issue in the `TargetVerifier` if there happened to be any configured schema or table rewrites.

This patch correctly handles any configured rewrites by reversing the configurations to lookup DML events using the Source `TableSchemaCache` from DML events streamed on the Target. 

Note that If there are duplicate values in the original rewrites, an error will be raised and Target Verification will not be able to be used as Ghostferry will not be able to correctly map the DML back to the Source.

### Details

Previous to this fix,  if running Ghostferry with schema or table rewrites, it would fail to inspect binlog events on the Target, and, as a result, fail to update its position in the `StateTracker`.

As you can see in the snippet below, the `BinlogStreamer` in the `TargetVerifier` would silently return from any events that did not exist in the `TableSchema`, which is correct, because Ghostferry should only ever care about the schema and tables for which it is configured: 

https://github.com/Shopify/ghostferry/blob/203cd1a16ef38300638770b1c9fcc7fa6e230ab0/binlog_streamer.go#L353-L356

However, because the `TargetVerifier` may be running against a Target with configured rewrites (differently named databases or tables), these lookups must either:
1.  Be mapped back to the original `TableSchema` of the Source or 
2. Be mapped to another `TableSchema` with the configured rewrites applied. 

I originally attempted the second approach, but abandoned the idea after failing to track down some supposed side effects that were occurring on the `f.Tables` (the Source `TableSchemaCache`) within an allotted amount of time. Eventually, I was able to get a working solution to the first approach, which is this PR. 

### Other considerations

We should consider rethinking the `TableSchema` and `TableSchemaCache` components and how they are used within the Ferry. The abstractions are difficult to work with and made this patch a bit more difficult than it should have been. 

Performing the lookups and applying the rewrites to the DML events in all the various places (`BatchWriter`, `InlineVerifier`, `BinlogWriter`, and now `BinlogStreamer`) is a bit of a duplicated effort. It may make more sense to apply the rewrites to the applicable `TableSchema`s and `TableSchemaCache`s once and then hand them off to their respective components. 

cc @Shopify/db-engineering 