### PR TITLE
Add sanity check to InlineVerifier and TargetVerifier

### DIFF
--- a/copydb/copydb.go
+++ b/copydb/copydb.go
@@ -109,7 +109,10 @@ func (this *CopydbFerry) Run() {
 	// should be identical.
 	copyWG.Wait()
 
-	this.Ferry.StopTargetVerifier()
+	err := this.Ferry.StopTargetVerifier()
+	if err != nil {
+		this.Ferry.ErrorHandler.Fatal("target_verifier", err)
+	}
 
 	// This is where you cutover from using the source database to
 	// using the target database.

--- a/ferry.go
+++ b/ferry.go
@@ -844,11 +844,17 @@ func (f *Ferry) FlushBinlogAndStopStreaming() {
 	f.BinlogStreamer.FlushAndStop()
 }
 
-func (f *Ferry) StopTargetVerifier() {
+func (f *Ferry) StopTargetVerifier() error {
 	if !f.Config.SkipTargetVerification {
 		f.TargetVerifier.BinlogStreamer.FlushAndStop()
 		f.targetVerifierWg.Wait()
+		if f.TargetVerifier.EventsChecked == 0 {
+			err := fmt.Errorf("no events checked")
+			f.logger.WithField("error", err).Errorf("target verifier did not check any events")
+			return err
+		}
 	}
+	return nil
 }
 
 func (f *Ferry) SerializeStateToJSON() (string, error) {

--- a/sharding/sharding.go
+++ b/sharding/sharding.go
@@ -157,11 +157,10 @@ func (r *ShardingFerry) Run() {
 		r.logger.WithField("error", err).Errorf("verification encountered an error, aborting run")
 		r.Ferry.ErrorHandler.Fatal("inline_verifier", err)
 	} else if !verificationResult.DataCorrect {
-		err = fmt.Errorf("verifier detected data discrepancy: %s", verificationResult.Message)
+		err = fmt.Errorf("verifier detected error: %s", verificationResult.Message)
 		r.logger.WithField("error", err).Errorf("verification failed, aborting run")
 		r.Ferry.ErrorHandler.Fatal("inline_verifier", err)
 	}
-
 	metrics.Measure("CopyPrimaryKeyTables", nil, 1.0, func() {
 		err = r.copyPrimaryKeyTables()
 	})
@@ -172,7 +171,10 @@ func (r *ShardingFerry) Run() {
 
 	r.Ferry.Throttler.SetDisabled(false)
 
-	r.Ferry.StopTargetVerifier()
+	err = r.Ferry.StopTargetVerifier()
+	if err != nil {
+		r.Ferry.ErrorHandler.Fatal("target_verifier", err)
+	}
 
 	metrics.Measure("CutoverUnlock", nil, 1.0, func() {
 		err = r.config.CutoverUnlock.Post(&client)

--- a/target_verifier.go
+++ b/target_verifier.go
@@ -12,6 +12,7 @@ type TargetVerifier struct {
 	DB             *sql.DB
 	BinlogStreamer *BinlogStreamer
 	StateTracker   *StateTracker
+	EventsChecked  int
 }
 
 func NewTargetVerifier(targetDB *sql.DB, stateTracker *StateTracker, binlogStreamer *BinlogStreamer) (*TargetVerifier, error) {
@@ -36,7 +37,8 @@ func (t *TargetVerifier) BinlogEventListener(evs []DMLEvent) error {
 			return err
 		}
 
-		// Ghostferry's annotation will alwaays be the first, if available
+		t.EventsChecked += 1
+		// Ghostferry's annotation will always be the first, if available
 		if annotation == "" || annotation != t.DB.Marginalia {
 			paginationKey, err := ev.PaginationKey()
 			if err != nil {

--- a/test/integration/inline_verifier_test.rb
+++ b/test/integration/inline_verifier_test.rb
@@ -68,7 +68,7 @@ class InlineVerifierTest < GhostferryTestCase
 
     assert verification_ran
     assert_equal ["#{DEFAULT_DB}.#{DEFAULT_TABLE}"], incorrect_tables
-    assert_equal "cutover verification failed for: gftest.test_table_1 [paginationKeys: 1 ] ", ghostferry.error_lines.last["msg"]
+    assert_equal "cutover verification failed for: gftest.test_table_1 [paginationKeys: 1 ] ", ghostferry.error_lines.first["msg"]
   end
 
   def test_same_decompressed_data_different_compressed_test_passes_inline_verification
@@ -430,7 +430,7 @@ class InlineVerifierTest < GhostferryTestCase
 
     assert verification_ran
     assert_equal ["#{DEFAULT_DB}.#{DEFAULT_TABLE}"], incorrect_tables
-    assert_equal "cutover verification failed for: #{DEFAULT_DB}.#{DEFAULT_TABLE} [paginationKeys: 1 ] ", ghostferry.error_lines.last["msg"]
+    assert_equal "cutover verification failed for: #{DEFAULT_DB}.#{DEFAULT_TABLE} [paginationKeys: 1 ] ", ghostferry.error_lines.first["msg"]
 
     # Now we run the real test case.
     target_db.query("UPDATE #{DEFAULT_FULL_TABLE_NAME} SET data = -0.0 WHERE id = 1")
@@ -484,7 +484,7 @@ class InlineVerifierTest < GhostferryTestCase
 
     assert verification_ran
     assert_equal ["#{DEFAULT_DB}.#{DEFAULT_TABLE}"], incorrect_tables
-    assert_equal "cutover verification failed for: gftest.test_table_1 [paginationKeys: 1 ] ", ghostferry.error_lines.last["msg"]
+    assert_equal "cutover verification failed for: gftest.test_table_1 [paginationKeys: 1 ] ", ghostferry.error_lines.first["msg"]
   end
 
   def test_null_vs_null_string
@@ -507,7 +507,7 @@ class InlineVerifierTest < GhostferryTestCase
 
     assert verification_ran
     assert_equal ["#{DEFAULT_DB}.#{DEFAULT_TABLE}"], incorrect_tables
-    assert_equal "cutover verification failed for: gftest.test_table_1 [paginationKeys: 1 ] ", ghostferry.error_lines.last["msg"]
+    assert_equal "cutover verification failed for: gftest.test_table_1 [paginationKeys: 1 ] ", ghostferry.error_lines.first["msg"]
   end
 
   def test_null_in_different_order
@@ -533,7 +533,19 @@ class InlineVerifierTest < GhostferryTestCase
 
     assert verification_ran
     assert_equal ["#{DEFAULT_DB}.#{DEFAULT_TABLE}"], incorrect_tables
-    assert_equal "cutover verification failed for: gftest.test_table_1 [paginationKeys: 1 ] ", ghostferry.error_lines.last["msg"]
+    assert_equal "cutover verification failed for: gftest.test_table_1 [paginationKeys: 1 ] ", ghostferry.error_lines.first["msg"]
+  end
+
+  def test_no_events_verified_on_target_will_log_error
+    seed_random_data(source_db, number_of_rows: 0)
+    seed_random_data(target_db, number_of_rows: 0)
+
+    ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline" })
+
+    ghostferry.run
+
+    assert_equal "target verifier did not check any events", ghostferry.error_lines.last["msg"]
+    assert_equal "no events checked", ghostferry.error_lines.last["error"]
   end
 
   ###################


### PR DESCRIPTION
#263

For InlineVerifier: 
 check if `rowsChecked > 0` when we run `VerifyDuringCutover`.
 if no rows were checked, return `VerificationResult.DataCorrect = False`


For TargetVerifier:
 check after we run `StopTargetVerifier` to see if we verified any events
 if no events were checked, we log and return an error, copydb and sharding will then panic

