### PR TITLE
sharding: made metrics buffer bigger

### DIFF
--- a/sharding/metrics.go
+++ b/sharding/metrics.go
@@ -22,7 +22,7 @@ func InitializeMetrics(prefix string, config *Config) error {
 		return err
 	}
 
-	metricsChan := make(chan interface{}, 1024)
+	metricsChan := make(chan interface{}, 4096)  // TODO: make this queue size configurable
 	SetGlobalMetrics(prefix, metricsChan)
 
 	metrics.DefaultTags = []ghostferry.MetricTag{


### PR DESCRIPTION
I'm seeing metrics sink full warnings in production spamming our logs. I tested making the buffer bigger and it appears to have helped...

That said, I'm not sure why making metrics buffer bigger actually solves the problem, because there's should be a "conservation of mass" type dynamics: the number of metrics going into the channel should equal the number coming out for the channel to not be filled. I guess buffers for audio workstations also have similar behaviours, so maybe I should just read up more about how buffers work.