### PR TITLE
Enable Cutover callback in config for copydb

### DIFF
--- a/config.go
+++ b/config.go
@@ -618,9 +618,22 @@ type Config struct {
 	StateCallback        HTTPCallback
 	StateReportFrequency int
 
+
 	// Report error via an HTTP callback. The Payload field will contain the ErrorType,
 	// ErrorMessage and the StateDump.
 	ErrorCallback HTTPCallback
+
+	// Report when ghostferry is entering cutover
+	CutoverLock   			HTTPCallback
+
+	// Report when ghostferry is finished cutover
+	CutoverUnlock 			HTTPCallback
+
+	// These two values configure the amount of times Ferry should attempt to
+	// retry acquiring the cutover lock, and for how long the Ferry should wait
+	// before attempting another lock acquisition
+	MaxCutoverRetries       int
+	CutoverRetryWaitSeconds int
 
 	// The state to resume from as dumped by the PanicErrorHandler.
 	// If this is null, a new Ghostferry run will be started. Otherwise, the
@@ -798,6 +811,14 @@ func (c *Config) ValidateConfig() error {
 
 	if c.WebBasedir == "" {
 		c.WebBasedir = "."
+	}
+
+	if c.MaxCutoverRetries == 0 {
+		c.MaxCutoverRetries = 1
+	}
+
+	if c.CutoverRetryWaitSeconds == 0 {
+		c.CutoverRetryWaitSeconds = 1
 	}
 
 	return nil

--- a/config.go
+++ b/config.go
@@ -629,9 +629,11 @@ type Config struct {
 	// Report when ghostferry is finished cutover
 	CutoverUnlock 			HTTPCallback
 
-	// These two values configure the amount of times Ferry should attempt to
+	// If the callback returns a non OK status, these two values configure the number of times Ferry should attempt to
 	// retry acquiring the cutover lock, and for how long the Ferry should wait
 	// before attempting another lock acquisition
+	// MaxCutoverRetries default is 1 retry
+	// CutoverRetryWaitSeconds default is 1 second
 	MaxCutoverRetries       int
 	CutoverRetryWaitSeconds int
 

--- a/copydb/copydb.go
+++ b/copydb/copydb.go
@@ -100,6 +100,7 @@ func (this *CopydbFerry) Run() {
 	// binlog streamer catching up.
 	this.Ferry.WaitUntilBinlogStreamerCatchesUp()
 
+	cutoverStart := this.Ferry.StartCutover()
 	// This is when the source database should be set as read only, whether it
 	// is done in application level or the database level.
 	// Must ensure that all transactions are flushed to the binlog before
@@ -112,6 +113,7 @@ func (this *CopydbFerry) Run() {
 
 	this.Ferry.StopTargetVerifier()
 
+	this.Ferry.EndCutover(cutoverStart)
 	// This is where you cutover from using the source database to
 	// using the target database.
 	logrus.Info("ghostferry main operations has terminated but the control server remains online")

--- a/copydb/copydb.go
+++ b/copydb/copydb.go
@@ -100,7 +100,10 @@ func (this *CopydbFerry) Run() {
 	// binlog streamer catching up.
 	this.Ferry.WaitUntilBinlogStreamerCatchesUp()
 
+	// Optionally (configurable) POST to an HTTP endpoint telling that service that Ghostferry is ready for cutover.
+	// The external service can then perform steps needed immediately prior to cutover. For example, on receiving the callback, the service can set the database to be readonly.
 	cutoverStart := this.Ferry.StartCutover()
+
 	// This is when the source database should be set as read only, whether it
 	// is done in application level or the database level.
 	// Must ensure that all transactions are flushed to the binlog before
@@ -113,7 +116,10 @@ func (this *CopydbFerry) Run() {
 
 	this.Ferry.StopTargetVerifier()
 
+	// Optionally (configurable) POST to an HTTP endpoint telling that service Ghostferry has completed cutover and has stopped streaming the binlog.
+	// The external service can then perform steps needed after cutover. For example, on receiving the callback, the service can set the target database to allow writes.
 	this.Ferry.EndCutover(cutoverStart)
+
 	// This is where you cutover from using the source database to
 	// using the target database.
 	logrus.Info("ghostferry main operations has terminated but the control server remains online")

--- a/sharding/config.go
+++ b/sharding/config.go
@@ -17,31 +17,15 @@ type Config struct {
 	RunFerryFromReplica           bool
 
 	StatsDAddress string
-	CutoverLock   ghostferry.HTTPCallback
-	CutoverUnlock ghostferry.HTTPCallback
 
 	JoinedTables     map[string][]JoinTable
 	IgnoredTables    []string
 	PrimaryKeyTables []string
 
 	Throttle *ghostferry.LagThrottlerConfig
-
-	// These two values configure the amount of times Ferry should attempt to
-	// retry acquiring the cutover lock, and for how long the Ferry should wait
-	// before attempting another lock acquisition
-	MaxCutoverRetries       int
-	CutoverRetryWaitSeconds int
 }
 
 func (c *Config) ValidateConfig() error {
-	if c.MaxCutoverRetries == 0 {
-		c.MaxCutoverRetries = 1
-	}
-
-	if c.CutoverRetryWaitSeconds == 0 {
-		c.CutoverRetryWaitSeconds = 1
-	}
-
 	if c.RunFerryFromReplica && c.SourceReplicationMaster != nil {
 		if err := c.SourceReplicationMaster.Validate(); err != nil {
 			return err

--- a/sharding/test/callbacks_test.go
+++ b/sharding/test/callbacks_test.go
@@ -48,7 +48,7 @@ func (t *CallbacksTestSuite) TestFailsRunOnUnlockError() {
 }
 
 func (t *CallbacksTestSuite) TestRetriesOnLockError() {
-	t.Config.MaxCutoverRetries = 3
+	t.Ferry.Ferry.Config.MaxCutoverRetries = 3
 
 	callbacksReceived := 0
 	t.CutoverLock = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -58,14 +58,14 @@ func (t *CallbacksTestSuite) TestRetriesOnLockError() {
 
 	t.Ferry.Run()
 
-	t.Require().Equal(callbacksReceived, t.Config.MaxCutoverRetries)
+	t.Require().Equal(callbacksReceived, t.Ferry.Ferry.Config.MaxCutoverRetries)
 
 	t.Require().NotNil(t.errHandler.LastError)
 	t.Require().Equal("callback returned 500 Internal Server Error", t.errHandler.LastError.Error())
 }
 
 func (t *CallbacksTestSuite) TestSucceedsOnLockRetry() {
-	t.Config.MaxCutoverRetries = 3
+	t.Ferry.Ferry.Config.MaxCutoverRetries = 3
 
 	unlockReceived := false
 	t.CutoverUnlock = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sharding/testhelpers/unit_test_suite.go
+++ b/sharding/testhelpers/unit_test_suite.go
@@ -150,16 +150,17 @@ func (t *ShardingUnitTestSuite) setupShardingFerry() {
 		},
 
 		PrimaryKeyTables: []string{primaryKeyTable},
+	}
 
-		CutoverLock: ghostferry.HTTPCallback{
-			URI:     fmt.Sprintf("%s/lock", t.server.URL),
-			Payload: "test_lock",
-		},
 
-		CutoverUnlock: ghostferry.HTTPCallback{
-			URI:     fmt.Sprintf("%s/unlock", t.server.URL),
-			Payload: "test_unlock",
-		},
+	t.Config.CutoverLock = ghostferry.HTTPCallback{
+		URI: fmt.Sprintf("%s/lock", t.server.URL),
+		Payload: "test_lock",
+	}
+
+	t.Config.CutoverUnlock = ghostferry.HTTPCallback{
+		URI: fmt.Sprintf("%s/unlock", t.server.URL),
+		Payload: "test_unlock",
 	}
 
 	t.Config.ErrorCallback = ghostferry.HTTPCallback{


### PR DESCRIPTION
Refactoring the code so the shared config between copydb and sharding allow `CutoverLock` and `CutoverUnlock` callbacks. 