### PR TITLE
Binlog writer lag and target binlog streamer lag 

### DIFF
--- a/config.go
+++ b/config.go
@@ -618,16 +618,15 @@ type Config struct {
 	StateCallback        HTTPCallback
 	StateReportFrequency int
 
-
 	// Report error via an HTTP callback. The Payload field will contain the ErrorType,
 	// ErrorMessage and the StateDump.
 	ErrorCallback HTTPCallback
 
 	// Report when ghostferry is entering cutover
-	CutoverLock   			HTTPCallback
+	CutoverLock HTTPCallback
 
 	// Report when ghostferry is finished cutover
-	CutoverUnlock 			HTTPCallback
+	CutoverUnlock HTTPCallback
 
 	// If the callback returns a non OK status, these two values configure the number of times Ferry should attempt to
 	// retry acquiring the cutover lock, and for how long the Ferry should wait

--- a/data_iterator.go
+++ b/data_iterator.go
@@ -18,7 +18,7 @@ type DataIterator struct {
 	ErrorHandler ErrorHandler
 	CursorConfig *CursorConfig
 	StateTracker *StateTracker
-	TableSorter DataIteratorSorter
+	TableSorter  DataIteratorSorter
 
 	targetPaginationKeys *sync.Map
 	batchListeners       []func(*RowBatch) error

--- a/data_iterator_sorter.go
+++ b/data_iterator_sorter.go
@@ -12,7 +12,7 @@ type DataIteratorSorter interface {
 }
 
 // MaxPaginationKeySorter arranges table based on the MaxPaginationKey in DESC order
-type MaxPaginationKeySorter struct {}
+type MaxPaginationKeySorter struct{}
 
 func (s *MaxPaginationKeySorter) Sort(unorderedTables map[*TableSchema]uint64) ([]TableMaxPaginationKey, error) {
 	orderedTables := make([]TableMaxPaginationKey, len(unorderedTables))
@@ -29,6 +29,7 @@ func (s *MaxPaginationKeySorter) Sort(unorderedTables map[*TableSchema]uint64) (
 
 	return orderedTables, nil
 }
+
 // MaxTableSizeSorter uses `information_schema.tables` to estimate the size of the DB and sorts tables in DESC order
 type MaxTableSizeSorter struct {
 	DataIterator *DataIterator

--- a/progress.go
+++ b/progress.go
@@ -32,8 +32,12 @@ type Progress struct {
 
 	Tables                  map[string]TableProgress
 	LastSuccessfulBinlogPos mysql.Position
-	BinlogStreamerLag       float64 // seconds
+	BinlogStreamerLag       float64 // This is the amount of seconds the binlog streamer is lagging by (seconds)
+	BinlogWriterLag         float64 // This is the amount of seconds the binlog writer is lagging by (seconds)
 	Throttled               bool
+
+	// if the TargetVerifier is enabled, we emit this lag, otherwise this number will be 0
+	TargetBinlogStreamerLag float64
 
 	// The number of data iterators currently active.
 	ActiveDataIterators int

--- a/row_batch.go
+++ b/row_batch.go
@@ -1,8 +1,8 @@
 package ghostferry
 
 import (
-	"strings"
 	"encoding/json"
+	"strings"
 )
 
 type RowBatch struct {

--- a/sharding/test/copy_filter_test.go
+++ b/sharding/test/copy_filter_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/Shopify/ghostferry"
 	"github.com/Shopify/ghostferry/sharding"
@@ -146,6 +147,7 @@ func (t *CopyFilterTestSuite) TestShardingValueTypes() {
 		mysql.Position{},
 		mysql.Position{},
 		nil,
+		time.Unix(1618318965, 0),
 	)
 
 	for _, tenantId := range tenantIds {
@@ -162,6 +164,7 @@ func (t *CopyFilterTestSuite) TestInvalidShardingValueTypesErrors() {
 		mysql.Position{},
 		mysql.Position{},
 		nil,
+		time.Unix(1618318965, 0),
 	)
 
 	dmlEvents, err := ghostferry.NewBinlogInsertEvents(eventBase, t.newRowsEvent([]interface{}{1001, string("1"), "data"}))

--- a/test/go/dml_events_test.go
+++ b/test/go/dml_events_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Shopify/ghostferry"
 	"github.com/siddontang/go-mysql/mysql"
@@ -52,7 +53,7 @@ func (this *DMLEventsTestSuite) SetupTest() {
 		"test_schema.test_table": this.sourceTable,
 	}
 
-	this.eventBase = ghostferry.NewDMLEventBase(this.sourceTable, mysql.Position{}, mysql.Position{}, nil)
+	this.eventBase = ghostferry.NewDMLEventBase(this.sourceTable, mysql.Position{}, mysql.Position{}, nil, time.Unix(1618318965, 0))
 }
 
 func (this *DMLEventsTestSuite) TestBinlogInsertEventGeneratesInsertQuery() {
@@ -105,6 +106,7 @@ func (this *DMLEventsTestSuite) TestBinlogInsertEventMetadata() {
 	this.Require().Equal("test_table", dmlEvents[0].Table())
 	this.Require().Nil(dmlEvents[0].OldValues())
 	this.Require().Equal(ghostferry.RowData{1000}, dmlEvents[0].NewValues())
+	this.Require().Equal(time.Unix(1618318965, 0), dmlEvents[0].Timestamp())
 }
 
 func (this *DMLEventsTestSuite) TestBinlogUpdateEventGeneratesUpdateQuery() {
@@ -177,6 +179,7 @@ func (this *DMLEventsTestSuite) TestBinlogUpdateEventMetadata() {
 	this.Require().Equal("test_table", dmlEvents[0].Table())
 	this.Require().Equal(ghostferry.RowData{1000}, dmlEvents[0].OldValues())
 	this.Require().Equal(ghostferry.RowData{1001}, dmlEvents[0].NewValues())
+	this.Require().Equal(time.Unix(1618318965, 0), dmlEvents[0].Timestamp())
 }
 
 func (this *DMLEventsTestSuite) TestBinlogDeleteEventGeneratesDeleteQuery() {
@@ -246,6 +249,7 @@ func (this *DMLEventsTestSuite) TestBinlogDeleteEventMetadata() {
 	this.Require().Equal("test_table", dmlEvents[0].Table())
 	this.Require().Equal(ghostferry.RowData{1000}, dmlEvents[0].OldValues())
 	this.Require().Nil(dmlEvents[0].NewValues())
+	this.Require().Equal(time.Unix(1618318965, 0), dmlEvents[0].Timestamp())
 }
 
 func (this *DMLEventsTestSuite) TestAnnotations() {
@@ -261,6 +265,7 @@ func (this *DMLEventsTestSuite) TestAnnotations() {
 		mysql.Position{},
 		mysql.Position{},
 		[]byte("/*application:ghostferry*/ INSERT IGNORE INTO `target_schema`.`target_table` (`col1`,`col2`) VALUES (1, val1)"),
+		time.Unix(1618318965, 0),
 	)
 
 	dmlEvents, err := ghostferry.NewBinlogInsertEvents(eventBase, rowsEvent)
@@ -286,6 +291,7 @@ func (this *DMLEventsTestSuite) TestNoAnnotations() {
 		mysql.Position{},
 		mysql.Position{},
 		[]byte("INSERT IGNORE INTO `target_schema`.`target_table` (`col1`,`col2`) VALUES (1, val1)"),
+		time.Unix(1618318965, 0),
 	)
 
 	dmlEvents, err := ghostferry.NewBinlogInsertEvents(eventBase, rowsEvent)
@@ -310,6 +316,7 @@ func (this *DMLEventsTestSuite) TestMultipleAnnotations() {
 		mysql.Position{},
 		mysql.Position{},
 		[]byte("/*application:ghostferry*/ /*request_id:d8e8fca2dc0f896fd7cb4cb0031ba249*/ /*myannotation*/ INSERT IGNORE INTO `target_schema`.`target_table` (`col1`,`col2`) VALUES (1, val1)"),
+		time.Unix(1618318965, 0),
 	)
 
 	dmlEvents, err := ghostferry.NewBinlogInsertEvents(eventBase, rowsEvent)
@@ -334,6 +341,7 @@ func (this *DMLEventsTestSuite) TestSeparatedAnnotations() {
 		mysql.Position{},
 		mysql.Position{},
 		[]byte("/*application:ghostferry*/ /*request_id:d8e8fca2dc0f896fd7cb4cb0031ba249;other:annotation*/ INSERT IGNORE INTO `target_schema`.`target_table` (`col1`,`col2`) VALUES (1, val1)"),
+		time.Unix(1618318965, 0),
 	)
 
 	dmlEvents, err := ghostferry.NewBinlogInsertEvents(eventBase, rowsEvent)
@@ -358,6 +366,7 @@ func (this *DMLEventsTestSuite) TestNoRowsQueryEvent() {
 		mysql.Position{},
 		mysql.Position{},
 		nil,
+		time.Unix(1618318965, 0),
 	)
 
 	dmlEvents, err := ghostferry.NewBinlogInsertEvents(eventBase, rowsEvent)


### PR DESCRIPTION
The binlog writer and binlog streamer lag can diverge. This allows us to track them individually in the Progress struct. 

Furthermore, the target binlog streamer lag is a thing when the TargetVerifier is active, this allows us to track that lag when it is in use.

Also ran go fmt in a few places. We should probably setup CI to catch format issues.
