### PR TITLE
Add wait for Target Binlog Streamer to catch up before cutover

### DIFF
--- a/ferry.go
+++ b/ferry.go
@@ -816,7 +816,8 @@ func (f *Ferry) WaitUntilRowCopyIsComplete() {
 }
 
 func (f *Ferry) WaitUntilBinlogStreamerCatchesUp() {
-	for !f.BinlogStreamer.IsAlmostCaughtUp() {
+	for !f.BinlogStreamer.IsAlmostCaughtUp() ||
+		(!f.Config.SkipTargetVerification && !f.TargetVerifier.BinlogStreamer.IsAlmostCaughtUp()) {
 		time.Sleep(500 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
During our recent test run, we noticed that the Target Binlog Streamer can be significantly lagged during cutover when the Target Verification is enabled. This caused longer than necessary downtime during cutover. This PR addresses the issue by waiting for Target Binlog Streamer to catch up before entering cutover, like how we currently wait for the Source Binlog Streamer.