### PR TITLE
Fixed make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ GOTESTSUM_URL   := "https://github.com/gotestyourself/gotestsum/releases/downloa
 
 $(PROJECTS): $(GOBIN)
 	$(eval proj := $@)
-	go build -i -ldflags "$(LDFLAGS)" -o $(BIN_TARGET) $(PROJECT_PKG)
+	go build -ldflags "$(LDFLAGS)" -o $(BIN_TARGET) $(PROJECT_PKG)
 
 $(PROJECT_DEBS): LDFLAGS += -X github.com/Shopify/ghostferry.WebUiBasedir=/$(SHARE_DIR)
 $(PROJECT_DEBS): reset-deb-dir

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # Variables to be built into the binary
 VERSION         := 1.1.0
-DATETIME        ?= $(shell date -u +%Y%m%d%H%M%S) # This variable can be overwritten by the caller
+
+# This variable can be overwritten by the caller
+DATETIME        ?= $(shell date -u +%Y%m%d%H%M%S)
 
 ifndef IGNORE_DIRTY_TREE
 DIRTY_TREE      := $(shell git diff-index --quiet HEAD -- || echo '+dirty')


### PR DESCRIPTION
With the comment after the DATETIME variable in make, the extra space before the `#` symbol was interpreted as a part of the variable...