### PR TITLE
report error to the callback if ferry initialization fails in copydb

### DIFF
--- a/copydb/cmd/main.go
+++ b/copydb/cmd/main.go
@@ -112,6 +112,7 @@ func main() {
 
 	err = ferry.Start()
 	if err != nil {
+		ferry.Ferry.ErrorHandler.ReportError("ferry.start", err)
 		errorAndExit(fmt.Sprintf("failed to start ferry: %v", err))
 	}
 
@@ -123,6 +124,7 @@ func main() {
 	if config.StateToResumeFrom == nil {
 		err = ferry.CreateDatabasesAndTables()
 		if err != nil {
+			ferry.Ferry.ErrorHandler.ReportError("ferry.createDatabasesAndTables", err)
 			errorAndExit(fmt.Sprintf("failed to create databases and tables: %v", err))
 		}
 	}

--- a/copydb/cmd/main.go
+++ b/copydb/cmd/main.go
@@ -106,6 +106,8 @@ func main() {
 
 	err = ferry.Initialize()
 	if err != nil {
+		// This is not a good idea to reach deep within ferry from copydb. The entire ErrorHandler needs
+		// refactoring which is defined in this issue - https://github.com/Shopify/ghostferry/issues/284
 		ferry.Ferry.ErrorHandler.ReportError("ferry.initialize", err)
 		errorAndExit(fmt.Sprintf("failed to initialize ferry: %v", err))
 	}

--- a/copydb/cmd/main.go
+++ b/copydb/cmd/main.go
@@ -106,6 +106,7 @@ func main() {
 
 	err = ferry.Initialize()
 	if err != nil {
+		ferry.Ferry.ErrorHandler.ReportError("ferry.initialize", err)
 		errorAndExit(fmt.Sprintf("failed to initialize ferry: %v", err))
 	}
 


### PR DESCRIPTION
During the initial setup for the `ferry` in copydb we were not reporting errors to error callback. Before the ferry runs we are doing a bunch of initialization work which is prone to fail but we were simply exiting from copydb and not reporting these errors to error callback-server. This PR fixes that. 