### PR TITLE
Preserve collation in create database for copydb

### DIFF
--- a/copydb/test/copydb_test.go
+++ b/copydb/test/copydb_test.go
@@ -53,6 +53,10 @@ func (t *CopydbTestSuite) SetupTest() {
 
 	t.ferry = t.copydbFerry.Ferry
 
+	// Need to do this, because we will change the character set, which can cause seed initial data to fail on subsequent runs
+	_, err = t.ferry.SourceDB.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", testSchemaName))
+	t.Require().Nil(err)
+
 	testhelpers.SeedInitialData(t.ferry.SourceDB, testSchemaName, testTableName, 10)
 }
 
@@ -106,6 +110,43 @@ func (t *CopydbTestSuite) TestCreateDatabasesAndTablesAlreadyExistsAllowed() {
 
 	err = t.copydbFerry.CreateDatabasesAndTables()
 	t.Require().Nil(err)
+}
+
+func (t *CopydbTestSuite) TestCreateDatabaseCopiesTheRightCollation() {
+	// Drop the default version first because we don't need it.
+	_, err := t.ferry.SourceDB.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", testSchemaName))
+	t.Require().Nil(err)
+
+	_, err = t.ferry.SourceDB.Exec(fmt.Sprintf("CREATE DATABASE `%s` DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci", testSchemaName))
+	t.Require().Nil(err)
+
+	query := "CREATE TABLE %s.%s (id bigint(20) not null auto_increment, data TEXT, primary key(id)) CHARACTER SET latin1 COLLATE latin1_danish_ci"
+	query = fmt.Sprintf(query, testSchemaName, testTableName)
+	_, err = t.ferry.SourceDB.Exec(query)
+	t.Require().Nil(err)
+
+	t.copydbFerry.Ferry.Tables, err = ghostferry.LoadTables(t.ferry.SourceDB, t.copydbFerry.Ferry.TableFilter, nil, nil, nil, nil)
+	t.Require().Nil(err)
+
+	err = t.copydbFerry.CreateDatabasesAndTables()
+	t.Require().Nil(err)
+
+	query = "SELECT default_character_set_name, default_collation_name from information_schema.schemata where schema_name = \"%s\""
+	query = fmt.Sprintf(query, renamedSchemaName)
+
+	var characterSet, collation string
+	row := t.ferry.TargetDB.QueryRow(query)
+	err = row.Scan(&characterSet, &collation)
+	t.Require().Nil(err)
+	t.Require().Equal(characterSet, "utf8")
+	t.Require().Equal(collation, "utf8_general_ci")
+
+	query = "SELECT table_collation FROM information_schema.tables WHERE table_schema = \"%s\" AND table_name = \"%s\""
+	query = fmt.Sprintf(query, renamedSchemaName, renamedTableName)
+	row = t.ferry.TargetDB.QueryRow(query)
+	err = row.Scan(&collation)
+	t.Require().Nil(err)
+	t.Require().Equal(collation, "latin1_danish_ci")
 }
 
 func (t *CopydbTestSuite) TestCreateDatabaseAndTableWithOrdering() {


### PR DESCRIPTION
Copydb, when creating the database, didn't preserve the database collation setting from the source side. This fixes it.