### PR TITLE
Dynamic reconfiguration for DataIterationBatchSize

### DIFF
--- a/config.go
+++ b/config.go
@@ -284,7 +284,7 @@ func (c *IterativeVerifierConfig) Validate() error {
 
 type ControlServerConfig struct {
 	// enable/disable http control server
-	EnableControlServer bool
+	Enabled bool
 
 	// Bind control server address
 	ServerBindAddr string
@@ -297,7 +297,7 @@ type ControlServerConfig struct {
 	// path specified.
 	// The format is "script name" => ["path to script", "arg1", "arg2"]. The script name
 	// will be displayed on the web ui.
-	ControlServerCustomScripts map[string][]string
+	CustomScripts map[string][]string
 }
 
 func (c *ControlServerConfig) Validate() error {

--- a/config.go
+++ b/config.go
@@ -301,6 +301,11 @@ type ControlServerConfig struct {
 }
 
 func (c *ControlServerConfig) Validate() error {
+	// this is used to update the web base dir path from the debian packager
+	if WebUiBasedir != "" {
+		c.WebBasedir = WebUiBasedir
+	}
+
 	if c.ServerBindAddr == "" {
 		c.ServerBindAddr = "0.0.0.0:8000"
 	}
@@ -782,7 +787,7 @@ type Config struct {
 	// Updatable config
 	// The following configs are updatable via the `Config.Update` method and should be passed by pointer
 
-	UpdatableConfig *UpdatableConfig
+	UpdatableConfig UpdatableConfig
 }
 
 func (c *Config) ValidateConfig() error {
@@ -824,9 +829,6 @@ func (c *Config) ValidateConfig() error {
 		c.DBWriteRetries = 5
 	}
 
-	if c.UpdatableConfig == nil {
-		c.UpdatableConfig = &UpdatableConfig{}
-	}
 
 	if err := c.UpdatableConfig.Validate(); err != nil {
 		return fmt.Errorf("updatable config: %s", err)

--- a/config.go
+++ b/config.go
@@ -486,6 +486,10 @@ func linearInterpolation(x, x0, y0, x1, y1 int) int {
 	return y0*(x1-x)/(x1-x0) + y1*(x-x0)/(x1-x0)
 }
 
+type UpdatableConfigs struct {
+	DataIterationBatchSize uint64
+}
+
 type Config struct {
 	// Source database connection configuration
 	//
@@ -594,6 +598,9 @@ type Config struct {
 	// and the stdout dumping. This may save a lot of space if you don't need
 	// to deal with schema migrations.
 	DoNotIncludeSchemaCacheInStateDump bool
+
+	// enable/disable http control server
+	EnableControlServer bool
 
 	// Config for the ControlServer
 	ServerBindAddr string
@@ -837,4 +844,11 @@ func (c *Config) ValidateConfig() error {
 	}
 
 	return nil
+}
+
+func (c *Config) Update(updatedConfig UpdatableConfigs) {
+	if updatedConfig.DataIterationBatchSize > 0 {
+		c.DataIterationBatchSize = updatedConfig.DataIterationBatchSize
+	}
+
 }

--- a/control_server.go
+++ b/control_server.go
@@ -22,6 +22,8 @@ type ControlServerTableStatus struct {
 	Status                      string
 	LastSuccessfulPaginationKey uint64
 	TargetPaginationKey         uint64
+
+	BatchSize                   uint64
 }
 
 type CustomScriptStatus struct {
@@ -230,9 +232,9 @@ func (this *ControlServer) fetchStatus() *ControlServerStatus {
 	status.StartTime = this.F.StartTime
 	status.CurrentTime = time.Now()
 
-	status.TimeTaken = time.Duration(status.Progress.TimeTaken * float64(time.Second))
-	status.BinlogStreamerLag = time.Duration(status.Progress.BinlogStreamerLag * float64(time.Second))
-	status.ETA = time.Duration(status.Progress.ETA * float64(time.Second))
+	status.TimeTaken = time.Duration(status.Progress.TimeTaken) * time.Second
+	status.BinlogStreamerLag = time.Duration(status.Progress.BinlogStreamerLag) * time.Second
+	status.ETA = time.Duration(status.Progress.ETA) * time.Second
 
 	status.AutomaticCutover = this.F.Config.AutomaticCutover
 	status.BinlogStreamerStopRequested = this.F.BinlogStreamer.stopRequested
@@ -286,6 +288,8 @@ func (this *ControlServer) fetchStatus() *ControlServerStatus {
 			Status:                      tableProgress.CurrentAction,
 			LastSuccessfulPaginationKey: lastSuccessfulPaginationKey,
 			TargetPaginationKey:         tableProgress.TargetPaginationKey,
+			BatchSize:			         tableProgress.BatchSize,
+
 		}
 
 		tablesGroupByStatus[tableStatus] = append(tablesGroupByStatus[tableStatus], controlStatus)

--- a/control_server.go
+++ b/control_server.go
@@ -89,6 +89,7 @@ type ControlServer struct {
 func (this *ControlServer) Initialize() (err error) {
 	this.logger = logrus.WithField("tag", "control_server")
 	this.logger.Info("initializing")
+	this.wg = &sync.WaitGroup{}
 
 	this.customScriptsRunning = make(map[string]bool)
 	this.customScriptsLogs = make(map[string]string)
@@ -134,10 +135,6 @@ func (this *ControlServer) Run() {
 	if err != nil {
 		logrus.WithError(err).Error("error on ListenAndServe")
 	}
-}
-
-func (this *ControlServer) Shutdown() error {
-	return this.server.Shutdown(nil)
 }
 
 func (this *ControlServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/control_server.go
+++ b/control_server.go
@@ -363,7 +363,7 @@ func (this *ControlServer) HandleConfig(w http.ResponseWriter, r *http.Request) 
 	var decoder = json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
 
-	var updatableConfig UpdatableConfigs
+	var updatableConfig UpdatableConfig
 	err := decoder.Decode(&updatableConfig)
 
 	if err != nil {

--- a/copydb/cmd/main.go
+++ b/copydb/cmd/main.go
@@ -61,8 +61,11 @@ func main() {
 				User: "ghostferry",
 			},
 
+			ControlServerConfig: &ghostferry.ControlServerConfig{
+				EnableControlServer:    true,
+			},
+
 			AutomaticCutover:       false,
-			EnableControlServer:    true,
 		},
 	}
 

--- a/copydb/cmd/main.go
+++ b/copydb/cmd/main.go
@@ -61,7 +61,8 @@ func main() {
 				User: "ghostferry",
 			},
 
-			AutomaticCutover: false,
+			AutomaticCutover:       false,
+			EnableControlServer:    true,
 		},
 	}
 

--- a/copydb/cmd/main.go
+++ b/copydb/cmd/main.go
@@ -62,7 +62,7 @@ func main() {
 			},
 
 			ControlServerConfig: &ghostferry.ControlServerConfig{
-				EnableControlServer:    true,
+				Enabled: true,
 			},
 
 			AutomaticCutover:       false,

--- a/copydb/copydb.go
+++ b/copydb/copydb.go
@@ -109,10 +109,6 @@ func (this *CopydbFerry) Run() {
 	this.Ferry.ControlServer.Wait()
 }
 
-func (this *CopydbFerry) ShutdownControlServer() error {
-	return this.Ferry.ControlServer.Shutdown()
-}
-
 func (this *CopydbFerry) initializeWaitUntilReplicaIsCaughtUpToMasterConnection() error {
 	masterDB, err := this.config.SourceReplicationMaster.SqlDB(logrus.WithField("tag", "copydb"))
 	if err != nil {

--- a/copydb/copydb.go
+++ b/copydb/copydb.go
@@ -106,7 +106,7 @@ func (this *CopydbFerry) Run() {
 	logrus.Info("ghostferry main operations has terminated but the control server remains online")
 	logrus.Info("press CTRL+C or send an interrupt to stop the control server and end this process")
 
-	select{}
+	this.Ferry.ControlServer.Wait()
 }
 
 func (this *CopydbFerry) ShutdownControlServer() error {

--- a/copydb/copydb.go
+++ b/copydb/copydb.go
@@ -102,6 +102,11 @@ func (this *CopydbFerry) Run() {
 
 	// This is where you cutover from using the source database to
 	// using the target database
+
+	logrus.Info("ghostferry main operations has terminated but the control server remains online")
+	logrus.Info("press CTRL+C or send an interrupt to stop the control server and end this process")
+
+	select{}
 }
 
 func (this *CopydbFerry) ShutdownControlServer() error {

--- a/copydb/copydb.go
+++ b/copydb/copydb.go
@@ -11,9 +11,8 @@ import (
 )
 
 type CopydbFerry struct {
-	Ferry         *ghostferry.Ferry
-	controlServer *ghostferry.ControlServer
-	config        *Config
+	Ferry  *ghostferry.Ferry
+	config *Config
 }
 
 func NewFerry(config *Config) *CopydbFerry {
@@ -21,17 +20,9 @@ func NewFerry(config *Config) *CopydbFerry {
 		Config: config.Config,
 	}
 
-	controlServer := &ghostferry.ControlServer{
-		F:             ferry,
-		Addr:          config.ServerBindAddr,
-		Basedir:       config.WebBasedir,
-		CustomScripts: config.ControlServerCustomScripts,
-	}
-
 	return &CopydbFerry{
-		Ferry:         ferry,
-		controlServer: controlServer,
-		config:        config,
+		Ferry:  ferry,
+		config: config,
 	}
 }
 
@@ -43,14 +34,7 @@ func (this *CopydbFerry) Initialize() error {
 		}
 	}
 
-	err := this.Ferry.Initialize()
-	if err != nil {
-		return err
-	}
-
-	this.controlServer.Verifier = this.Ferry.Verifier
-
-	return this.controlServer.Initialize()
+	return this.Ferry.Initialize()
 }
 
 func (this *CopydbFerry) Start() error {
@@ -81,10 +65,6 @@ func (this *CopydbFerry) CreateDatabasesAndTables() error {
 }
 
 func (this *CopydbFerry) Run() {
-	serverWG := &sync.WaitGroup{}
-	serverWG.Add(1)
-	go this.controlServer.Run(serverWG)
-
 	copyWG := &sync.WaitGroup{}
 	copyWG.Add(1)
 	go func() {
@@ -121,16 +101,11 @@ func (this *CopydbFerry) Run() {
 	this.Ferry.EndCutover(cutoverStart)
 
 	// This is where you cutover from using the source database to
-	// using the target database.
-	logrus.Info("ghostferry main operations has terminated but the control server remains online")
-	logrus.Info("press CTRL+C or send an interrupt to stop the control server and end this process")
-
-	// Work is done, the process will run the web server until killed.
-	serverWG.Wait()
+	// using the target database
 }
 
 func (this *CopydbFerry) ShutdownControlServer() error {
-	return this.controlServer.Shutdown()
+	return this.Ferry.ControlServer.Shutdown()
 }
 
 func (this *CopydbFerry) initializeWaitUntilReplicaIsCaughtUpToMasterConnection() error {

--- a/copydb/test/copydb_test.go
+++ b/copydb/test/copydb_test.go
@@ -42,7 +42,7 @@ func (t *CopydbTestSuite) SetupTest() {
 	}
 
 	// TODO: remove this hack
-	t.copydbConfig.WebBasedir = "../.."
+	t.copydbConfig.ControlServerConfig.WebBasedir = "../.."
 
 	err := t.copydbConfig.InitializeAndValidateConfig()
 	t.Require().Nil(err)

--- a/cursor.go
+++ b/cursor.go
@@ -37,7 +37,8 @@ type CursorConfig struct {
 
 	ColumnsToSelect           []string
 	BuildSelect               func([]string, *TableSchema, uint64, uint64) (squirrel.SelectBuilder, error)
-	// BatchSize is a pointer to make this value updatable
+	// BatchSize is a pointer to the BatchSize in Config.UpdatableConfig which can be independently updated from this code.
+	// Having it as a pointer allows the updated value to be read without needing additional code to copy the batch size value into the cursor config for each cursor we create.
 	BatchSize                 *uint64
 	BatchSizePerTableOverride *DataIterationBatchSizePerTableOverride
 	ReadRetries               int

--- a/cursor.go
+++ b/cursor.go
@@ -37,6 +37,7 @@ type CursorConfig struct {
 
 	ColumnsToSelect           []string
 	BuildSelect               func([]string, *TableSchema, uint64, uint64) (squirrel.SelectBuilder, error)
+	// BatchSize is a pointer to make this value updatable
 	BatchSize                 *uint64
 	BatchSizePerTableOverride *DataIterationBatchSizePerTableOverride
 	ReadRetries               int

--- a/cursor.go
+++ b/cursor.go
@@ -3,9 +3,8 @@ package ghostferry
 import (
 	sqlorig "database/sql"
 	"fmt"
-	"strings"
-
 	sql "github.com/Shopify/ghostferry/sqlwrapper"
+	"strings"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/go-mysql-org/go-mysql/schema"
@@ -38,7 +37,7 @@ type CursorConfig struct {
 
 	ColumnsToSelect           []string
 	BuildSelect               func([]string, *TableSchema, uint64, uint64) (squirrel.SelectBuilder, error)
-	BatchSize                 uint64
+	BatchSize                 *uint64
 	BatchSizePerTableOverride *DataIterationBatchSizePerTableOverride
 	ReadRetries               int
 }
@@ -67,7 +66,7 @@ func (c CursorConfig) GetBatchSize(schemaName string, tableName string) uint64 {
 			return batchSize
 		}
 	}
-	return c.BatchSize
+	return *c.BatchSize
 }
 
 type Cursor struct {

--- a/examples/copydb/conf.json
+++ b/examples/copydb/conf.json
@@ -39,11 +39,12 @@
 
   "VerifierType": "Inline",
 
-  "ControlServerCustomScripts": {
-    "Custom Script 1": ["examples/copydb/s1"],
-    "Custom Script 2": ["examples/copydb/s2"]
+  "ControlServer": {
+    "CustomScripts": {
+      "Custom Script 1": ["examples/copydb/s1"],
+      "Custom Script 2": ["examples/copydb/s2"]
+    }
   },
-
   "DumpStateToStdoutOnError": true,
   "SkipTargetVerification": true
 }

--- a/ferry.go
+++ b/ferry.go
@@ -531,13 +531,6 @@ func (f *Ferry) Initialize() (err error) {
 	f.DataIterator = f.NewDataIterator()
 	f.BatchWriter = f.NewBatchWriter()
 
-	if f.Config.ControlServerConfig.Enabled {
-		f.ControlServer, err = f.NewControlServer()
-		if err != nil {
-			return err
-		}
-	}
-
 	if f.Config.VerifierType != "" {
 		if f.Verifier != nil {
 			return errors.New("VerifierType specified and Verifier is given. these are mutually exclusive options")
@@ -561,6 +554,13 @@ func (f *Ferry) Initialize() (err error) {
 			// skip
 		default:
 			return fmt.Errorf("'%s' is not a known VerifierType", f.Config.VerifierType)
+		}
+	}
+
+	if f.Config.ControlServerConfig.Enabled {
+		f.ControlServer, err = f.NewControlServer()
+		if err != nil {
+			return err
 		}
 	}
 

--- a/ferry.go
+++ b/ferry.go
@@ -253,9 +253,9 @@ func (f *Ferry) NewControlServer() (*ControlServer, error) {
 	f.ensureInitialized()
 
 	controlServer := &ControlServer{
-		ControlServerConfig: f.Config.ControlServerConfig,
-		F:             f,
-		Verifier:      f.Verifier,
+		Config:   f.Config.ControlServerConfig,
+		F:        f,
+		Verifier: f.Verifier,
 	}
 
 	err := controlServer.Initialize()
@@ -665,12 +665,7 @@ func (f *Ferry) Run() {
 	}()
 
 	if f.Config.ControlServerConfig.EnableControlServer {
-		supportingServicesWg.Add(1)
-		go func() {
-			defer supportingServicesWg.Done()
-
-			f.ControlServer.Run()
-		}()
+		go f.ControlServer.Run()
 	}
 
 	if f.Config.ProgressCallback.URI != "" {
@@ -829,10 +824,7 @@ func (f *Ferry) Run() {
 	binlogWg.Wait()
 
 	f.logger.Info("ghostferry run is complete, shutting down auxiliary services")
-	if f.Config.ControlServerConfig.EnableControlServer == true {
-		logrus.Info("ghostferry main operations has terminated but the control server remains online")
-		logrus.Info("press CTRL+C or send an interrupt to stop the control server and end this process")
-	}
+
 	f.OverallState.Store(StateDone)
 	f.DoneTime = time.Now()
 

--- a/ferry.go
+++ b/ferry.go
@@ -106,7 +106,7 @@ func (f *Ferry) NewDataIterator() *DataIterator {
 			DB:        f.SourceDB,
 			Throttler: f.Throttler,
 
-			BatchSize:                 &f.Config.DataIterationBatchSize,
+			BatchSize:                 &f.Config.UpdatableConfig.DataIterationBatchSize,
 			BatchSizePerTableOverride: f.Config.DataIterationBatchSizePerTableOverride,
 			ReadRetries:               f.Config.DBReadRetries,
 		},
@@ -305,7 +305,7 @@ func (f *Ferry) NewIterativeVerifier() (*IterativeVerifier, error) {
 		CursorConfig: &CursorConfig{
 			DB:                        f.SourceDB,
 			// BatchSize is a pointer to make this value updatable
-			BatchSize:                 &f.Config.DataIterationBatchSize,
+			BatchSize:                 &f.Config.UpdatableConfig.DataIterationBatchSize,
 			BatchSizePerTableOverride: f.Config.DataIterationBatchSizePerTableOverride,
 			ReadRetries:               f.Config.DBReadRetries,
 		},

--- a/ferry.go
+++ b/ferry.go
@@ -304,7 +304,6 @@ func (f *Ferry) NewIterativeVerifier() (*IterativeVerifier, error) {
 	v := &IterativeVerifier{
 		CursorConfig: &CursorConfig{
 			DB:                        f.SourceDB,
-			// BatchSize is a pointer to make this value updatable
 			BatchSize:                 &f.Config.UpdatableConfig.DataIterationBatchSize,
 			BatchSizePerTableOverride: f.Config.DataIterationBatchSizePerTableOverride,
 			ReadRetries:               f.Config.DBReadRetries,
@@ -532,7 +531,7 @@ func (f *Ferry) Initialize() (err error) {
 	f.DataIterator = f.NewDataIterator()
 	f.BatchWriter = f.NewBatchWriter()
 
-	if f.Config.ControlServerConfig.EnableControlServer {
+	if f.Config.ControlServerConfig.Enabled {
 		f.ControlServer, err = f.NewControlServer()
 		if err != nil {
 			return err
@@ -664,7 +663,7 @@ func (f *Ferry) Run() {
 		handleError("throttler", f.Throttler.Run(ctx))
 	}()
 
-	if f.Config.ControlServerConfig.EnableControlServer {
+	if f.Config.ControlServerConfig.Enabled {
 		go f.ControlServer.Run()
 	}
 

--- a/iterative_verifier.go
+++ b/iterative_verifier.go
@@ -435,7 +435,7 @@ func (v *IterativeVerifier) iterateTableFingerprints(table *TableSchema, mismatc
 }
 
 func (v *IterativeVerifier) verifyStore(sourceTag string, additionalTags []MetricTag) (VerificationResult, error) {
-	allBatches := v.reverifyStore.FlushAndBatchByTable(int(v.CursorConfig.BatchSize))
+	allBatches := v.reverifyStore.FlushAndBatchByTable(int(*v.CursorConfig.BatchSize))
 	v.logger.WithField("batches", len(allBatches)).Debug("reverifying")
 
 	if len(allBatches) == 0 {

--- a/test/go/config_test.go
+++ b/test/go/config_test.go
@@ -118,7 +118,7 @@ func (this *ConfigTestSuite) TestDefaultValues() {
 	this.Require().Equal("tcp", this.config.Source.Net)
 	this.Require().Equal("tcp", this.config.Target.Net)
 	this.Require().Equal(5, this.config.DBWriteRetries)
-	this.Require().Equal(uint64(200), this.config.DataIterationBatchSize)
+	this.Require().Equal(uint64(200), this.config.UpdatableConfig.DataIterationBatchSize)
 	this.Require().Equal(4, this.config.DataIterationConcurrency)
 	this.Require().Equal(5, this.config.DBReadRetries)
 	this.Require().Equal("0.0.0.0:8000", this.config.ControlServerConfig.ServerBindAddr)

--- a/test/go/config_test.go
+++ b/test/go/config_test.go
@@ -121,8 +121,8 @@ func (this *ConfigTestSuite) TestDefaultValues() {
 	this.Require().Equal(uint64(200), this.config.DataIterationBatchSize)
 	this.Require().Equal(4, this.config.DataIterationConcurrency)
 	this.Require().Equal(5, this.config.DBReadRetries)
-	this.Require().Equal("0.0.0.0:8000", this.config.ServerBindAddr)
-	this.Require().Equal(".", this.config.WebBasedir)
+	this.Require().Equal("0.0.0.0:8000", this.config.ControlServerConfig.ServerBindAddr)
+	this.Require().Equal(".", this.config.ControlServerConfig.WebBasedir)
 }
 
 func (this *ConfigTestSuite) TestCorruptCert() {

--- a/test/go/data_iterator_test.go
+++ b/test/go/data_iterator_test.go
@@ -2,10 +2,9 @@ package test
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/suite"
 	"sync"
 	"testing"
-
-	"github.com/stretchr/testify/suite"
 
 	"github.com/Shopify/ghostferry"
 	"github.com/Shopify/ghostferry/testhelpers"
@@ -52,7 +51,7 @@ func (this *DataIteratorTestSuite) SetupTest() {
 			Throttler: throttler,
 
 			BuildSelect:               nil,
-			BatchSize:                 config.DataIterationBatchSize,
+			BatchSize:                 &config.DataIterationBatchSize,
 			BatchSizePerTableOverride: config.DataIterationBatchSizePerTableOverride,
 			ReadRetries:               config.DBReadRetries,
 		},
@@ -231,6 +230,11 @@ func (this *DataIteratorTestSuite) TestDataIterationBatchSizePerTableOverrideMax
 		// since 3276 > MaxRowSize  we default to use point ControlPoints[3000]
 		this.Require().Equal(uint64(4000), this.di.CursorConfig.GetBatchSize(table.Schema, table.Name))
 	}
+}
+
+func (this *DataIteratorTestSuite) TestBatchSizeUpdate() {
+	this.Ferry.Config.Update(ghostferry.UpdatableConfigs{DataIterationBatchSize: 1234})
+	this.Require().Equal(uint64(1234), this.di.CursorConfig.GetBatchSize(testhelpers.TestSchemaName, "any_table"))
 }
 
 func (this *DataIteratorTestSuite) TestDataIterationBatchSizePerTableOverrideCalculateBatchSize() {

--- a/test/go/data_iterator_test.go
+++ b/test/go/data_iterator_test.go
@@ -39,7 +39,7 @@ func (this *DataIteratorTestSuite) SetupTest() {
 	this.Ferry.Tables = tables
 	this.tables = tables.AsSlice()
 
-	config.DataIterationBatchSize = 2
+	config.UpdatableConfig.DataIterationBatchSize = 2
 
 	this.di = &ghostferry.DataIterator{
 		DB:          sourceDb,
@@ -51,7 +51,7 @@ func (this *DataIteratorTestSuite) SetupTest() {
 			Throttler: throttler,
 
 			BuildSelect:               nil,
-			BatchSize:                 &config.DataIterationBatchSize,
+			BatchSize:                 &config.UpdatableConfig.DataIterationBatchSize,
 			BatchSizePerTableOverride: config.DataIterationBatchSizePerTableOverride,
 			ReadRetries:               config.DBReadRetries,
 		},
@@ -187,7 +187,7 @@ func (this *DataIteratorTestSuite) TestDataIterationBatchSizePerTableOverride() 
 		// Using linear interpolation with points ControlPoints[3000] and ControlPoints[4000] gives 3862
 		this.Require().Equal(uint64(3862), this.di.CursorConfig.GetBatchSize(table.Schema, table.Name))
 	}
-	this.Require().Equal(this.Ferry.Config.DataIterationBatchSize, this.di.CursorConfig.GetBatchSize("DNE", "DNE"))
+	this.Require().Equal(this.Ferry.Config.UpdatableConfig.DataIterationBatchSize, this.di.CursorConfig.GetBatchSize("DNE", "DNE"))
 }
 
 func (this *DataIteratorTestSuite) TestDataIterationBatchSizePerTableOverrideMinRowSize() {
@@ -233,7 +233,7 @@ func (this *DataIteratorTestSuite) TestDataIterationBatchSizePerTableOverrideMax
 }
 
 func (this *DataIteratorTestSuite) TestBatchSizeUpdate() {
-	this.Ferry.Config.Update(ghostferry.UpdatableConfigs{DataIterationBatchSize: 1234})
+	this.Ferry.Config.Update(ghostferry.UpdatableConfig{DataIterationBatchSize: 1234})
 	this.Require().Equal(uint64(1234), this.di.CursorConfig.GetBatchSize(testhelpers.TestSchemaName, "any_table"))
 }
 

--- a/test/go/iterative_verifier_integration_test.go
+++ b/test/go/iterative_verifier_integration_test.go
@@ -243,7 +243,7 @@ func TestVerificationPasses(t *testing.T) {
 func setupIterativeVerifierFromFerry(v *ghostferry.IterativeVerifier, f *ghostferry.Ferry) {
 	v.CursorConfig = &ghostferry.CursorConfig{
 		DB:          f.SourceDB,
-		BatchSize:   &f.Config.DataIterationBatchSize,
+		BatchSize:   &f.Config.UpdatableConfig.DataIterationBatchSize,
 		ReadRetries: f.Config.DBReadRetries,
 	}
 

--- a/test/go/iterative_verifier_integration_test.go
+++ b/test/go/iterative_verifier_integration_test.go
@@ -243,7 +243,7 @@ func TestVerificationPasses(t *testing.T) {
 func setupIterativeVerifierFromFerry(v *ghostferry.IterativeVerifier, f *ghostferry.Ferry) {
 	v.CursorConfig = &ghostferry.CursorConfig{
 		DB:          f.SourceDB,
-		BatchSize:   f.Config.DataIterationBatchSize,
+		BatchSize:   &f.Config.DataIterationBatchSize,
 		ReadRetries: f.Config.DBReadRetries,
 	}
 

--- a/test/go/iterative_verifier_test.go
+++ b/test/go/iterative_verifier_test.go
@@ -40,7 +40,7 @@ func (t *IterativeVerifierTestSuite) SetupTest() {
 		CompressionVerifier: compressionVerifier,
 		CursorConfig: &ghostferry.CursorConfig{
 			DB:          t.Ferry.SourceDB,
-			BatchSize:   t.Ferry.Config.DataIterationBatchSize,
+			BatchSize:   &t.Ferry.Config.DataIterationBatchSize,
 			ReadRetries: t.Ferry.Config.DBReadRetries,
 		},
 		BinlogStreamer: t.Ferry.BinlogStreamer,

--- a/test/go/iterative_verifier_test.go
+++ b/test/go/iterative_verifier_test.go
@@ -40,7 +40,7 @@ func (t *IterativeVerifierTestSuite) SetupTest() {
 		CompressionVerifier: compressionVerifier,
 		CursorConfig: &ghostferry.CursorConfig{
 			DB:          t.Ferry.SourceDB,
-			BatchSize:   &t.Ferry.Config.DataIterationBatchSize,
+			BatchSize:   &t.Ferry.Config.UpdatableConfig.DataIterationBatchSize,
 			ReadRetries: t.Ferry.Config.DBReadRetries,
 		},
 		BinlogStreamer: t.Ferry.BinlogStreamer,

--- a/test/go/race_conditions_integration_test.go
+++ b/test/go/race_conditions_integration_test.go
@@ -145,7 +145,7 @@ func TestOnlyDeleteRowWithMaxPaginationKey(t *testing.T) {
 		Ferry: testhelpers.NewTestFerry(),
 	}
 
-	testcase.Ferry.DataIterationBatchSize = 1
+	testcase.Ferry.UpdatableConfig.DataIterationBatchSize = 1
 
 	lastRowDeleted := false
 	testcase.Ferry.BeforeBatchCopyListener = func(batch *ghostferry.RowBatch) error {

--- a/webui/index.html
+++ b/webui/index.html
@@ -238,6 +238,7 @@
               <th>Status</th>
               <th>Last Successful PaginationKey</th>
               <th>Target PaginationKey</th>
+              <th>Batch Size</th>
             </tr>
           </thead>
           <tbody>
@@ -248,6 +249,7 @@
                 <td>{{.Status}}</td>
                 <td>{{.LastSuccessfulPaginationKey}}</td>
                 <td>{{.TargetPaginationKey}}</td>
+                <td>{{.BatchSize}}</td>
               </tr>
             {{end}}
           </tbody>
@@ -255,6 +257,7 @@
       </div>
     </div>
   </div>
+
 
   <script>
     var lastUpdatedSpan = document.getElementById("last-updated");


### PR DESCRIPTION
Re: https://github.com/Shopify/ghostferry/issues/265

As part of the above issue I was looking into a way to implement dynamic configuration via the control server.
This PR adds a new endpoint to the `ControlServer` which allows dynamic reconfiguration, currently it only supports updating the `DataIterationBatchSize` value.

Another important change is the move of  `ControlServer` into `Ferry` as an optional component, disabled by default and enabled for copydb. This will allow to use the dynamic reconfiguration and other `ControlServer` endpoints outside of copydb.