### PR TITLE
Only log when failing to call report state callback

### DIFF
--- a/ferry.go
+++ b/ferry.go
@@ -1047,6 +1047,7 @@ func (f *Ferry) ReportState() {
 	state, err := f.SerializeStateToJSON()
 	if err != nil {
 		f.logger.WithError(err).Error("failed to serialize state to JSON")
+		return
 	}
 
 	callback.Payload = string(state)


### PR DESCRIPTION
We should not panic the process if an external callback endpoint give us a bad reply.