### PR TITLE
Rename lag to lag_value in tests

### DIFF
--- a/test/go/lag_throttler_test.go
+++ b/test/go/lag_throttler_test.go
@@ -38,12 +38,12 @@ func setupLagTable(db *sql.DB, ctx context.Context) {
 	_, err = db.Exec("CREATE DATABASE meta")
 	testhelpers.PanicIfError(err)
 
-	_, err = db.Exec("CREATE TABLE meta.lag_table (lag FLOAT NOT NULL, server_id int unsigned NOT NULL PRIMARY KEY)")
+	_, err = db.Exec("CREATE TABLE meta.lag_table (lag_value FLOAT NOT NULL, server_id int unsigned NOT NULL PRIMARY KEY)")
 	testhelpers.PanicIfError(err)
 }
 
 func setLag(throttler *ghostferry.LagThrottler, serverId int, lag float32) {
-	_, err := throttler.DB.Exec("INSERT INTO meta.lag_table (lag, server_id) VALUES (?, ?) ON DUPLICATE KEY UPDATE lag = ?", lag, serverId, lag)
+	_, err := throttler.DB.Exec("INSERT INTO meta.lag_table (lag_value, server_id) VALUES (?, ?) ON DUPLICATE KEY UPDATE lag_value = ?", lag, serverId, lag)
 	testhelpers.PanicIfError(err)
 	time.Sleep(10 * time.Millisecond)
 }


### PR DESCRIPTION
`lag` is a keyword in MySQL 8, so using it as a column name creates syntax problems.

E.g. 

This is OK in MySQL 5.7:
```sql
CREATE TABLE foo (lag FLOAT NOT NULL);
```

But in MySQL 8.0+, it spits out this error:
```
Schema Error: Error: ER_PARSE_ERROR: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'lag FLOAT NOT NULL)' at line 1
```

⏯️ [Try it on DB Fiddle](https://www.db-fiddle.com/f/mgiTY55MPjynhbu5aqRKez/1)

----

Ref. [New keywords in MySQL 8](https://dev.mysql.com/doc/refman/8.0/en/keywords.html#keywords-new-8-0-L)