### PR TITLE
update dev setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.16
+          go-version: 1.18
 
       - name: Starting up MySQL
         run: .github/workflows/start-mysql.sh
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.16
+          go-version: 1.18
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2

--- a/dev.yml
+++ b/dev.yml
@@ -9,7 +9,7 @@ up:
   - ruby
   - bundler
   - go:
-      version: "1.16"
+      version: "1.18"
   - podman
   - custom:
       name: Go Dependencies

--- a/dev.yml
+++ b/dev.yml
@@ -5,7 +5,7 @@ env:
 
 up:
   - packages:
-      - mysql-client@5.7
+      - mysql_client
   - ruby
   - bundler
   - go:

--- a/shell.nix
+++ b/shell.nix
@@ -15,7 +15,7 @@ in stdenv.mkDerivation {
   buildInputs = [
     env
     ruby
-    go_1_16
+    go_1_18
     mysql57
   ];
 }


### PR DESCRIPTION
there are a few hiccups when setting up ghostferry locally, so this PR addresses these issues:
- some modules require go version 1.18
- use correct dev `mysql_client` package