### PR TITLE
Speed up the test DataWriter to help with a flaky test

### DIFF
--- a/test/helpers/data_writer_helper.rb
+++ b/test/helpers/data_writer_helper.rb
@@ -65,10 +65,10 @@ module DataWriterHelper
 
             until @stop_requested do
               write_data(connection, &on_write)
-              n += 1
               # Kind of makes the following race condition a bit better...
               # https://github.com/Shopify/ghostferry/issues/280
-              sleep(0.03)
+              sleep(0.03) if n > 10
+              n += 1
             end
           ensure
             connection.close


### PR DESCRIPTION
Improves `InterruptResumeTest#test_interrupt_resume_inline_verifier_with_datawriter` flakiness ([sample build](https://github.com/Shopify/ghostferry/actions/runs/11256073582/job/31297085505)). 

My assumption is that `ghostferry.run_expecting_interrupt` was able to send and handle the `TERM` signal before it received anything from `DataWriter`, which only starts in a callback inside `start_datawriter_with_ghostferry`.

https://github.com/Shopify/ghostferry/blob/6df01d3ecba8bcc4fcf557809a5e92801c4afdb6/test/integration/interrupt_resume_test.rb#L124-L143

`./test_loop.sh 100 "ruby test/main.rb -v -n "InterruptResumeTest#test_interrupt_resume_inline_verifier_with_datawriter""` passes with `n = 10` 🎉 

It's a magic number (bad) and ideally these kind of tests could be set up in a deterministic way (e.g. using mocking + semaphores), but this could still be a net positive to the test suite stability.

TODO:
- [ ] https://github.com/Shopify/ghostferry/actions/runs/12164156108/job/33925112440?pr=371 got stuck (deadlocked?), find out why

---
`test_loop.sh` in case you'd like to try this locally
```
#!/bin/bash
if [ "$#" -ne 2 ]; then
    echo "Usage: $0 <number_of_runs> <command>"
    exit 1
fi
n=$1
command=$2
all_success=true
for ((i=1; i<=n; i++)); do
    echo "Running command: $command (Run $i)"

    eval $command

    if [ $? -ne 0 ]; then
        all_success=false
    fi
done
echo $all_success
```