### PR TITLE
Fix docs build & warnings, update sphinx deps and create a venv to avoid clashes

### DIFF
--- a/.github/workflows/build-docs.sh
+++ b/.github/workflows/build-docs.sh
@@ -4,7 +4,11 @@ set -xe
 
 sudo apt-get update
 sudo apt-get install -y python3-pip
-sudo pip3 install sphinx==1.8.5
+
+python3 -m venv ./venv
+source venv/bin/activate
+
+pip3 install sphinx==8.1.3
 cd docs
 make html
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,7 +46,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Ghostferry'
-copyright = u'2017, Shopify'
+copyright = u'2017-2024, Shopify'
 author = u'Shopify'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -63,7 +63,7 @@ release = u'1.0.0'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/source/verifiers.rst
+++ b/docs/source/verifiers.rst
@@ -96,7 +96,7 @@ cases are possible.
        algorithm to enumerate the table and tail the binlogs.
 
 IterativeVerifier (Deprecated)
------------------
+------------------------------
 
 **NOTE! This is a deprecated verifier. Use the InlineVerifier instead.**
 


### PR DESCRIPTION
The Sphinx update introduced just a few minor changes to the page: spacing in navbar and slightly different looks of the code blocks. I'd say we keep these defaults?

Tested the build locally using podman ubuntu