### PR TITLE
Use 64 bit size when formatting FloatWithTrailingZero

### DIFF
--- a/vendor/github.com/go-mysql-org/go-mysql/replication/json_binary.go
+++ b/vendor/github.com/go-mysql-org/go-mysql/replication/json_binary.go
@@ -49,10 +49,10 @@ type FloatWithTrailingZero float64
 
 func (f FloatWithTrailingZero) MarshalJSON() ([]byte, error) {
 	if float64(f) == float64(int(f)) {
-		return []byte(strconv.FormatFloat(float64(f), 'f', 1, 32)), nil
+		return []byte(strconv.FormatFloat(float64(f), 'f', 1, 64)), nil
 	}
 
-	return []byte(strconv.FormatFloat(float64(f), 'f', -1, 32)), nil
+	return []byte(strconv.FormatFloat(float64(f), 'f', -1, 64)), nil
 }
 
 func jsonbGetOffsetSize(isSmall bool) int {


### PR DESCRIPTION
Caused errors with moves that involve double precision numbers in JSON blobs.

Failed move included lat and long values that were added to the test case (and verified as passing before the initial FloatWithTrailingZero fix in https://github.com/Shopify/ghostferry/pull/368))

https://app.shopify.com/services/internal/shop_mover/queues/24399136440/progress