### PR TITLE
Manage index hinting for sharding data iterator query

### DIFF
--- a/sharding/config.go
+++ b/sharding/config.go
@@ -2,6 +2,7 @@ package sharding
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Shopify/ghostferry"
 )
@@ -29,6 +30,9 @@ type Config struct {
 	PrimaryKeyTables []string
 
 	Throttle *ghostferry.LagThrottlerConfig
+
+	// ShardedCopyFilterConfig is used to configure the sharded copy filter query.
+	ShardedCopyFilterConfig *ShardedCopyFilterConfig
 }
 
 func (c *Config) ValidateConfig() error {
@@ -42,5 +46,75 @@ func (c *Config) ValidateConfig() error {
 		}
 	}
 
+	if err := c.ShardedCopyFilterConfig.Validate(); err != nil {
+		return err
+	}
+
 	return c.Config.ValidateConfig()
+}
+
+type ShardedCopyFilterConfig struct {
+	// Ghostferry requires an index to be present on sharding key to improve the performance of the data iterator's query.
+
+	// `use` is used by default as part of the index hint i.e. `USE INDEX`.
+	// `USE INDEX` is taken as a suggestion and optimizer can still opt in to use full table scan if it thinks it's faster.
+	//
+	// `force` replaces `USE INDEX` with `FORCE INDEX` on the query.
+	// `FORCE INDEX` will force the optimizer to use the index and will not consider other options like full table scan.
+	//
+	// `none` will not use any index hint.
+
+	// See https://dev.mysql.com/doc/refman/8.0/en/index-hints.html for more information on index hints.
+	IndexHint string // none or force or use
+
+	// IndexHintingPerTable has greatest specificity and takes precedence over the other options if specified.
+	// Otherwise it will inherit the higher level IndexHint.
+	// IndexName option is ignored if IndexHint is "none".
+	// IndexName option is ignored if it is not an index on the table.
+	//
+	// example:
+	// IndexHintingPerTable: {
+	//   "blog": {
+	//     "users": {
+	//       "IndexHint": "force",
+	//       "IndexName": "ix_users_some_id"
+	//     }
+	//   }
+	// }
+	IndexHintingPerTable map[string]map[string]IndexConfigPerTable
+}
+
+// SchemaName => TableName => IndexConfig
+func (c *ShardedCopyFilterConfig) IndexConfigForTables(schemaName string) map[string]IndexConfigPerTable {
+	tableConfig, found := c.IndexHintingPerTable[schemaName]
+	if !found {
+		return nil
+	}
+
+	return tableConfig
+}
+
+func (c *ShardedCopyFilterConfig) Validate() error {
+	if c.IndexHint == "" {
+		c.IndexHint = "use"
+	}
+
+	indexHint := strings.ToLower(c.IndexHint)
+
+	if indexHint != "none" && indexHint != "force" && indexHint != "use" {
+		return fmt.Errorf("IndexHint must be one of: none, force, use")
+	}
+
+	if c.IndexHintingPerTable != nil {
+		for _, tableConfig := range c.IndexHintingPerTable {
+			for tableName, indexConfig := range tableConfig {
+				tableIndexHint := strings.ToLower(indexConfig.IndexHint)
+				if tableIndexHint != "" && tableIndexHint != "none" && tableIndexHint != "force" && tableIndexHint != "use" {
+					return fmt.Errorf("For table %s, IndexHint must be one of: none, force, use", tableName)
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/sharding/test/config_test.go
+++ b/sharding/test/config_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestConfigWithBothIncludedAndIgnoredTablesIsInvalid(t *testing.T)  {
+func TestConfigWithBothIncludedAndIgnoredTablesIsInvalid(t *testing.T) {
 	config := sharding.Config{
 		IncludedTables: []string{"table_one", "table_two"},
 		IgnoredTables:  []string{"table_one", "table_two"},
@@ -18,13 +18,71 @@ func TestConfigWithBothIncludedAndIgnoredTablesIsInvalid(t *testing.T)  {
 	assert.EqualError(t, err, "IgnoredTables and IncludedTables cannot be defined at the same time.")
 }
 
-
-func TestConfigWithRunFerryFromReplicaWithoutValidSourceReplicationMasterIsInvalid(t *testing.T)  {
+func TestConfigWithRunFerryFromReplicaWithoutValidSourceReplicationMasterIsInvalid(t *testing.T) {
 	config := sharding.Config{
-		RunFerryFromReplica: true,
+		RunFerryFromReplica:     true,
 		SourceReplicationMaster: &ghostferry.DatabaseConfig{},
 	}
 
 	err := config.ValidateConfig()
 	assert.EqualError(t, err, "host is empty")
+}
+
+func TestConfigWithInvalidIndexHintIsInvalid(t *testing.T) {
+	config := sharding.Config{
+		ShardedCopyFilterConfig: &sharding.ShardedCopyFilterConfig{
+			IndexHint: "invalid",
+		},
+	}
+
+	err := config.ValidateConfig()
+	assert.EqualError(t, err, "IndexHint must be one of: none, force, use")
+}
+
+func TestConfigWithInvalidIndexHintForTableIsInvalid(t *testing.T) {
+	config := sharding.Config{
+		ShardedCopyFilterConfig: &sharding.ShardedCopyFilterConfig{
+			IndexHintingPerTable: map[string]map[string]sharding.IndexConfigPerTable{
+				"schema_one": {
+					"table_one": {
+						IndexHint: "invalid",
+					},
+				},
+			},
+		},
+	}
+
+	err := config.ValidateConfig()
+	assert.EqualError(t, err, "For table table_one, IndexHint must be one of: none, force, use")
+}
+
+func TestIndexConfigPerTableWithValues(t *testing.T) {
+	config := sharding.Config{
+		ShardedCopyFilterConfig: &sharding.ShardedCopyFilterConfig{
+			IndexHintingPerTable: map[string]map[string]sharding.IndexConfigPerTable{
+				"schema_one": {
+					"table_one": {
+						IndexHint: "force",
+						IndexName: "ix_table_one_id",
+					},
+				},
+			},
+		},
+	}
+
+	indexConfig := config.ShardedCopyFilterConfig.IndexConfigForTables("schema_one")
+	assert.Equal(t, indexConfig["table_one"].IndexHint, "force")
+	assert.Equal(t, indexConfig["table_one"].IndexName, "ix_table_one_id")
+}
+
+func TestIndexConfigPerTableWithNoValues(t *testing.T) {
+	config := sharding.Config{
+		ShardedCopyFilterConfig: &sharding.ShardedCopyFilterConfig{
+			IndexHintingPerTable: map[string]map[string]sharding.IndexConfigPerTable{},
+		},
+	}
+
+	indexConfig := config.ShardedCopyFilterConfig.IndexConfigForTables("schema_one")
+	assert.Equal(t, indexConfig["table_one"].IndexHint, "")
+	assert.Equal(t, indexConfig["table_one"].IndexName, "")
 }


### PR DESCRIPTION
Recently we have discovered that `USE INDEX` can slow the data iterator batching queries down as MySQL can decide to do a table scan instead, where as not using it allows the optimizer to select the correct index & avoid table scan. `FORCE INDEX` prevents MySQL from doing a table scan also but it removes the flexibility of selecting another index for the sharding key that might be more suitable. Another theory is that query optimizer is better in MySQL 8 and therefore we might not need to use "USE INDEX" to ensure MySQL is using the correct index with this version (index hinting was originally introduced for optimizer selecting the wrong index with 5.7 for some tables.)

This is why I am introducing a configuration to manage the index hinting for the sharded data iterator. 

```
IndexHint // "use" by default. Options "none", "use", "force"

IndexHintingPerTable // has higher specificity then higher level IndexHint if specified

example:
IndexHintingPerTable: { 
   "blog": { // schema name
      "users": { // table name
	 "IndexHint": "force" // has higher level specificity then higher level IndexHint
	 "IndexName": "ix_users_some_id" // defaults to empty string, will override the index chosen by Ghostferry
	},
      "accounts": {
          "IndexName": "ix_accounts_some_id" // indexName will be ignored if it doesn't exist on the table
          // will inherit the higher level IndexHint as not specified
     }
 }
 ```