### PR TITLE
fix(iterative_verifier): correct 'occured' -> 'occurred' in error log messages

### DIFF
--- a/iterative_verifier.go
+++ b/iterative_verifier.go
@@ -374,7 +374,7 @@ func (v *IterativeVerifier) iterateAllTables(mismatchedPaginationKeyFunc func(st
 
 			err := v.iterateTableFingerprints(table, mismatchedPaginationKeyFunc)
 			if err != nil {
-				v.logger.WithError(err).WithField("table", table.String()).Error("error occured during table verification")
+				v.logger.WithError(err).WithField("table", table.String()).Error("error occurred during table verification")
 			}
 			return nil, err
 		},
@@ -477,7 +477,7 @@ func (v *IterativeVerifier) verifyStore(sourceTag string, additionalTags []Metri
 
 			if resultAndErr.ErroredOrFailed() {
 				if resultAndErr.Error != nil {
-					v.logger.WithError(resultAndErr.Error).Error("error occured in reverification")
+					v.logger.WithError(resultAndErr.Error).Error("error occurred in reverification")
 				} else {
 					v.logger.Errorf("failed reverification: %s", resultAndErr.Result.Message)
 				}


### PR DESCRIPTION
Two zap log lines in `iterative_verifier.go` used `occured` instead of `occurred`:

- line 377: `error occured during table verification`
- line 480: `error occured in reverification`

Both messages are emitted by the table-verification routine and end up in production log output, so the spelling correction improves operator-facing telemetry. `go build ./...` stays clean against current `main` (`go vet` warnings on `test/go/*_test.go` are pre-existing and unrelated to this change).