### PR TITLE
Dump stacktraces from goroutines on timeouts for inspection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,10 @@ jobs:
     env:
       CI: "true"
       MYSQL_VERSION: ${{ matrix.mysql }}
+      # Emit full goroutine stacks (all goroutines, not just the crashing one)
+      # when the test binary panics or times out.  This is the primary
+      # diagnostic for stuck / deadlocked tests.
+      GOTRACEBACK: all
 
     steps:
       - uses: actions/checkout@v6.0.2

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,8 @@ test-go:
 		curl -sL $(GOTESTSUM_URL) | tar -xz -C ./bin gotestsum; \
 	fi
 
-	ulimit -n 1024 && ./bin/gotestsum --format short-verbose ./test/go ./copydb/test ./sharding/test -count 1 -p 1 -failfast
-	go test -v
+	ulimit -n 1024 && ./bin/gotestsum --format short-verbose ./test/go ./copydb/test ./sharding/test -count 1 -p 1 -failfast -timeout 5m
+	go test -v -timeout 5m
 
 test-ruby:
 	bundle install

--- a/slog_handler.go
+++ b/slog_handler.go
@@ -2,7 +2,9 @@ package ghostferry
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"reflect"
 )
 
 // loggerSlogHandler implements slog.Handler on top of a ghostferry Logger.
@@ -99,7 +101,98 @@ func applySlogAttrToLogger(l Logger, a slog.Attr, prefix string) Logger {
 	if a.Key == "" {
 		return l
 	}
-	return l.WithField(joinSlogPrefix(prefix, a.Key), a.Value.Any())
+	return l.WithField(joinSlogPrefix(prefix, a.Key), safeFieldValue(a.Value.Any()))
+}
+
+// safeFieldValue returns a value safe to hand to a structured-logging backend.
+//
+// Some third-party libraries log values that cannot be JSON-encoded. For
+// example, go-mysql's BinlogSyncer logs its entire config via
+// slog.Any("config", cfg), and that config contains func fields
+// (Option func(*client.Conn) error, Dialer). logrus's JSON formatter calls
+// json.Marshal on each field and fails on such values, printing
+// "Failed to obtain reader, failed to marshal fields to JSON, json:
+// unsupported type: func(*client.Conn) error" to stderr for every binlog
+// syncer created — which floods the test logs.
+//
+// To stay backend-agnostic, any value that contains an unmarshalable kind
+// (func, chan, or unsafe.Pointer) is rendered to a string via fmt instead of
+// being passed through as a live Go value. Ordinary values are returned
+// unchanged so normal structured fields are unaffected.
+func safeFieldValue(v any) any {
+	if v == nil {
+		return nil
+	}
+	if containsUnmarshalableKind(reflect.ValueOf(v), 0) {
+		return fmt.Sprintf("%+v", v)
+	}
+	return v
+}
+
+// containsUnmarshalableKind reports whether v contains a func, chan, or
+// unsafe.Pointer anywhere in its (possibly nested) structure. It guards
+// against unbounded recursion with a depth limit and treats anything beyond it
+// as unmarshalable so the value is stringified rather than risk a marshal
+// failure.
+func containsUnmarshalableKind(v reflect.Value, depth int) bool {
+	if !v.IsValid() {
+		return false
+	}
+	if depth > 8 {
+		return true
+	}
+
+	switch v.Kind() {
+	case reflect.Func, reflect.Chan, reflect.UnsafePointer:
+		return true
+	case reflect.Ptr, reflect.Interface:
+		if v.IsNil() {
+			return false
+		}
+		return containsUnmarshalableKind(v.Elem(), depth+1)
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if containsUnmarshalableKind(v.Field(i), depth+1) {
+				return true
+			}
+		}
+		return false
+	case reflect.Slice, reflect.Array:
+		elem := v.Type().Elem()
+		if isUnmarshalableType(elem) {
+			return true
+		}
+		for i := 0; i < v.Len(); i++ {
+			if containsUnmarshalableKind(v.Index(i), depth+1) {
+				return true
+			}
+		}
+		return false
+	case reflect.Map:
+		if isUnmarshalableType(v.Type().Elem()) || isUnmarshalableType(v.Type().Key()) {
+			return true
+		}
+		for _, k := range v.MapKeys() {
+			if containsUnmarshalableKind(v.MapIndex(k), depth+1) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+// isUnmarshalableType reports whether a type is (or trivially contains) a kind
+// that cannot be JSON-encoded. Used to short-circuit empty containers whose
+// element type alone makes them unsafe.
+func isUnmarshalableType(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Func, reflect.Chan, reflect.UnsafePointer:
+		return true
+	default:
+		return false
+	}
 }
 
 // joinSlogPrefix concatenates prefix and key with a dot, eliding the dot when

--- a/test/go/logger_test.go
+++ b/test/go/logger_test.go
@@ -614,6 +614,51 @@ func (s *LoggerTestSuite) TestNewSlogLoggerOutputIsValidJSON() {
 	}
 }
 
+// configWithFunc mimics the shape of go-mysql's BinlogSyncerConfig, which is
+// logged via slog.Any("config", cfg) and contains func fields that cannot be
+// JSON-encoded. See safeFieldValue in slog_handler.go.
+type configWithFunc struct {
+	ServerID uint32
+	Host     string
+	Option   func(conn *struct{}) error
+}
+
+// TestNewSlogLoggerHandlesUnmarshalableFields is a regression test for the
+// "Failed to obtain reader, failed to marshal fields to JSON, json:
+// unsupported type: func(...)" noise that flooded the logs whenever go-mysql's
+// BinlogSyncer logged its config (which contains func fields) through our slog
+// bridge with the logrus JSON formatter.
+func (s *LoggerTestSuite) TestNewSlogLoggerHandlesUnmarshalableFields() {
+	for _, b := range backends {
+		s.Run(string(b), func() {
+			var buf bytes.Buffer
+			useBackend(b, &buf)
+			ghostferry.SetLogJSONFormatter()
+
+			cfg := configWithFunc{
+				ServerID: 42,
+				Host:     "localhost",
+				Option:   func(_ *struct{}) error { return nil },
+			}
+
+			sl := ghostferry.NewSlogLogger(ghostferry.LogWithField("tag", "slog_unmarshalable"))
+			sl.Info("create BinlogSyncer", slog.Any("config", cfg))
+
+			out := buf.String()
+			s.Require().NotContains(out, "failed to marshal fields to JSON", "log line: %s", out)
+			s.Require().NotContains(out, "unsupported type", "log line: %s", out)
+
+			var parsed map[string]any
+			err := json.Unmarshal(buf.Bytes(), &parsed)
+			s.Require().NoError(err, "output should be valid JSON: %s", out)
+			s.Require().Equal("create BinlogSyncer", parsed["msg"])
+			// The config is stringified, so it should be present as a string
+			// field and include the non-func data.
+			s.Require().Contains(fmt.Sprintf("%v", parsed["config"]), "localhost")
+		})
+	}
+}
+
 func TestLoggerTestSuite(t *testing.T) {
 	suite.Run(t, new(LoggerTestSuite))
 }

--- a/test/helpers/blocking_gate_helper.rb
+++ b/test/helpers/blocking_gate_helper.rb
@@ -1,0 +1,73 @@
+require "thread"
+
+module BlockingGateHelper
+  # BlockingGate is a bounded synchronization primitive for integration tests
+  # that need to block Ghostferry's progress at a certain point (by blocking
+  # inside a status handler) until some other event releases it.
+  #
+  # Previously tests used a bare `sleep` with no argument inside a status
+  # handler to block the DataIterator/BinlogStreamer indefinitely, relying on
+  # a later status handler (e.g. AFTER_BINLOG_APPLY) to TERM the process and
+  # unblock everything. When the expected releasing event did not arrive (a
+  # legitimate ordering race), the handler slept forever. The Go side then hit
+  # its 30s HTTP client timeout and panicked, but the Ruby WEBrick handler
+  # thread stayed asleep, which blocked server shutdown and hung the whole
+  # suite until the CI job-level timeout.
+  #
+  # BlockingGate replaces the bare `sleep` with a wait that:
+  #   - returns immediately once #release is called, and
+  #   - raises a clear error after `timeout` seconds instead of blocking
+  #     forever, so a broken ordering assumption fails fast with a useful
+  #     message rather than wedging CI.
+  class BlockingGate
+    Error = Class.new(StandardError)
+    TimeoutError = Class.new(Error)
+
+    def initialize(label:, timeout: 20)
+      @label = label
+      @timeout = timeout
+      @mutex = Mutex.new
+      @cond = ConditionVariable.new
+      @released = false
+    end
+
+    # Block the calling thread until #release is called or `timeout` seconds
+    # elapse. Raises BlockingGate::TimeoutError on timeout.
+    def wait
+      deadline = monotonic_now + @timeout
+      @mutex.synchronize do
+        until @released
+          remaining = deadline - monotonic_now
+          if remaining <= 0
+            raise TimeoutError, "BlockingGate(#{@label}) timed out after #{@timeout}s waiting to be released"
+          end
+          @cond.wait(@mutex, remaining)
+        end
+      end
+    end
+
+    # Unblock any thread currently in #wait, and make future #wait calls
+    # return immediately. Idempotent.
+    def release
+      @mutex.synchronize do
+        @released = true
+        @cond.broadcast
+      end
+    end
+
+    def released?
+      @mutex.synchronize { @released }
+    end
+
+    private
+
+    def monotonic_now
+      ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+    end
+  end
+
+  # Convenience factory so tests can write `gate = blocking_gate(...)`.
+  def blocking_gate(label:, timeout: 20)
+    BlockingGate.new(label: label, timeout: timeout)
+  end
+end

--- a/test/helpers/ghostferry_helper.rb
+++ b/test/helpers/ghostferry_helper.rb
@@ -34,6 +34,12 @@ module GhostferryHelper
     ExitError = Class.new(Error)
     TimeoutError = Class.new(Error)
 
+    # Maximum time we are willing to wait for the Ghostferry subprocess thread
+    # to finish when joining (during term/kill/cleanup). Bounded so that a
+    # wedged subprocess or a status handler that never returns fails fast with
+    # a diagnostic instead of hanging until the CI job-level timeout.
+    SUBPROCESS_JOIN_TIMEOUT = 60
+
     module Status
       # This should be in sync with integrationferry.go
       READY = "READY"
@@ -61,6 +67,21 @@ module GhostferryHelper
 
       @status_handlers = {}
       @callback_handlers = {}
+
+      # Tracks status handlers that are currently executing in the WEBrick
+      # server thread, keyed by an incrementing id. Used to print which handler
+      # was running (and its backtrace) when a join times out, so a handler
+      # that blocks forever is immediately visible in CI logs.
+      @active_handlers = {}
+      @active_handlers_mutex = Mutex.new
+      @active_handler_seq = 0
+
+      # Controls whether non-JSON subprocess stderr (panic traces, goroutine
+      # dumps, GOTRACEBACK output) is echoed to $stderr in real time. For runs
+      # that are *expected* to interrupt/fail, the resulting panic stack is
+      # noise, so it is suppressed from the live stream (still buffered in
+      # @stderr and the debug log). It is forced on when diagnostics fire.
+      @live_stderr_diagnostics = true
 
       @server_thread = nil
       @server_watchdog_thread = nil
@@ -113,6 +134,10 @@ module GhostferryHelper
     # When using this method, you need to ensure that the datawriter has been
     # stopped properly (if you're using stop_datawriter_during_cutover).
     def run_expecting_interrupt(resuming_state = nil)
+      # The interrupt produces an expected PanicErrorHandler stack on stderr;
+      # suppress it from the live stream to keep CI logs readable. It is still
+      # buffered and printed on actual test failure.
+      @live_stderr_diagnostics = false
       run(resuming_state)
     rescue ExitError
       dumped_state = @stdout.join("")
@@ -124,6 +149,9 @@ module GhostferryHelper
     # Same as above - ensure that the datawriter has been
     # stopped properly (if you're using stop_datawriter_during_cutover).
     def run_expecting_failure(resuming_state = nil)
+      # Same rationale as run_expecting_interrupt: the failure path emits an
+      # expected panic stack that would otherwise be noise.
+      @live_stderr_diagnostics = false
       run(resuming_state)
     rescue ExitError
     else
@@ -186,7 +214,9 @@ module GhostferryHelper
           end
 
           @last_message_time = now
-          @status_handlers[status].each { |f| f.call(*data) } unless @status_handlers[status].nil?
+          unless @status_handlers[status].nil?
+            @status_handlers[status].each { |f| call_tracked_handler(status, f, data) }
+          end
         rescue StandardError => e
           # errors are not reported from WEBrick but the server should fail early
           # as this indicates there is likely a programming error.
@@ -305,12 +335,17 @@ module GhostferryHelper
                   if logline["level"] == "error"
                     @error_lines << logline
                   end
-                else
+                elsif @live_stderr_diagnostics
                   # Non-JSON stderr lines are runtime diagnostics: goroutine
                   # dumps (from SIGQUIT), panic traces, GOTRACEBACK output.
                   # Write them immediately to Ruby's stderr so they appear in
                   # CI logs in real time rather than only inside the
                   # post-failure debug buffer printed by LogCapturer.
+                  #
+                  # Suppressed for runs that are expected to interrupt/fail,
+                  # where the panic stack is noise; those lines are still kept
+                  # in @stderr and the debug log below. Forced back on when
+                  # diagnostics fire (join timeout / watchdog).
                   $stderr.puts(line)
                   $stderr.flush
                 end
@@ -395,12 +430,20 @@ module GhostferryHelper
 
     def term_and_wait_for_exit
       send_signal("TERM")
-      @subprocess_thread.join
+      join_subprocess_thread_or_diagnose("term_and_wait_for_exit")
     end
 
     def kill_and_wait_for_exit
       send_signal("KILL")
-      @subprocess_thread.join
+      join_subprocess_thread_or_diagnose("kill_and_wait_for_exit")
+    end
+
+    # Public entry point for an external watchdog (e.g. the test-level
+    # wall-clock watchdog) to dump diagnostics for this instance and ask the
+    # Go child to print its goroutine stacks.
+    def diagnose!(context)
+      dump_diagnostics(context)
+      send_signal("QUIT")
     end
 
     def kill
@@ -413,13 +456,90 @@ module GhostferryHelper
       @server_watchdog_thread.join if @server_watchdog_thread
 
       begin
-        @subprocess_thread.join if @subprocess_thread
+        join_subprocess_thread_or_diagnose("kill") if @subprocess_thread
       rescue ExitError
         # ignore
       end
     end
 
     private
+
+    # Joins the Ghostferry subprocess thread with a bound. On timeout it dumps
+    # diagnostics (Ruby thread backtraces, currently-running status handlers,
+    # and a Go goroutine dump via SIGQUIT) and raises TimeoutError instead of
+    # blocking forever. This is the safety net for a status handler that never
+    # returns or a subprocess that never exits.
+    def join_subprocess_thread_or_diagnose(context)
+      return if @subprocess_thread.nil?
+      return if @subprocess_thread.join(SUBPROCESS_JOIN_TIMEOUT)
+
+      dump_diagnostics(context)
+
+      # SIGQUIT asks the Go runtime to print all goroutine stacks to its
+      # stderr (captured by our reader loop / forwarded to $stderr). KILL then
+      # guarantees the process actually goes away so the thread can finish.
+      send_signal("QUIT")
+      @subprocess_thread.join(5)
+      send_signal("KILL")
+      @subprocess_thread.join(5)
+
+      raise TimeoutError, "ghostferry subprocess did not exit within #{SUBPROCESS_JOIN_TIMEOUT}s during #{context}"
+    end
+
+    # Wraps a status handler invocation so that, while it runs, it is recorded
+    # in @active_handlers. dump_diagnostics can then report exactly which
+    # handler (and which thread) is currently executing -- e.g. one blocked in
+    # BlockingGate#wait -- when a join times out.
+    def call_tracked_handler(status, handler, data)
+      id = nil
+      @active_handlers_mutex.synchronize do
+        id = (@active_handler_seq += 1)
+        @active_handlers[id] = {
+          status: status,
+          thread: Thread.current,
+          started_at: now,
+        }
+      end
+
+      begin
+        handler.call(*data)
+      ensure
+        @active_handlers_mutex.synchronize { @active_handlers.delete(id) }
+      end
+    end
+
+    # Prints diagnostics for a stuck subprocess/handler directly to $stderr so
+    # they show up in CI logs in real time (not only in the post-failure debug
+    # buffer).
+    def dump_diagnostics(context)
+      # Something is genuinely stuck: re-enable live stderr so the goroutine
+      # dump we are about to request (SIGQUIT) is visible in real time even if
+      # this run had suppressed it as an expected interrupt/failure.
+      @live_stderr_diagnostics = true
+
+      $stderr.puts("\n=== GHOSTFERRY RUBY HARNESS DIAGNOSTICS (#{context}) ===")
+      $stderr.puts("subprocess pid: #{@pid}")
+
+      active = @active_handlers_mutex.synchronize { @active_handlers.values.dup }
+      if active.empty?
+        $stderr.puts("no status handlers currently running")
+      else
+        active.each do |h|
+          elapsed = (now - h[:started_at]).round(1)
+          $stderr.puts("active status handler: #{h[:status]} (running #{elapsed}s)")
+          backtrace = h[:thread].backtrace || []
+          backtrace.each { |line| $stderr.puts("    #{line}") }
+        end
+      end
+
+      $stderr.puts("--- all ruby thread backtraces ---")
+      Thread.list.each do |t|
+        $stderr.puts("thread #{t.object_id} status=#{t.status.inspect}")
+        (t.backtrace || []).each { |line| $stderr.puts("    #{line}") }
+      end
+      $stderr.puts("=== END GHOSTFERRY RUBY HARNESS DIAGNOSTICS ===\n")
+      $stderr.flush
+    end
 
     def json_log_line?(line)
       line.start_with?("{")

--- a/test/helpers/ghostferry_helper.rb
+++ b/test/helpers/ghostferry_helper.rb
@@ -305,6 +305,14 @@ module GhostferryHelper
                   if logline["level"] == "error"
                     @error_lines << logline
                   end
+                else
+                  # Non-JSON stderr lines are runtime diagnostics: goroutine
+                  # dumps (from SIGQUIT), panic traces, GOTRACEBACK output.
+                  # Write them immediately to Ruby's stderr so they appear in
+                  # CI logs in real time rather than only inside the
+                  # post-failure debug buffer printed by LogCapturer.
+                  $stderr.puts(line)
+                  $stderr.flush
                 end
                 @logger.debug("stderr: #{line}")
               end
@@ -329,6 +337,16 @@ module GhostferryHelper
       @server_watchdog_thread = Thread.new do
         while @subprocess_thread.alive? do
           if (now - @last_message_time) > @message_timeout
+            # Ask the Go process to dump all goroutine stacks to its stderr
+            # before we shut down.  SIGQUIT is the standard Go
+            # goroutine-dump signal (equivalent to pressing Ctrl-\ on the
+            # terminal).  With GOTRACEBACK=all set in the environment, the
+            # runtime will print every goroutine — not just the crashing
+            # one — which is essential for diagnosing stuck tests.
+            @logger.warn("ghostferry watchdog: sending SIGQUIT to #{@pid} for goroutine dump")
+            send_signal("QUIT")
+            sleep 2 # allow the runtime to finish writing the dump to stderr
+
             @server.shutdown
             raise TimeoutError, "ghostferry did not report to the integration test server for the last #{@message_timeout}s"
           end

--- a/test/integration/interrupt_resume_test.rb
+++ b/test/integration/interrupt_resume_test.rb
@@ -173,14 +173,23 @@ class InterruptResumeTest < GhostferryTestCase
 
     ghostferry = new_ghostferry(MINIMAL_GHOSTFERRY, config: { verifier_type: "Inline" })
 
+    # Block the DataIterator (in AFTER_ROW_COPY) so it doesn't race with the
+    # term_and_wait_for_exit in AFTER_BINLOG_APPLY below. The gate is released
+    # by AFTER_BINLOG_APPLY before it terminates the process, so the blocked
+    # handler returns cleanly. If AFTER_BINLOG_APPLY never fires (an ordering
+    # race), the gate times out and fails the test instead of hanging the suite
+    # forever and letting the Go child hit its HTTP timeout.
+    iterator_gate = blocking_gate(label: "AFTER_ROW_COPY waiting for AFTER_BINLOG_APPLY")
+
     i = 0
     ghostferry.on_status(Ghostferry::Status::AFTER_ROW_COPY) do
-      sleep if i >= 1 # block the DataIterator so it doesn't race with the term_and_wait_for_exit below.
+      iterator_gate.wait if i >= 1
       source_db.query("INSERT INTO #{DEFAULT_FULL_TABLE_NAME} (id, data) VALUES (#{chosen_id}, 'data')")
       i += 1
     end
 
     ghostferry.on_status(Ghostferry::Status::AFTER_BINLOG_APPLY) do
+      iterator_gate.release
       ghostferry.term_and_wait_for_exit
     end
 
@@ -217,6 +226,14 @@ class InterruptResumeTest < GhostferryTestCase
     result = source_db.query("SELECT MIN(id) FROM #{DEFAULT_FULL_TABLE_NAME}")
     chosen_id = result.first["MIN(id)"] + 1
 
+    # Block the DataIterator (in AFTER_ROW_COPY) so it doesn't race with the
+    # term_and_wait_for_exit in AFTER_BINLOG_APPLY below. The gate is released
+    # by AFTER_BINLOG_APPLY before it terminates the process, so the blocked
+    # handler returns cleanly. If AFTER_BINLOG_APPLY never fires (an ordering
+    # race), the gate times out and fails the test instead of hanging the suite
+    # forever and letting the Go child hit its HTTP timeout.
+    iterator_gate = blocking_gate(label: "AFTER_ROW_COPY waiting for AFTER_BINLOG_APPLY")
+
     i = 0
     ghostferry.on_status(Ghostferry::Status::AFTER_ROW_COPY) do
       if i == 1
@@ -225,11 +242,12 @@ class InterruptResumeTest < GhostferryTestCase
         # DataIterator holds a FOR UPDATE lock for the minimum id row.
         source_db.query("DELETE FROM #{DEFAULT_FULL_TABLE_NAME} WHERE id = #{chosen_id}")
       end
-      sleep if i > 1 # block the DataIterator so it doesn't race with the term_and_wait_for_exit below.
+      iterator_gate.wait if i > 1
       i += 1
     end
 
     ghostferry.on_status(Ghostferry::Status::AFTER_BINLOG_APPLY) do
+      iterator_gate.release
       ghostferry.term_and_wait_for_exit
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -164,23 +164,29 @@ class GhostferryTestCase < Minitest::Test
   # Covers hangs anywhere in the test lifecycle, including setup, teardown,
   # datawriter joins, and DB queries -- not just inside Ghostferry#run.
   def start_test_watchdog
-    @test_watchdog_done = false
-    @test_watchdog_mutex = Mutex.new
-    @test_watchdog_cond = ConditionVariable.new
+    # A Queue is used purely as a blocking, interruptible timer: the watchdog
+    # thread blocks on pop with a timeout. stop_test_watchdog pushes a token to
+    # release it cleanly. This avoids ConditionVariable timeout subtleties and
+    # captures everything as locals so there is no cross-test ivar aliasing.
+    done_queue = Thread::Queue.new
+    @test_watchdog_done_queue = done_queue
     test_name = "#{self.class.name}##{self.name}"
+    timeout = TEST_WALL_CLOCK_TIMEOUT
+    ghostferry_instances = @ghostferry_instances
+    log_capturer = @log_capturer
 
     @test_watchdog_thread = Thread.new do
-      @test_watchdog_mutex.synchronize do
-        unless @test_watchdog_done
-          @test_watchdog_cond.wait(@test_watchdog_mutex, TEST_WALL_CLOCK_TIMEOUT)
-        end
-        next if @test_watchdog_done
-      end
+      # Thread::Queue#pop(timeout:) returns the pushed value on release, or nil
+      # when the timeout elapses (Ruby 3.2+). A non-nil value means
+      # stop_test_watchdog released us, so we exit quietly. nil means the test
+      # overran its wall-clock budget and we should fire.
+      token = done_queue.pop(timeout: timeout)
+      Thread.exit unless token.nil?
 
       $stderr.puts("\n=== GHOSTFERRY TEST WATCHDOG FIRED ===")
-      $stderr.puts("Test #{test_name.inspect} exceeded #{TEST_WALL_CLOCK_TIMEOUT}s.")
+      $stderr.puts("Test #{test_name.inspect} exceeded #{timeout}s.")
 
-      Array(@ghostferry_instances).each do |ghostferry|
+      Array(ghostferry_instances).each do |ghostferry|
         begin
           ghostferry.diagnose!("test_watchdog: #{test_name}")
         rescue StandardError => e
@@ -198,7 +204,7 @@ class GhostferryTestCase < Minitest::Test
 
       # Give the Go child a moment to flush its goroutine dump before we exit.
       sleep 2
-      @log_capturer.print_output
+      log_capturer.print_output
       $stderr.flush
       exit!(1)
     end
@@ -207,12 +213,10 @@ class GhostferryTestCase < Minitest::Test
   def stop_test_watchdog
     return unless @test_watchdog_thread
 
-    @test_watchdog_mutex.synchronize do
-      @test_watchdog_done = true
-      @test_watchdog_cond.broadcast
-    end
+    @test_watchdog_done_queue&.push(:done)
     @test_watchdog_thread.join(5)
     @test_watchdog_thread = nil
+    @test_watchdog_done_queue = nil
   end
 
   def on_term

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,7 @@ helpers_path   = File.join(test_path, "helpers")
 require "db_helper"
 require "ghostferry_helper"
 require "data_writer_helper"
+require "blocking_gate_helper"
 
 Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 Minitest::Retry.use!(exceptions_to_retry: [GhostferryHelper::Ghostferry::TimeoutError])
@@ -66,8 +67,17 @@ class GhostferryTestCase < Minitest::Test
   include GhostferryHelper
   include DbHelper
   include DataWriterHelper
+  include BlockingGateHelper
 
   MINIMAL_GHOSTFERRY = "minimal_ghostferry"
+
+  # Wall-clock budget for a single integration test, independent of the
+  # Ghostferry idle-message watchdog. This catches hangs that happen *outside*
+  # of an active Ghostferry#run, such as a wedged teardown or datawriter join.
+  # On timeout the watchdog dumps Ruby thread backtraces, asks every tracked
+  # Ghostferry subprocess for a goroutine dump (SIGQUIT), and exits the process
+  # so CI fails fast with diagnostics instead of waiting for the job timeout.
+  TEST_WALL_CLOCK_TIMEOUT = Integer(ENV.fetch("GHOSTFERRY_TEST_TIMEOUT", "240"))
 
   def new_ghostferry(filepath, config: {})
     # Transform path to something ruby understands
@@ -129,9 +139,13 @@ class GhostferryTestCase < Minitest::Test
 
     # Same thing with DataWriter as above
     @datawriter_instances = []
+
+    start_test_watchdog
   end
 
   def after_teardown
+    stop_test_watchdog
+
     @ghostferry_instances.each do |ghostferry|
       ghostferry.kill
     end
@@ -143,6 +157,62 @@ class GhostferryTestCase < Minitest::Test
     @log_capturer.print_output if self.failure
     @log_capturer.reset
     super
+  end
+
+  # Starts a background thread that fires after TEST_WALL_CLOCK_TIMEOUT and,
+  # if the test has not finished, dumps diagnostics and terminates the process.
+  # Covers hangs anywhere in the test lifecycle, including setup, teardown,
+  # datawriter joins, and DB queries -- not just inside Ghostferry#run.
+  def start_test_watchdog
+    @test_watchdog_done = false
+    @test_watchdog_mutex = Mutex.new
+    @test_watchdog_cond = ConditionVariable.new
+    test_name = "#{self.class.name}##{self.name}"
+
+    @test_watchdog_thread = Thread.new do
+      @test_watchdog_mutex.synchronize do
+        unless @test_watchdog_done
+          @test_watchdog_cond.wait(@test_watchdog_mutex, TEST_WALL_CLOCK_TIMEOUT)
+        end
+        next if @test_watchdog_done
+      end
+
+      $stderr.puts("\n=== GHOSTFERRY TEST WATCHDOG FIRED ===")
+      $stderr.puts("Test #{test_name.inspect} exceeded #{TEST_WALL_CLOCK_TIMEOUT}s.")
+
+      Array(@ghostferry_instances).each do |ghostferry|
+        begin
+          ghostferry.diagnose!("test_watchdog: #{test_name}")
+        rescue StandardError => e
+          $stderr.puts("failed to diagnose ghostferry instance: #{e.class}: #{e.message}")
+        end
+      end
+
+      $stderr.puts("--- all ruby thread backtraces ---")
+      Thread.list.each do |t|
+        $stderr.puts("thread #{t.object_id} status=#{t.status.inspect}")
+        (t.backtrace || []).each { |line| $stderr.puts("    #{line}") }
+      end
+      $stderr.puts("=== END GHOSTFERRY TEST WATCHDOG ===\n")
+      $stderr.flush
+
+      # Give the Go child a moment to flush its goroutine dump before we exit.
+      sleep 2
+      @log_capturer.print_output
+      $stderr.flush
+      exit!(1)
+    end
+  end
+
+  def stop_test_watchdog
+    return unless @test_watchdog_thread
+
+    @test_watchdog_mutex.synchronize do
+      @test_watchdog_done = true
+      @test_watchdog_cond.broadcast
+    end
+    @test_watchdog_thread.join(5)
+    @test_watchdog_thread = nil
   end
 
   def on_term

--- a/testhelpers/integration_test_case.go
+++ b/testhelpers/integration_test_case.go
@@ -2,13 +2,22 @@ package testhelpers
 
 import (
 	"fmt"
+	"os"
+	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	sql "github.com/Shopify/ghostferry/sqlwrapper"
 
 	"github.com/Shopify/ghostferry"
 )
+
+// integrationTestTimeout is the per-test deadline enforced by startWatchdog.
+// It is intentionally shorter than the -timeout flag passed to go test so
+// that the goroutine dump produced here is visible in CI logs before the
+// test binary is killed by the Go test runner.
+const integrationTestTimeout = 4 * time.Minute
 
 type IntegrationTestCase struct {
 	T *testing.T
@@ -32,9 +41,53 @@ type IntegrationTestCase struct {
 }
 
 func (this *IntegrationTestCase) Run() {
+	watchdogDone := this.startWatchdog()
+	defer close(watchdogDone)
 	defer this.Teardown()
 	this.CopyData()
 	this.VerifyData()
+}
+
+// startWatchdog starts a background goroutine that fires after
+// integrationTestTimeout.  When it fires it writes a full goroutine dump to
+// stderr — the primary diagnostic for a stuck / deadlocked test — then
+// terminates the process with exit code 1 so that CI sees a failure instead
+// of silently waiting for the job-level timeout.
+//
+// The caller must close the returned channel when the test finishes normally
+// so the watchdog goroutine exits cleanly.
+func (this *IntegrationTestCase) startWatchdog() chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-done:
+			return
+		case <-time.After(integrationTestTimeout):
+		}
+
+		// runtime.Stack with true collects stacks for all goroutines, not
+		// just the calling one.  1 MB is enough for hundreds of goroutines.
+		buf := make([]byte, 1<<20)
+		n := runtime.Stack(buf, true)
+
+		// Write directly to stderr so the output is not swallowed by the
+		// test runner's log-capture buffer.
+		fmt.Fprintf(os.Stderr,
+			"\n=== GHOSTFERRY INTEGRATION TEST WATCHDOG FIRED ===\n"+
+				"Test %q has been running for more than %s.\n"+
+				"All goroutines at the time of the hang:\n\n"+
+				"%s\n"+
+				"===================================================\n",
+			this.T.Name(), integrationTestTimeout, buf[:n])
+		os.Stderr.Sync()
+
+		// os.Exit terminates immediately, bypassing deferred teardown.
+		// This is intentional: the test is hung and we want fast CI
+		// failure with the diagnostic above rather than waiting for the
+		// GitHub Actions job timeout.
+		os.Exit(1)
+	}()
+	return done
 }
 
 func (this *IntegrationTestCase) CopyData() {


### PR DESCRIPTION
This should help debug timeouts that we are having in tests 