### PR TITLE
EXPLORATION: refactor BinlogStreamer onto go-mysql canal (findings)

### DIFF
--- a/binlog_streamer.go
+++ b/binlog_streamer.go
@@ -1,29 +1,26 @@
 package ghostferry
 
 import (
-	"context"
-	"crypto/tls"
 	sqlorig "database/sql"
-	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	sql "github.com/Shopify/ghostferry/sqlwrapper"
 
+	"github.com/go-mysql-org/go-mysql/canal"
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/replication"
 )
 
 const caughtUpThreshold = 10 * time.Second
 
-// this is passed into event handlers to keep track of state of the binlog event stream.
-type BinlogEventState struct {
-	evPosition               mysql.Position
-	isEventPositionResumable bool
-	isEventPositionValid     bool
-	nextFilename             string
-}
+// DDLEventHandler is an optional hook invoked for every schema-changing DDL
+// statement observed on the stream (canal's OnDDL). Returning an error aborts
+// the streamer. It replaces the previous raw AddBinlogEventHandler mechanism,
+// whose only real use was intercepting DDL QueryEvents.
+type DDLEventHandler func(schemaName, tableName string, query []byte) error
 
 type BinlogStreamer struct {
 	DB           *sql.DB
@@ -34,9 +31,6 @@ type BinlogStreamer struct {
 
 	TableSchema TableSchemaCache
 	LogTag      string
-
-	binlogSyncer   *replication.BinlogSyncer
-	binlogStreamer *replication.BinlogStreamer
 
 	// These rewrite structures are used specifically for the Target
 	// Verifier as it needs to map events streamed from the Target back
@@ -50,6 +44,11 @@ type BinlogStreamer struct {
 	// or GTID coordinates. An empty value is treated as file/position for
 	// backwards compatibility.
 	BinlogCoordinateMode BinlogCoordinateType
+
+	// DDLEventHandler, if set, is invoked for each schema-changing DDL.
+	DDLEventHandler DDLEventHandler
+
+	canal *canal.Canal
 
 	lastStreamedBinlogPosition  mysql.Position
 	lastResumableBinlogPosition mysql.Position
@@ -71,11 +70,17 @@ type BinlogStreamer struct {
 
 	logger         Logger
 	eventListeners []func([]DMLEvent) error
-	// eventhandlers can be attached to binlog Replication Events
-	// for any event that does not have a specific handler attached, a default eventHandler
-	// is provided (defaultEventHandler). Event handlers are provided the replication binLogEvent
-	// and a state object that carries information about the state of the binlog event stream.
-	eventHandlers map[string]func(*replication.BinlogEvent, []byte, *BinlogEventState) ([]byte, error)
+
+	// stopOnce guards canal.Close so the stop monitor and Run's defer never
+	// double-close the canal (canal.Close is not safe to call concurrently
+	// with itself while run() is tearing down).
+	stopOnce sync.Once
+
+	// query holds the annotated statement from the most recent RowsQueryEvent
+	// so it can be attached to the following RowsEvent (marginalia detection).
+	// canal delivers OnRowsQueryEvent before OnRow, so this is single-writer
+	// within the canal callback goroutine.
+	query []byte
 }
 
 func (s *BinlogStreamer) ensureLogger() {
@@ -88,17 +93,22 @@ func (s *BinlogStreamer) ensureLogger() {
 	}
 }
 
-func (s *BinlogStreamer) createBinlogSyncer() error {
-	var err error
-	var tlsConfig *tls.Config
-
-	if s.DBConfig.TLS != nil {
-		tlsConfig, err = s.DBConfig.TLS.BuildConfig()
-		if err != nil {
-			return err
-		}
+// coordinateMode returns the effective coordinate mode, treating the empty
+// value as file/position for backwards compatibility.
+func (s *BinlogStreamer) coordinateMode() BinlogCoordinateType {
+	if s.BinlogCoordinateMode == "" {
+		return BinlogCoordinateFilePosition
 	}
+	return s.BinlogCoordinateMode
+}
 
+// createCanal builds the canal instance. Unlike canal.NewDefaultConfig, dump
+// mode is explicitly disabled (no ExecutionPath): Ghostferry only streams the
+// binlog and does its own initial copy. Table filtering is left to Ghostferry's
+// TableSchemaCache/Filter rather than canal's include/exclude regex, to keep
+// behavior identical to the previous implementation.
+func (s *BinlogStreamer) createCanal() error {
+	var err error
 	if s.MyServerId == 0 {
 		s.MyServerId, err = s.generateNewServerId()
 		if err != nil {
@@ -107,23 +117,48 @@ func (s *BinlogStreamer) createBinlogSyncer() error {
 		}
 	}
 
-	syncerConfig := replication.BinlogSyncerConfig{
-		ServerID:                 s.MyServerId,
-		Host:                     s.DBConfig.Host,
-		Port:                     s.DBConfig.Port,
-		User:                     s.DBConfig.User,
-		Password:                 s.DBConfig.Pass,
-		TLSConfig:                tlsConfig,
-		UseDecimal:               true,
-		UseFloatWithTrailingZero: true,
-		TimestampStringLocation:  time.UTC,
-		Logger:                   NewSlogLogger(s.logger),
+	cfg := canal.NewDefaultConfig()
+	cfg.ServerID = s.MyServerId
+	cfg.Flavor = mysql.MySQLFlavor
+	cfg.User = s.DBConfig.User
+	cfg.Password = s.DBConfig.Pass
+	cfg.UseDecimal = true
+	cfg.ParseTime = false
+	cfg.TimestampStringLocation = time.UTC
+	cfg.Logger = NewSlogLogger(s.logger)
+	// Disable mysqldump: Ghostferry streams binlog only.
+	cfg.Dump.ExecutionPath = ""
+	// canal owns the event loop, so Ghostferry stops the stream by calling
+	// canal.Close(). Close() must interrupt the syncer goroutine, which
+	// otherwise parks in a blocking socket read with no data (e.g. after the
+	// source goes read-only at cutover). A ReadTimeout wakes that read
+	// periodically so Close() (which waits on the syncer goroutine) cannot
+	// deadlock, and a HeartbeatPeriod keeps an otherwise-idle connection alive.
+	cfg.HeartbeatPeriod = 1 * time.Second
+
+	if s.DBConfig.Net == "unix" {
+		cfg.Addr = s.DBConfig.Host
+	} else {
+		cfg.Addr = fmt.Sprintf("%s:%d", s.DBConfig.Host, s.DBConfig.Port)
 	}
 
-	s.binlogSyncer = replication.NewBinlogSyncer(syncerConfig)
+	if s.DBConfig.TLS != nil {
+		cfg.TLSConfig, err = s.DBConfig.TLS.BuildConfig()
+		if err != nil {
+			return err
+		}
+	}
+
+	s.canal, err = canal.NewCanal(cfg)
+	if err != nil {
+		return err
+	}
+	s.canal.SetEventHandler(&binlogEventHandler{streamer: s})
 	return nil
 }
 
+// ConnectBinlogStreamerToMysql starts streaming from the current server
+// file/position coordinate.
 func (s *BinlogStreamer) ConnectBinlogStreamerToMysql() (mysql.Position, error) {
 	s.ensureLogger()
 
@@ -139,8 +174,7 @@ func (s *BinlogStreamer) ConnectBinlogStreamerToMysql() (mysql.Position, error) 
 func (s *BinlogStreamer) ConnectBinlogStreamerToMysqlFrom(startFromBinlogPosition mysql.Position) (mysql.Position, error) {
 	s.ensureLogger()
 
-	err := s.createBinlogSyncer()
-	if err != nil {
+	if err := s.createCanal(); err != nil {
 		return mysql.Position{}, err
 	}
 
@@ -154,22 +188,7 @@ func (s *BinlogStreamer) ConnectBinlogStreamerToMysqlFrom(startFromBinlogPositio
 		"port":     s.DBConfig.Port,
 	}).Info("starting binlog streaming")
 
-	s.binlogStreamer, err = s.binlogSyncer.StartSync(s.lastStreamedBinlogPosition)
-	if err != nil {
-		s.logger.WithError(err).Error("unable to start binlog streamer")
-		return mysql.Position{}, err
-	}
-
-	return s.lastStreamedBinlogPosition, err
-}
-
-// coordinateMode returns the effective coordinate mode, treating the empty
-// value as file/position for backwards compatibility.
-func (s *BinlogStreamer) coordinateMode() BinlogCoordinateType {
-	if s.BinlogCoordinateMode == "" {
-		return BinlogCoordinateFilePosition
-	}
-	return s.BinlogCoordinateMode
+	return s.lastStreamedBinlogPosition, nil
 }
 
 // ConnectBinlogStreamerToMysqlWithCoordinate starts streaming from the current
@@ -220,8 +239,7 @@ func (s *BinlogStreamer) ConnectBinlogStreamerToMysqlSinceCoordinate(startFrom B
 }
 
 func (s *BinlogStreamer) connectBinlogStreamerFromGTID(startFrom BinlogCoordinate) (BinlogCoordinate, error) {
-	err := s.createBinlogSyncer()
-	if err != nil {
+	if err := s.createCanal(); err != nil {
 		return BinlogCoordinate{}, err
 	}
 
@@ -242,145 +260,7 @@ func (s *BinlogStreamer) connectBinlogStreamerFromGTID(startFrom BinlogCoordinat
 		"port":     s.DBConfig.Port,
 	}).Info("starting binlog streaming from GTID set")
 
-	s.binlogStreamer, err = s.binlogSyncer.StartSyncGTID(gtidSet)
-	if err != nil {
-		s.logger.WithError(err).Error("unable to start binlog streamer from GTID set")
-		return BinlogCoordinate{}, err
-	}
-
 	return NewGTIDCoordinate(s.lastStreamedGTIDSet.String()), nil
-}
-
-// the default event handler is called for replication binLogEvents that do not have a
-// separate event Handler registered.
-
-func (s *BinlogStreamer) defaultEventHandler(ev *replication.BinlogEvent, query []byte, es *BinlogEventState) ([]byte, error) {
-	var err error
-	switch e := ev.Event.(type) {
-	case *replication.RotateEvent:
-		// This event is used to keep the "current binlog filename" of the binlog streamer in sync.
-		es.nextFilename = string(e.NextLogName)
-
-		isFakeRotateEvent := ev.Header.LogPos == 0 && ev.Header.Timestamp == 0
-		if isFakeRotateEvent {
-			// Sometimes the RotateEvent is fake and not a real rotation. we want to ignore the log position in the header for those events
-			// https://github.com/percona/percona-server/blob/3ff016a46ce2cde58d8007ec9834f958da53cbea/sql/rpl_binlog_sender.cc#L278-L287
-			// https://github.com/percona/percona-server/blob/3ff016a46ce2cde58d8007ec9834f958da53cbea/sql/rpl_binlog_sender.cc#L904-L907
-
-			// However, we can always advance our lastStreamedBinlogPosition according to its data fields
-			es.evPosition = mysql.Position{
-				Name: string(e.NextLogName),
-				Pos:  uint32(e.Position),
-			}
-		}
-
-		s.logger.WithFields(Fields{
-			"new_position":  es.evPosition.Pos,
-			"new_filename":  es.evPosition.Name,
-			"last_position": s.lastStreamedBinlogPosition.Pos,
-			"last_filename": s.lastStreamedBinlogPosition.Name,
-		}).Info("binlog file rotated")
-	case *replication.FormatDescriptionEvent:
-		// This event is sent:
-		//   1) when our replication client connects to mysql
-		//   2) at the beginning of each binlog file
-		//
-		// For (1), if we are starting the binlog from a position that's greater
-		// than BIN_LOG_HEADER_SIZE (currently, 4th byte), this event's position
-		// is explicitly set to 0 and should not be considered valid according to
-		// the mysql source. See:
-		// https://github.com/percona/percona-server/blob/93165de1451548ff11dd32c3d3e5df0ff28cfcfa/sql/rpl_binlog_sender.cc#L1020-L1026
-		es.isEventPositionValid = ev.Header.LogPos != 0
-	case *replication.RowsQueryEvent:
-		// A RowsQueryEvent will always precede the corresponding RowsEvent
-		// if binlog_rows_query_log_events is enabled, and is used to get
-		// the full query that was executed on the master (with annotations)
-		// that is otherwise not possible to reconstruct
-		query = ev.Event.(*replication.RowsQueryEvent).Query
-	case *replication.RowsEvent:
-		err = s.handleRowsEvent(ev, query)
-		if err != nil {
-			s.logger.WithError(err).Error("failed to handle rows event")
-			s.ErrorHandler.Fatal("binlog_streamer", err)
-		}
-	case *replication.QueryEvent:
-		// DDL and administrative statements (CREATE TABLE, GRANT, etc.) commit
-		// via a QueryEvent rather than an XIDEvent, so their GTID is only
-		// visible here. Without this, the streamed GTID set would never
-		// advance past such a statement and a cutover whose stop target
-		// includes it would hang forever. go-mysql attaches the current
-		// executed GTID set (including this statement's GTID) to the event.
-		//
-		// Transaction-control statements ("BEGIN") also arrive as QueryEvents
-		// but do NOT commit anything; their GTID is captured at the closing
-		// XIDEvent instead, so we must skip them here to avoid advancing the
-		// streamed set before the transaction's rows have been applied.
-		if s.coordinateMode() == BinlogCoordinateGTID {
-			qe := ev.Event.(*replication.QueryEvent)
-			if qe.GSet != nil && !isTransactionControlQuery(qe.Query) {
-				// A DDL/admin statement is its own transaction; the pre-statement
-				// committed set is a safe resume point.
-				if s.lastStreamedGTIDSet != nil {
-					s.lastResumableGTIDSet = s.lastStreamedGTIDSet.Clone()
-				}
-				s.lastStreamedGTIDSet = qe.GSet.Clone()
-			}
-		}
-	case *replication.XIDEvent, *replication.GTIDEvent:
-		// With regards to DMLs, we see (at least) the following sequence
-		// of events in the binlog stream:
-		//
-		// - GTIDEvent  <- START of transaction
-		// - QueryEvent
-		// - RowsQueryEvent
-		// - TableMapEvent
-		// - RowsEvent
-		// - RowsEvent
-		// - XIDEvent   <- END of transaction
-		//
-		// *NOTE*
-		//
-		// First, RowsQueryEvent is only available with `binlog_rows_query_log_events`
-		// set to "ON".
-		//
-		// Second, there will be at least one (but potentially more) RowsEvents
-		// depending on the number of rows updated in the transaction.
-		//
-		// Lastly, GTIDEvents will only be available if they are enabled.
-		//
-		// As a result, the following case will set the last resumable position for
-		// interruption to EITHER the start (if using GTIDs) or the end of the
-		// last transaction
-		es.isEventPositionResumable = true
-
-		// GTID tracking. go-mysql maintains the current GTID set internally and
-		// attaches it to XIDEvent.GSet at commit boundaries, so we do not need
-		// to reconstruct it from raw GTIDEvent SID/GNO.
-		if s.coordinateMode() == BinlogCoordinateGTID {
-			switch tev := ev.Event.(type) {
-			case *replication.GTIDEvent:
-				// Start of a transaction. A safe resume point is the committed
-				// set that existed BEFORE this transaction, so that an
-				// interruption replays the whole in-flight transaction.
-				if s.lastStreamedGTIDSet != nil {
-					s.lastResumableGTIDSet = s.lastStreamedGTIDSet.Clone()
-				}
-			case *replication.XIDEvent:
-				// End of a transaction. GSet is the committed GTID set through
-				// this transaction. Clone to avoid aliasing go-mysql's mutable
-				// internal set.
-				if tev.GSet != nil {
-					s.lastStreamedGTIDSet = tev.GSet.Clone()
-				}
-			}
-		}
-
-		// Here we also reset the query event as we are either at the beginning
-		// or the end of the current/next transaction. As such, the query will be
-		// reset following the next RowsQueryEvent before the corresponding RowsEvent(s)
-		query = nil
-	}
-	return query, err
 }
 
 // shouldContinueStreaming reports whether the Run loop should keep streaming.
@@ -413,6 +293,10 @@ func (s *BinlogStreamer) shouldContinueStreaming() bool {
 	return !reached
 }
 
+// Run drives the canal until the stop coordinate is reached. canal owns the
+// low-level syncer, event loop, reconnect logic, position tracking and DDL
+// parsing; Ghostferry only observes events through binlogEventHandler and
+// decides when to stop.
 func (s *BinlogStreamer) Run() {
 	s.ensureLogger()
 
@@ -422,93 +306,62 @@ func (s *BinlogStreamer) Run() {
 			"lastStreamedBinlogPosition": s.lastStreamedBinlogPosition,
 			"coordinateMode":             s.coordinateMode(),
 		}).Info("exiting binlog streamer")
-		s.binlogSyncer.Close()
+		s.closeCanal()
 	}()
 
-	var query []byte
-	es := BinlogEventState{}
-
-	currentFilename := s.lastStreamedBinlogPosition.Name
-	es.nextFilename = s.lastStreamedBinlogPosition.Name
 	s.logger.Info("starting binlog streamer")
-	for s.shouldContinueStreaming() {
-		currentFilename = es.nextFilename
-		var ev *replication.BinlogEvent
-		var timedOut bool
-		var err error
 
-		// We wrap this code in an anonymous function so the context can be
-		// properly cancelled and not cause a memory leak.
-		func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-			defer cancel()
-			ev, err = s.binlogStreamer.GetEvent(ctx)
-			if err == context.DeadlineExceeded {
-				timedOut = true
-			} else if err != nil {
-				s.ErrorHandler.Fatal("binlog_streamer", err)
+	// canal owns the event loop and has no built-in "stop at coordinate", so
+	// Ghostferry's cutover semantics live in this background monitor. It also
+	// preserves the previous streamer's idle keep-alive: while streaming, it
+	// advances lastProcessedEventTime every tick so IsAlmostCaughtUp stays true
+	// on an idle source (matching the old GetEvent 500ms timeout behavior). Once
+	// the stop coordinate is reached it closes the canal exactly once, which
+	// unblocks RunFrom/StartFromGTID below.
+	stopMonitorDone := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(500 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopMonitorDone:
+				return
+			case <-ticker.C:
+				s.lastProcessedEventTime = time.Now()
+				if !s.shouldContinueStreaming() {
+					s.closeCanal()
+					return
+				}
 			}
-		}()
-
-		if timedOut {
-			s.lastProcessedEventTime = time.Now()
-			continue
 		}
+	}()
 
-		es.evPosition = mysql.Position{
-			Name: currentFilename,
-			Pos:  ev.Header.LogPos,
-		}
+	var err error
+	switch s.coordinateMode() {
+	case BinlogCoordinateGTID:
+		err = s.canal.StartFromGTID(s.lastStreamedGTIDSet)
+	default:
+		err = s.canal.RunFrom(s.lastStreamedBinlogPosition)
+	}
 
-		s.logger.WithFields(Fields{
-			"position":                   es.evPosition.Pos,
-			"file":                       es.evPosition.Name,
-			"type":                       fmt.Sprintf("%T", ev.Event),
-			"lastStreamedBinlogPosition": s.lastStreamedBinlogPosition,
-		}).Debug("reached position")
+	close(stopMonitorDone)
 
-		es.isEventPositionResumable = false
-		es.isEventPositionValid = true
-
-		// if there is a handler associated with this eventType, call it
-		eventTypeString := ev.Header.EventType.String()
-		if handler, ok := s.eventHandlers[eventTypeString]; ok {
-			query, err = handler(ev, query, &es)
-			if err != nil {
-				s.logger.WithError(err).Error("failed to handle event")
-				s.ErrorHandler.Fatal("binlog_streamer", err)
-			}
-		} else {
-			// call the default event handler for everything else
-			query, err = s.defaultEventHandler(ev, query, &es)
-		}
-
-		if es.isEventPositionValid {
-			evType := fmt.Sprintf("%T", ev.Event)
-			evTimestamp := ev.Header.Timestamp
-			s.updateLastStreamedPosAndTime(evTimestamp, es.evPosition, evType, es.isEventPositionResumable)
-		}
+	// A deliberate stop closes the canal, which surfaces as a context.Canceled
+	// / closed error from RunFrom. Only treat it as fatal if we were not
+	// stopping.
+	if err != nil && !s.stopRequested {
+		s.ErrorHandler.Fatal("binlog_streamer", err)
 	}
 }
 
-// Attach an event handler to a replication BinLogEvent
-// We only support attaching events to any of the events defined in
-// https://github.com/go-mysql-org/go-mysql/blob/master/replication/const.go
-// custom event handlers are provided the replication BinLogEvent and a state object
-// that carries the current state of the binlog event stream.
-func (s *BinlogStreamer) AddBinlogEventHandler(evType replication.EventType, eh func(*replication.BinlogEvent, []byte, *BinlogEventState) ([]byte, error)) error {
-	// verify that event-type is valid
-	// if eventTypeString is unrecognized, bail
-	eventTypeString := evType.String()
-	if eventTypeString == "UnknownEvent" {
-		return errors.New("Unknown event type")
-	}
-
-	if s.eventHandlers == nil {
-		s.eventHandlers = make(map[string]func(*replication.BinlogEvent, []byte, *BinlogEventState) ([]byte, error))
-	}
-	s.eventHandlers[eventTypeString] = eh
-	return nil
+// closeCanal closes the underlying canal exactly once. It is safe to call from
+// both the stop monitor goroutine and Run's defer.
+func (s *BinlogStreamer) closeCanal() {
+	s.stopOnce.Do(func() {
+		if s.canal != nil {
+			s.canal.Close()
+		}
+	})
 }
 
 func (s *BinlogStreamer) AddEventListener(listener func([]DMLEvent) error) {
@@ -603,20 +456,9 @@ func (s *BinlogStreamer) FlushAndStop() {
 	s.stopRequested = true
 }
 
-func (s *BinlogStreamer) updateLastStreamedPosAndTime(evTimestamp uint32, evPos mysql.Position, evType string, isResumablePosition bool) {
-	if evPos.Pos == 0 {
-		// This shouldn't happen, as the cases where it does happen are excluded and thus signal a programming error
-		s.logger.Panicf("tried to advance to a zero log position: %s %d %T", evPos.Name, evPos.Pos, evType)
-	}
-
-	s.lastStreamedBinlogPosition = evPos
-	if isResumablePosition {
-		s.lastResumableBinlogPosition = evPos
-	}
-
-	// The first couple of events when connecting the binlog syncer (RotateEvent
-	// and FormatDescriptionEvent) have a zero timestamp..  Ignore those for
-	// timing updates
+// updateLag emits the replication lag metric, throttled to once per second. The
+// event time is derived from the binlog event header timestamp.
+func (s *BinlogStreamer) updateLag(evTimestamp uint32) {
 	if evTimestamp == 0 {
 		return
 	}
@@ -631,27 +473,20 @@ func (s *BinlogStreamer) updateLastStreamedPosAndTime(evTimestamp uint32, evPos 
 	}
 }
 
-func (s *BinlogStreamer) handleRowsEvent(ev *replication.BinlogEvent, query []byte) error {
-	rowsEvent := ev.Event.(*replication.RowsEvent)
-
-	if ev.Header.LogPos == 0 {
-		// This shouldn't happen, as rows events always have a logpos.
-		s.logger.Panicf("logpos: %d %d %T", ev.Header.LogPos, ev.Header.Timestamp, ev.Event)
-	}
-
+// handleRowsEvent converts a canal RowsEvent into Ghostferry DMLEvents, applies
+// rewrites/filtering, stamps coordinates, and fans out to listeners.
+func (s *BinlogStreamer) handleRowsEvent(e *canal.RowsEvent) error {
 	pos := mysql.Position{
-		// The filename is only changed and visible during the RotateEvent, which
-		// is handled transparently in Run().
 		Name: s.lastStreamedBinlogPosition.Name,
-		Pos:  ev.Header.LogPos,
+		Pos:  e.Header.LogPos,
 	}
 
-	db := string(rowsEvent.Table.Schema)
+	db := string(e.Table.Schema)
 	if rewrittenDBName, exists := s.DatabaseRewrites[db]; exists {
 		db = rewrittenDBName
 	}
 
-	table := string(rowsEvent.Table.Table)
+	table := string(e.Table.Name)
 	if rewrittenTableName, exists := s.TableRewrites[table]; exists {
 		table = rewrittenTableName
 	}
@@ -661,7 +496,7 @@ func (s *BinlogStreamer) handleRowsEvent(ev *replication.BinlogEvent, query []by
 		return nil
 	}
 
-	dmlEvs, err := NewBinlogDMLEvents(tableFromSchemaCache, ev, pos, s.lastResumableBinlogPosition, query)
+	dmlEvs, err := NewBinlogDMLEventsFromCanal(tableFromSchemaCache, e, pos, s.lastResumableBinlogPosition, s.query)
 	if err != nil {
 		return err
 	}
@@ -674,9 +509,6 @@ func (s *BinlogStreamer) handleRowsEvent(ev *replication.BinlogEvent, query []by
 		currentCoord := NewGTIDCoordinateFromSet(s.lastStreamedGTIDSet)
 		resumableCoord := NewGTIDCoordinateFromSet(s.lastResumableGTIDSet)
 		for _, dmlEv := range dmlEvs {
-			// SetCoordinates is an internal capability (coordinateStamper), not
-			// part of the exported DMLEvent interface; all built-in events
-			// satisfy it via DMLEventBase.
 			if stamper, ok := dmlEv.(coordinateStamper); ok {
 				stamper.SetCoordinates(currentCoord, resumableCoord)
 			}
@@ -710,8 +542,7 @@ func (s *BinlogStreamer) handleRowsEvent(ev *replication.BinlogEvent, query []by
 	}
 
 	for _, listener := range s.eventListeners {
-		err := listener(events)
-		if err != nil {
+		if err := listener(events); err != nil {
 			return err
 		}
 	}
@@ -799,4 +630,124 @@ func idsOnServer(db *sql.DB) ([]uint32, error) {
 	}
 
 	return server_ids, nil
+}
+
+// binlogEventHandler implements canal.EventHandler. It is the single adapter
+// between canal's callback API and Ghostferry's DMLEvent/coordinate model.
+// This replaces the previous hand-rolled event loop and big event-type switch.
+type binlogEventHandler struct {
+	canal.DummyEventHandler
+	streamer *BinlogStreamer
+}
+
+func (h *binlogEventHandler) OnRotate(header *replication.EventHeader, e *replication.RotateEvent) error {
+	s := h.streamer
+	s.lastStreamedBinlogPosition = mysql.Position{
+		Name: string(e.NextLogName),
+		Pos:  uint32(e.Position),
+	}
+	s.logger.WithFields(Fields{
+		"new_position": s.lastStreamedBinlogPosition.Pos,
+		"new_filename": s.lastStreamedBinlogPosition.Name,
+	}).Info("binlog file rotated")
+	return nil
+}
+
+func (h *binlogEventHandler) OnRowsQueryEvent(e *replication.RowsQueryEvent) error {
+	// A RowsQueryEvent always precedes the corresponding RowsEvent when
+	// binlog_rows_query_log_events=ON. It carries the full query (with
+	// annotations/marginalia) so downstream can attach it to the row events.
+	h.streamer.query = e.Query
+	return nil
+}
+
+func (h *binlogEventHandler) OnRow(e *canal.RowsEvent) error {
+	s := h.streamer
+	s.updateLag(e.Header.Timestamp)
+	if e.Header.LogPos != 0 {
+		s.lastStreamedBinlogPosition.Pos = e.Header.LogPos
+	}
+	if err := s.handleRowsEvent(e); err != nil {
+		s.logger.WithError(err).Error("failed to handle rows event")
+		s.ErrorHandler.Fatal("binlog_streamer", err)
+	}
+	return nil
+}
+
+func (h *binlogEventHandler) OnGTID(header *replication.EventHeader, gtidEvent mysql.BinlogGTIDEvent) error {
+	s := h.streamer
+	s.updateLag(header.Timestamp)
+	if s.coordinateMode() != BinlogCoordinateGTID {
+		return nil
+	}
+	// Start of a transaction. A safe resume point is the committed set that
+	// existed BEFORE this transaction, so an interruption replays the whole
+	// in-flight transaction.
+	if s.lastStreamedGTIDSet != nil {
+		s.lastResumableGTIDSet = s.lastStreamedGTIDSet.Clone()
+	}
+	return nil
+}
+
+func (h *binlogEventHandler) OnXID(header *replication.EventHeader, pos mysql.Position) error {
+	s := h.streamer
+	s.updateLag(header.Timestamp)
+	s.lastResumableBinlogPosition = mysql.Position{Name: s.lastStreamedBinlogPosition.Name, Pos: pos.Pos}
+	if pos.Pos != 0 {
+		s.lastStreamedBinlogPosition.Pos = pos.Pos
+	}
+	// End of a transaction: advance the committed GTID set. canal maintains the
+	// executed set internally and exposes it via SyncedGTIDSet.
+	if s.coordinateMode() == BinlogCoordinateGTID {
+		s.advanceStreamedGTID(s.canal.SyncedGTIDSet())
+	}
+	// A new RowsQueryEvent will set the query before the next RowsEvent.
+	s.query = nil
+	return nil
+}
+
+func (h *binlogEventHandler) OnDDL(header *replication.EventHeader, nextPos mysql.Position, e *replication.QueryEvent) error {
+	s := h.streamer
+	s.updateLag(header.Timestamp)
+	if nextPos.Pos != 0 {
+		s.lastStreamedBinlogPosition.Pos = nextPos.Pos
+	}
+
+	// A DDL/admin statement commits as its own transaction without an XIDEvent,
+	// so advance the committed GTID set here too. Skip transaction-control
+	// statements, which commit at their XIDEvent.
+	if s.coordinateMode() == BinlogCoordinateGTID && !isTransactionControlQuery(e.Query) {
+		s.advanceStreamedGTID(s.canal.SyncedGTIDSet())
+	}
+
+	if s.DDLEventHandler != nil {
+		return s.DDLEventHandler(string(e.Schema), "", e.Query)
+	}
+	return nil
+}
+
+// advanceStreamedGTID advances the committed (streamed) GTID set to committed,
+// recording the previous committed set as the resumable point first so that an
+// interruption replays the whole just-committed transaction. It is a no-op when
+// committed is nil. Extracted so the transaction-boundary GTID logic is unit
+// testable without a live canal.
+func (s *BinlogStreamer) advanceStreamedGTID(committed mysql.GTIDSet) {
+	if committed == nil {
+		return
+	}
+	if s.lastStreamedGTIDSet != nil {
+		s.lastResumableGTIDSet = s.lastStreamedGTIDSet.Clone()
+	}
+	s.lastStreamedGTIDSet = committed.Clone()
+}
+
+func (h *binlogEventHandler) OnPosSynced(header *replication.EventHeader, pos mysql.Position, set mysql.GTIDSet, force bool) error {
+	if pos.Name != "" {
+		h.streamer.lastStreamedBinlogPosition.Name = pos.Name
+	}
+	return nil
+}
+
+func (h *binlogEventHandler) String() string {
+	return "ghostferryBinlogEventHandler"
 }

--- a/binlog_streamer_gtid_test.go
+++ b/binlog_streamer_gtid_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
-	"github.com/go-mysql-org/go-mysql/replication"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,36 +30,34 @@ func TestIsTransactionControlQuery(t *testing.T) {
 	assert.False(t, isTransactionControlQuery([]byte("GRANT ALL ON *.* TO 'x'@'%'")))
 }
 
-// TestQueryEventAdvancesStreamedGTID verifies that a DDL/admin QueryEvent
-// (which commits without an XIDEvent) advances the streamed GTID set, while a
-// BEGIN QueryEvent does not. Without this, a cutover whose stop target includes
-// a trailing DDL would hang forever.
-func TestQueryEventAdvancesStreamedGTID(t *testing.T) {
+// TestAdvanceStreamedGTID verifies the transaction-boundary GTID advancement
+// used by OnXID/OnDDL: the committed set becomes the streamed set, and the
+// previous streamed set is recorded as the resumable point so an interruption
+// replays the whole just-committed transaction.
+func TestAdvanceStreamedGTID(t *testing.T) {
 	s := &BinlogStreamer{BinlogCoordinateMode: BinlogCoordinateGTID}
 	s.logger = LogWithField("tag", "test")
 
-	ddlSet := mustParseGTID(t, gtidSetTarget)
+	s.lastStreamedGTIDSet = mustParseGTID(t, gtidSetLower)
 
-	// A DDL QueryEvent carrying the executed set advances lastStreamedGTIDSet.
-	ddlEvent := &replication.BinlogEvent{
-		Header: &replication.EventHeader{LogPos: 100},
-		Event:  &replication.QueryEvent{Query: []byte("CREATE TABLE t (id int)"), GSet: ddlSet},
-	}
-	es := &BinlogEventState{}
-	_, err := s.defaultEventHandler(ddlEvent, nil, es)
-	require.NoError(t, err)
+	// Advancing to the target moves streamed forward and records the previous
+	// streamed set as resumable.
+	s.advanceStreamedGTID(mustParseGTID(t, gtidSetTarget))
 	require.NotNil(t, s.lastStreamedGTIDSet)
 	assert.Equal(t, gtidSetTarget, s.lastStreamedGTIDSet.String())
+	assert.Equal(t, gtidSetLower, s.lastResumableGTIDSet.String())
 
-	// A BEGIN QueryEvent must NOT advance the streamed set.
-	before := s.lastStreamedGTIDSet.String()
-	beginEvent := &replication.BinlogEvent{
-		Header: &replication.EventHeader{LogPos: 200},
-		Event:  &replication.QueryEvent{Query: []byte("BEGIN"), GSet: mustParseGTID(t, gtidSetPast)},
-	}
-	_, err = s.defaultEventHandler(beginEvent, nil, es)
-	require.NoError(t, err)
-	assert.Equal(t, before, s.lastStreamedGTIDSet.String(), "BEGIN must not advance the streamed GTID set")
+	// A nil committed set is a no-op (e.g. non-GTID server, or set unavailable).
+	s.advanceStreamedGTID(nil)
+	assert.Equal(t, gtidSetTarget, s.lastStreamedGTIDSet.String())
+}
+
+// TestDDLGTIDGatingByTransactionControl documents that OnDDL only advances the
+// committed GTID set for real DDL/admin statements, not transaction-control
+// queries (BEGIN/COMMIT/ROLLBACK), which commit at their XIDEvent.
+func TestDDLGTIDGatingByTransactionControl(t *testing.T) {
+	assert.False(t, isTransactionControlQuery([]byte("CREATE TABLE t (id int)")))
+	assert.True(t, isTransactionControlQuery([]byte("BEGIN")))
 }
 
 func TestCoordinateModeDefaultsToFilePosition(t *testing.T) {

--- a/dml_events.go
+++ b/dml_events.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/shopspring/decimal"
 
+	"github.com/go-mysql-org/go-mysql/canal"
 	"github.com/go-mysql-org/go-mysql/mysql"
-	"github.com/go-mysql-org/go-mysql/replication"
 	"github.com/go-mysql-org/go-mysql/schema"
 )
 
@@ -191,10 +191,10 @@ type BinlogInsertEvent struct {
 	*DMLEventBase
 }
 
-func NewBinlogInsertEvents(eventBase *DMLEventBase, rowsEvent *replication.RowsEvent) ([]DMLEvent, error) {
-	insertEvents := make([]DMLEvent, len(rowsEvent.Rows))
+func NewBinlogInsertEvents(eventBase *DMLEventBase, rows [][]interface{}) ([]DMLEvent, error) {
+	insertEvents := make([]DMLEvent, len(rows))
 
-	for i, row := range rowsEvent.Rows {
+	for i, row := range rows {
 		insertEvents[i] = &BinlogInsertEvent{
 			newValues:    row,
 			DMLEventBase: eventBase,
@@ -235,22 +235,22 @@ type BinlogUpdateEvent struct {
 	*DMLEventBase
 }
 
-func NewBinlogUpdateEvents(eventBase *DMLEventBase, rowsEvent *replication.RowsEvent) ([]DMLEvent, error) {
+func NewBinlogUpdateEvents(eventBase *DMLEventBase, rows [][]interface{}) ([]DMLEvent, error) {
 	// UPDATE events have two rows in the RowsEvent. The first row is the
 	// entries of the old record (for WHERE) and the second row is the
 	// entries of the new record (for SET).
 	// There can be n db rows changed in one RowsEvent, resulting in
 	// 2*n binlog rows.
-	updateEvents := make([]DMLEvent, len(rowsEvent.Rows)/2)
+	updateEvents := make([]DMLEvent, len(rows)/2)
 
-	for i, row := range rowsEvent.Rows {
+	for i, row := range rows {
 		if i%2 == 1 {
 			continue
 		}
 
 		updateEvents[i/2] = &BinlogUpdateEvent{
 			oldValues:    row,
-			newValues:    rowsEvent.Rows[i+1],
+			newValues:    rows[i+1],
 			DMLEventBase: eventBase,
 		}
 	}
@@ -295,10 +295,10 @@ func (e *BinlogDeleteEvent) NewValues() RowData {
 	return nil
 }
 
-func NewBinlogDeleteEvents(eventBase *DMLEventBase, rowsEvent *replication.RowsEvent) ([]DMLEvent, error) {
-	deleteEvents := make([]DMLEvent, len(rowsEvent.Rows))
+func NewBinlogDeleteEvents(eventBase *DMLEventBase, rows [][]interface{}) ([]DMLEvent, error) {
+	deleteEvents := make([]DMLEvent, len(rows))
 
-	for i, row := range rowsEvent.Rows {
+	for i, row := range rows {
 		deleteEvents[i] = &BinlogDeleteEvent{
 			oldValues:    row,
 			DMLEventBase: eventBase,
@@ -323,12 +323,15 @@ func (e *BinlogDeleteEvent) PaginationKey() (string, error) {
 	return paginationKeyFromEventData(e.table, e.oldValues)
 }
 
-func NewBinlogDMLEvents(table *TableSchema, ev *replication.BinlogEvent, pos, resumablePos mysql.Position, query []byte) ([]DMLEvent, error) {
-	rowsEvent := ev.Event.(*replication.RowsEvent)
-
-	for _, row := range rowsEvent.Rows {
+// normalizeUnsignedColumns rewrites signed integer values to their unsigned
+// counterparts for columns that Ghostferry's own schema marks unsigned. The
+// binlog protocol does not carry signedness, so go-mysql surfaces integers as
+// signed; we correct them against our authoritative TableSchema. It also
+// validates the row width against the schema.
+func normalizeUnsignedColumns(table *TableSchema, rows [][]interface{}) error {
+	for _, row := range rows {
 		if len(row) != len(table.Columns) {
-			return nil, fmt.Errorf(
+			return fmt.Errorf(
 				"table %s.%s has %d columns but event has %d columns instead",
 				table.Schema,
 				table.Name,
@@ -353,18 +356,30 @@ func NewBinlogDMLEvents(table *TableSchema, ev *replication.BinlogEvent, pos, re
 			}
 		}
 	}
+	return nil
+}
 
-	timestamp := time.Unix(int64(ev.Header.Timestamp), 0)
+// NewBinlogDMLEventsFromCanal builds Ghostferry DMLEvents from a
+// canal.RowsEvent. canal has already normalized event-version differences into
+// a stable {Action, Rows} shape (with UPDATE rows laid out as
+// [before, after, ...]), which lets this constructor be representation-agnostic
+// and drop the per-event-type replication constant switch.
+func NewBinlogDMLEventsFromCanal(table *TableSchema, e *canal.RowsEvent, pos, resumablePos mysql.Position, query []byte) ([]DMLEvent, error) {
+	if err := normalizeUnsignedColumns(table, e.Rows); err != nil {
+		return nil, err
+	}
+
+	timestamp := time.Unix(int64(e.Header.Timestamp), 0)
 	eventBase := NewDMLEventBase(table, pos, resumablePos, query, timestamp)
-	switch ev.Header.EventType {
-	case replication.WRITE_ROWS_EVENTv1, replication.WRITE_ROWS_EVENTv2:
-		return NewBinlogInsertEvents(eventBase, rowsEvent)
-	case replication.DELETE_ROWS_EVENTv1, replication.DELETE_ROWS_EVENTv2:
-		return NewBinlogDeleteEvents(eventBase, rowsEvent)
-	case replication.UPDATE_ROWS_EVENTv1, replication.UPDATE_ROWS_EVENTv2:
-		return NewBinlogUpdateEvents(eventBase, rowsEvent)
+	switch e.Action {
+	case canal.InsertAction:
+		return NewBinlogInsertEvents(eventBase, e.Rows)
+	case canal.DeleteAction:
+		return NewBinlogDeleteEvents(eventBase, e.Rows)
+	case canal.UpdateAction:
+		return NewBinlogUpdateEvents(eventBase, e.Rows)
 	default:
-		return nil, fmt.Errorf("unrecognized rows event: %s", ev.Header.EventType.String())
+		return nil, fmt.Errorf("unrecognized canal rows action: %s", e.Action)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/BurntSushi/toml v1.3.2 // indirect
 	github.com/Microsoft/go-winio v0.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
@@ -31,6 +32,7 @@ require (
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pingcap/errors v0.11.5-0.20250318082626-8f80e5cb09ec // indirect
+	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
 	github.com/pingcap/log v1.1.1-0.20241212030209-7e3ff8601a2a // indirect
 	github.com/pingcap/tidb/pkg/parser v0.0.0-20250421232622-526b2c79173d // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
+github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/DataDog/datadog-go v4.8.2+incompatible h1:qbcKSx29aBLD+5QLvlQZlGmRMF/FfGqFLFev/1TDzRo=
 github.com/DataDog/datadog-go v4.8.2+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Masterminds/squirrel v0.0.0-20180620232226-b127ed9be034 h1:hD1RvQnfYvjKbn87EkvXONhSJJ1o6NNHGQ0P+OOrIRA=
@@ -48,6 +50,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/pingcap/errors v0.11.0/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/errors v0.11.5-0.20250318082626-8f80e5cb09ec h1:3EiGmeJWoNixU+EwllIn26x6s4njiWRXewdx2zlYa84=
 github.com/pingcap/errors v0.11.5-0.20250318082626-8f80e5cb09ec/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
+github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 h1:tdMsjOqUR7YXHoBitzdebTvOjs/swniBTOLy5XiMtuE=
+github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86/go.mod h1:exzhVYca3WRtd6gclGNErRWb1qEgff3LYta0LvRmON4=
 github.com/pingcap/log v1.1.1-0.20241212030209-7e3ff8601a2a h1:WIhmJBlNGmnCWH6TLMdZfNEDaiU8cFpZe3iaqDbQ0M8=
 github.com/pingcap/log v1.1.1-0.20241212030209-7e3ff8601a2a/go.mod h1:ORfBOFp1eteu2odzsyaxI+b8TzJwgjwyQcGhI+9SfEA=
 github.com/pingcap/tidb/pkg/parser v0.0.0-20250421232622-526b2c79173d h1:3Ej6eTuLZp25p3aH/EXdReRHY12hjZYs3RrGp7iLdag=

--- a/sharding/test/copy_filter_test.go
+++ b/sharding/test/copy_filter_test.go
@@ -300,7 +300,7 @@ func (t *CopyFilterTestSuite) TestShardingValueTypes() {
 	)
 
 	for _, tenantId := range tenantIds {
-		dmlEvents, _ := ghostferry.NewBinlogInsertEvents(eventBase, t.newRowsEvent([]interface{}{1001, tenantId, "data"}))
+		dmlEvents, _ := ghostferry.NewBinlogInsertEvents(eventBase, t.newRowsEvent([]interface{}{1001, tenantId, "data"}).Rows)
 		applicable, err := t.filter.ApplicableEvent(dmlEvents[0])
 		t.Require().Nil(err)
 		t.Require().True(applicable, fmt.Sprintf("value %t wasn't applicable", tenantId))
@@ -316,7 +316,7 @@ func (t *CopyFilterTestSuite) TestInvalidShardingValueTypesErrors() {
 		time.Unix(1618318965, 0),
 	)
 
-	dmlEvents, err := ghostferry.NewBinlogInsertEvents(eventBase, t.newRowsEvent([]interface{}{1001, string("1"), "data"}))
+	dmlEvents, err := ghostferry.NewBinlogInsertEvents(eventBase, t.newRowsEvent([]interface{}{1001, string("1"), "data"}).Rows)
 	_, err = t.filter.ApplicableEvent(dmlEvents[0])
 	t.Require().Equal("parsing new sharding key: invalid type %!t(string=1)", err.Error())
 }

--- a/test/go/binlog_streamer_test.go
+++ b/test/go/binlog_streamer_test.go
@@ -5,13 +5,13 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	sql "github.com/Shopify/ghostferry/sqlwrapper"
 
 	"github.com/Shopify/ghostferry"
 	"github.com/Shopify/ghostferry/testhelpers"
 
-	"github.com/go-mysql-org/go-mysql/replication"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -196,18 +196,42 @@ func (this *BinlogStreamerTestSuite) TestBinlogStreamerSetsQueryEventOnRowsEvent
 	this.Require().True(eventAsserted)
 }
 
-func (this *BinlogStreamerTestSuite) TestBinlogStreamerAddEventHandlerEventTypes() {
-	qe := func(ev *replication.BinlogEvent, query []byte, es *ghostferry.BinlogEventState) ([]byte, error) {
-		return query, nil
-	}
-
-	// try attaching a handler to a valid event type
-	err := this.binlogStreamer.AddBinlogEventHandler(replication.TABLE_MAP_EVENT, qe)
+func (this *BinlogStreamerTestSuite) TestBinlogStreamerDDLEventHandler() {
+	_, err := this.binlogStreamer.ConnectBinlogStreamerToMysql()
 	this.Require().Nil(err)
 
-	// try attaching a handler to an invalid event type
-	err = this.binlogStreamer.AddBinlogEventHandler(replication.EventType(byte(0)), qe)
-	this.Require().NotNil(err)
+	ddlSeen := make(chan string, 1)
+	this.binlogStreamer.DDLEventHandler = func(schemaName, tableName string, query []byte) error {
+		select {
+		case ddlSeen <- string(query):
+		default:
+		}
+		return nil
+	}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		this.binlogStreamer.Run()
+	}()
+
+	_, err = this.sourceDB.Exec("CREATE TABLE gftest.ddl_probe (id bigint primary key)")
+	this.Require().Nil(err)
+
+	var seen string
+	select {
+	case seen = <-ddlSeen:
+	case <-time.After(10 * time.Second):
+		this.Fail("did not observe DDL event")
+	}
+	this.Require().Contains(seen, "ddl_probe")
+
+	this.binlogStreamer.FlushAndStop()
+	wg.Wait()
+
+	_, err = this.sourceDB.Exec("DROP TABLE IF EXISTS gftest.ddl_probe")
+	this.Require().Nil(err)
 }
 
 func TestBinlogStreamerTestSuite(t *testing.T) {

--- a/test/go/dml_events_test.go
+++ b/test/go/dml_events_test.go
@@ -66,7 +66,7 @@ func (this *DMLEventsTestSuite) TestBinlogInsertEventGeneratesInsertQuery() {
 		},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogInsertEvents(this.eventBase, rowsEvent)
+	dmlEvents, err := ghostferry.NewBinlogInsertEvents(this.eventBase, rowsEvent.Rows)
 	this.Require().Nil(err)
 	this.Require().Equal(3, len(dmlEvents))
 
@@ -89,7 +89,7 @@ func (this *DMLEventsTestSuite) TestBinlogInsertEventWithWrongColumnsReturnsErro
 		Rows:  [][]interface{}{{1000}},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogInsertEvents(this.eventBase, rowsEvent)
+	dmlEvents, err := ghostferry.NewBinlogInsertEvents(this.eventBase, rowsEvent.Rows)
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 
@@ -104,7 +104,7 @@ func (this *DMLEventsTestSuite) TestBinlogInsertEventMetadata() {
 		Rows:  [][]interface{}{{1000}},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogInsertEvents(this.eventBase, rowsEvent)
+	dmlEvents, err := ghostferry.NewBinlogInsertEvents(this.eventBase, rowsEvent.Rows)
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 	this.Require().Equal("test_schema", dmlEvents[0].Database())
@@ -127,7 +127,7 @@ func (this *DMLEventsTestSuite) TestBinlogUpdateEventGeneratesUpdateQuery() {
 		},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.eventBase, rowsEvent)
+	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.eventBase, rowsEvent.Rows)
 	this.Require().Nil(err)
 	this.Require().Equal(3, len(dmlEvents))
 
@@ -150,7 +150,7 @@ func (this *DMLEventsTestSuite) TestBinlogUpdateEventWithWrongColumnsReturnsErro
 		Rows:  [][]interface{}{{1000}, {1000}},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.eventBase, rowsEvent)
+	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.eventBase, rowsEvent.Rows)
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 
@@ -168,7 +168,7 @@ func (this *DMLEventsTestSuite) TestBinlogUpdateEventWithNull() {
 		},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.eventBase, rowsEvent)
+	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.eventBase, rowsEvent.Rows)
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 
@@ -183,7 +183,7 @@ func (this *DMLEventsTestSuite) TestBinlogUpdateEventMetadata() {
 		Rows:  [][]interface{}{{1000}, {1001}},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.eventBase, rowsEvent)
+	dmlEvents, err := ghostferry.NewBinlogUpdateEvents(this.eventBase, rowsEvent.Rows)
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 	this.Require().Equal("test_schema", dmlEvents[0].Database())
@@ -202,7 +202,7 @@ func (this *DMLEventsTestSuite) TestBinlogDeleteEventGeneratesDeleteQuery() {
 		},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.eventBase, rowsEvent)
+	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.eventBase, rowsEvent.Rows)
 	this.Require().Nil(err)
 	this.Require().Equal(2, len(dmlEvents))
 
@@ -223,7 +223,7 @@ func (this *DMLEventsTestSuite) TestBinlogDeleteEventWithNull() {
 		},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.eventBase, rowsEvent)
+	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.eventBase, rowsEvent.Rows)
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 
@@ -238,7 +238,7 @@ func (this *DMLEventsTestSuite) TestBinlogDeleteEventWithWrongColumnsReturnsErro
 		Rows:  [][]interface{}{{1000}},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.eventBase, rowsEvent)
+	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.eventBase, rowsEvent.Rows)
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 
@@ -253,7 +253,7 @@ func (this *DMLEventsTestSuite) TestBinlogDeleteEventMetadata() {
 		Rows:  [][]interface{}{{1000}},
 	}
 
-	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.eventBase, rowsEvent)
+	dmlEvents, err := ghostferry.NewBinlogDeleteEvents(this.eventBase, rowsEvent.Rows)
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 	this.Require().Equal("test_schema", dmlEvents[0].Database())
@@ -279,7 +279,7 @@ func (this *DMLEventsTestSuite) TestAnnotations() {
 		time.Unix(1618318965, 0),
 	)
 
-	dmlEvents, err := ghostferry.NewBinlogInsertEvents(eventBase, rowsEvent)
+	dmlEvents, err := ghostferry.NewBinlogInsertEvents(eventBase, rowsEvent.Rows)
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 
@@ -305,7 +305,7 @@ func (this *DMLEventsTestSuite) TestNoAnnotations() {
 		time.Unix(1618318965, 0),
 	)
 
-	dmlEvents, err := ghostferry.NewBinlogInsertEvents(eventBase, rowsEvent)
+	dmlEvents, err := ghostferry.NewBinlogInsertEvents(eventBase, rowsEvent.Rows)
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 
@@ -330,7 +330,7 @@ func (this *DMLEventsTestSuite) TestMultipleAnnotations() {
 		time.Unix(1618318965, 0),
 	)
 
-	dmlEvents, err := ghostferry.NewBinlogInsertEvents(eventBase, rowsEvent)
+	dmlEvents, err := ghostferry.NewBinlogInsertEvents(eventBase, rowsEvent.Rows)
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 
@@ -355,7 +355,7 @@ func (this *DMLEventsTestSuite) TestSeparatedAnnotations() {
 		time.Unix(1618318965, 0),
 	)
 
-	dmlEvents, err := ghostferry.NewBinlogInsertEvents(eventBase, rowsEvent)
+	dmlEvents, err := ghostferry.NewBinlogInsertEvents(eventBase, rowsEvent.Rows)
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 
@@ -380,7 +380,7 @@ func (this *DMLEventsTestSuite) TestNoRowsQueryEvent() {
 		time.Unix(1618318965, 0),
 	)
 
-	dmlEvents, err := ghostferry.NewBinlogInsertEvents(eventBase, rowsEvent)
+	dmlEvents, err := ghostferry.NewBinlogInsertEvents(eventBase, rowsEvent.Rows)
 	this.Require().Nil(err)
 	this.Require().Equal(1, len(dmlEvents))
 

--- a/test/lib/go/ddl_ghostferry/main.go
+++ b/test/lib/go/ddl_ghostferry/main.go
@@ -3,18 +3,15 @@ package main
 import (
 	"errors"
 
-	"github.com/Shopify/ghostferry"
 	tf "github.com/Shopify/ghostferry/test/lib/go/integrationferry"
-	"github.com/go-mysql-org/go-mysql/replication"
 )
 
-func queryEventHandler(ev *replication.BinlogEvent, query []byte, es *ghostferry.BinlogEventState) ([]byte, error) {
-	query = ev.Event.(*replication.QueryEvent).Query
-	return query, errors.New("Query event")
+func ddlEventHandler(schemaName, tableName string, query []byte) error {
+	return errors.New("Query event")
 }
 
 func AfterInitialize(f *tf.IntegrationFerry) error {
-	f.Ferry.BinlogStreamer.AddBinlogEventHandler(replication.QUERY_EVENT, queryEventHandler)
+	f.Ferry.BinlogStreamer.DDLEventHandler = ddlEventHandler
 	return nil
 }
 


### PR DESCRIPTION
> [!WARNING]
> **This is an exploration spike, not a merge candidate.** It compiles and is functionally correct on the happy path, but has a hard blocker at cutover (see below). Opening as draft to preserve the work and share findings.

## Goal

Evaluate replacing Ghostferry's hand-rolled binlog event loop with [`go-mysql/canal`](https://github.com/go-mysql-org/go-mysql/tree/master/canal), keeping the `DMLEvent` output boundary and GTID coordinate semantics unchanged. The hypothesis (from prior discussion) was that canal would improve **maintainability** by removing low-level code paths we currently own.

Base branch: `gtid-stage5-replica-progress` (canal pairs naturally with the GTID work).

## What changed

- **`binlog_streamer.go`** now drives `canal` instead of a raw `replication.BinlogSyncer`. Replaced by a single `canal.EventHandler` adapter (`OnRotate` / `OnRowsQueryEvent` / `OnRow` / `OnGTID` / `OnXID` / `OnDDL` / `OnPosSynced`):
  - the manual `Run()` `GetEvent` loop
  - the big event-type `switch` (`defaultEventHandler`)
  - rotate / format-description / position bookkeeping
  - `handleRowsEvent` raw decoding
- **`dml_events.go`**: row constructors take `[][]interface{}` (shared), and new `NewBinlogDMLEventsFromCanal` builds events from `canal.RowsEvent` (Action-based, no `replication` event-type switch).
- **API change**: removed the raw `AddBinlogEventHandler` / `BinlogEventState` hooks (only real use was intercepting DDL `QueryEvent`s) in favor of a typed `DDLEventHandler func(schema, table string, query []byte) error`. `ddl_ghostferry` harness + streamer tests migrated accordingly.

## Simplification measured

Modest.

| Metric | Before | After |
|---|---|---|
| `binlog_streamer.go` | 802 lines | 753 lines |
| new transitive deps | — | `BurntSushi/toml`, `pingcap/failpoint`, tidb parser |

The removed code *is* the gnarly low-level loop, but the DMLEvent construction, coordinate stamping, filtering, stop/cutover, lag metrics, and server-id logic all remain (canal doesn't own those). Net win is real but smaller than hoped, and it adds dependency surface.

## 🚧 Blocker: canal stop-path deadlock at cutover

Functionally the refactor is correct — unit tests pass, and happy-path copy passes in **both** `file_position` and `gtid` modes. But there is a hard **stop-path deadlock at cutover**, reproduced consistently at **~50% failure** on `TestCopyDataWith*`:

- canal owns the event loop and is stopped via `canal.Close()`.
- `canal.Close()` waits on the syncer goroutine (`wg.Wait()`).
- that goroutine is frequently parked in a **blocking socket read** — especially the low-traffic **target-verifier** streamer once the source goes `read_only` at cutover.
- canal's 100ms close read-deadline does **not** reliably preempt the in-progress `netpoll` read, so `Close()` (and thus `Ferry` shutdown via `StopTargetVerifier`) hangs → test timeout → cascade (leftover `read_only = ON` then fails the next run's replica precheck).

Representative goroutine dump at the hang:

```
goroutine [sync.WaitGroup.Wait]:
  ghostferry.(*Ferry).StopTargetVerifier
  ...
goroutine [select]:
  ghostferry.(*BinlogStreamer).Run.func2   // stop monitor, inside canal.Close()
goroutine [IO wait]:
  net.(*conn).Read
  go-mysql/packet.(*Conn).ReadPacket
  go-mysql/replication.(*BinlogSyncer).onStream   // parked read, never interrupted
```

Mitigations attempted (all still flaky):
- `cfg.ReadTimeout` at 1s and 5s
- `cfg.HeartbeatPeriod = 1s`
- `sync.Once`-guarded `Close()` to avoid double-close
- async `Close()` from the monitor + defer — made it **worse** (Run returns mid-teardown, reconnect races)

## Conclusion / recommendation

Canal is a genuine maintainability improvement for the **event-decode path**, but its **cooperative-shutdown model is incompatible with Ghostferry's stop-at-coordinate cutover** without upstream changes — e.g. a context-cancellable `GetEvent`, or a non-blocking / force-close `Close()`. **Not mergeable as-is.**

This matches the earlier assessment: canal helps maintainability, but the hard parts (here, deterministic stop/cutover) still need Ghostferry-level orchestration — and in this case canal actively fights it.

### Possible follow-ups (if we want to pursue canal)
1. Upstream a context-cancellable `GetEvent` / non-blocking `Close()` to `go-mysql`, or
2. Bypass `canal.Close()` by holding the syncer reference and force-closing the underlying `net.Conn`, or
3. Keep the raw `BinlogSyncer` (current approach) and only adopt canal's `RowsEvent`/`Action` normalization for the decode layer.

## Test status

- ✅ package unit tests (`go test .`) — both modes
- ✅ `TestBinlogStreamerTestSuite` (incl. new DDL-handler test) — file_position
- ✅ happy-path copy (`TestCopyDataWithInsertLoad`) — file_position and gtid
- ⚠️ `TestCopyDataWith*` under load — ~50% flaky due to the cutover deadlock above
