### PR TITLE
prevent nil pointer dereference on script execution error

### DIFF
--- a/control_server.go
+++ b/control_server.go
@@ -498,7 +498,7 @@ func (this *ControlServer) startScriptInBackground(scriptName string, scriptCmd 
 				LogWithFields(Fields{
 					"scriptName": scriptName,
 					"error":      err.Error(),
-					"exitCode":   exitError.ExitCode(),
+					"exitCode":   defaultExitCode,
 				}).Error("custom script ran with errors but could not determine the exit code")
 			}
 		} else {


### PR DESCRIPTION
### Summary
This PR fixes a runtime panic (`nil pointer dereference`) that occurs in `startScriptInBackground` when a configured custom script fails to execute due to an operating system or path error rather than returning a standard process exit code.

### Root Cause Analysis
In `control_server.go`, the background goroutine executes custom scripts via `exec.Command(...)` and handles errors returned by `cmd.CombinedOutput()`.

When `cmd.CombinedOutput()` returns an error that is not an `*exec.ExitError` (for instance, `os.ErrNotExist` / `exec.ErrNotFound` if the binary does not exist on `$PATH`, or an `os.PathError` due to permission issues):
1. `errors.As(err, &exitError)` evaluates to `false`.
2. The `exitError` pointer remains `nil`.
3. Inside the `else` block, `exitError.ExitCode()` is called to populate the structured log fields.
4. Calling any method on a `nil` pointer receiver causes an unhandled runtime panic (`invalid memory address or nil pointer dereference`), which terminates the entire application process.

### Solution
Replace the call to `exitError.ExitCode()` with `defaultExitCode` in the `else` block logging payload. The variable `defaultExitCode` is already defined and set to `1` right above the branch.

### Changes Made
- Modified `control_server.go` at line 501: pass `defaultExitCode` instead of `exitError.ExitCode()` when logging errors for non-ExitError failures.